### PR TITLE
fix: fix ci tests

### DIFF
--- a/tests/bench/test_benchmark.py
+++ b/tests/bench/test_benchmark.py
@@ -25,6 +25,9 @@ from flashinfer_bench.data import (
 )
 
 
+@pytest.mark.skipif(
+    __import__("torch").cuda.device_count() == 0, reason="CUDA devices not available"
+)
 def test_run_all_empty_traceset(tmp_path: Path):
     """Test run_all with completely empty trace set."""
     trace_set = TraceSet(root=str(tmp_path), definitions={}, solutions={}, workloads={}, traces={})
@@ -38,6 +41,9 @@ def test_run_all_empty_traceset(tmp_path: Path):
     assert len(result.traces) == 0
 
 
+@pytest.mark.skipif(
+    __import__("torch").cuda.device_count() == 0, reason="CUDA devices not available"
+)
 def test_run_all_no_solutions(tmp_path: Path, caplog):
     """Test run_all with definitions but no solutions."""
     # Create definition
@@ -70,6 +76,9 @@ def test_run_all_no_solutions(tmp_path: Path, caplog):
     assert len(result.traces) == 0
 
 
+@pytest.mark.skipif(
+    __import__("torch").cuda.device_count() == 0, reason="CUDA devices not available"
+)
 def test_run_all_no_workloads(tmp_path: Path):
     """Test run_all with definitions and solutions but no workloads."""
     # Create definition
@@ -109,6 +118,9 @@ def test_run_all_no_workloads(tmp_path: Path):
     assert len(result.traces) == 0
 
 
+@pytest.mark.skipif(
+    __import__("torch").cuda.device_count() == 0, reason="CUDA devices not available"
+)
 def test_dump_traces_false(tmp_path: Path):
     """Test run_all with dump_traces=False."""
     trace_set = TraceSet(root=str(tmp_path), definitions={}, solutions={}, workloads={}, traces={})

--- a/tests/integration/flashinfer/test_rmsnorm.py
+++ b/tests/integration/flashinfer/test_rmsnorm.py
@@ -1,4 +1,3 @@
-
 import torch
 
 from flashinfer_bench.apply import ApplyConfig, ApplyRuntime, set_apply_runtime


### PR DESCRIPTION
This PR added several marks in ci tests. Now ci tests can run successfully with Python 3.10+.

However, ci test will still fail with Python 3.9, and it seems to be [a compatibility problem in Flashinfer](https://github.com/flashinfer-ai/flashinfer/issues/1964), and a possible solution is to downgrade Flashinfer to 0.2.6.

`test_rmsnorm.py` is modified by pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Benchmark tests now detect when CUDA devices are unavailable and are automatically skipped to avoid false failures on non-GPU systems.
  * Minor formatting cleanup in an integration test import to improve code consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->