### PR TITLE
[refactor] apply() Overhead Reduction

### DIFF
--- a/flashinfer_bench/data/trace_set.py
+++ b/flashinfer_bench/data/trace_set.py
@@ -45,6 +45,16 @@ class TraceSet:
     definition."""
     traces: Dict[str, List[Trace]] = field(default_factory=dict)
     """The traces in the database. Map from definition name to all traces for that definition."""
+    _solution_by_name: Dict[str, Solution] = field(default_factory=dict, init=False, repr=False)
+    """Fast lookup index: solution name -> Solution object. Automatically maintained."""
+
+    def __post_init__(self):
+        """Initialize the _solution_by_name index from existing solutions."""
+        for solutions_list in self.solutions.values():
+            for solution in solutions_list:
+                if solution.name in self._solution_by_name:
+                    raise ValueError(f"Duplicate solution name found: {solution.name}")
+                self._solution_by_name[solution.name] = solution
 
     @property
     def definitions_path(self) -> Path:
@@ -132,6 +142,7 @@ class TraceSet:
                 raise ValueError(f"Duplicate solution name: {s.name}")
             seen_solutions.add(s.name)
             trace_set.solutions.setdefault(s.definition, []).append(s)
+            trace_set._solution_by_name[s.name] = s
 
         for p in sorted((trace_set.workloads_path.rglob("*.jsonl"))):
             for t in load_jsonl_file(Trace, p):
@@ -175,9 +186,8 @@ class TraceSet:
     def get_solution(self, name: str) -> Optional[Solution]:
         """Get a solution by name from all loaded solutions.
 
-        Searches across all solutions in the TraceSet to find one with the specified name.
-        Since solution names are unique across the entire dataset, this returns at most
-        one solution.
+        Uses an O(1) index lookup for fast retrieval. Since solution names are unique
+        across the entire dataset, this returns at most one solution.
 
         Parameters
         ----------
@@ -189,11 +199,7 @@ class TraceSet:
         Optional[Solution]
             The solution with the given name, or None if not found.
         """
-        for solution_list in self.solutions.values():
-            for solution in solution_list:
-                if solution.name == name:
-                    return solution
-        return None
+        return self._solution_by_name.get(name)
 
     def filter_traces(self, def_name: str, atol: float = 1e-2, rtol: float = 1e-2) -> List[Trace]:
         """Filter traces for a definition based on error bounds.


### PR DESCRIPTION
This PR reduces the overhead of apply():
* It simplified the `create_pkg_name` function to just use the solution name without hashing
* The `get_solution` method was originally doing a linear search through all solutions, which is O(n) where n is the total number of solutions across all definitions. So this PR added a `_solution_by_name` index that maps solution names directly to Solution objects.
* Removed repeated checks on cached solutions: Even when a solution is already cached in a builder, the registry still iterates through all builders calling `can_build()`. So this PR added a solution-to-builder mapping cache in the registry.

Minor naming refactor: The internal path for the cutlass dependency has been updated from `_deps` to `thirdparty` in both the CUDA builder configuration and pyproject.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect and report duplicate solution names during initialization.

* **Performance**
  * Improved solution lookup performance through optimized retrieval mechanism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->