### PR TITLE
feat: Dataset Validation Framework

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,12 @@ repos:
       - id: isort
         args: ["--profile=black"]
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.6
+    hooks:
+      - id: ruff
+        args: ["--fix", "--select=F401"]
+
   - repo: https://github.com/google/yamlfmt
     rev: v0.16.0
     hooks:

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -131,6 +131,6 @@ html_theme_options = {
     "logo_target": "/",
     "light_logo": "_static/brand/fib-light.png",
     "dark_logo": "_static/brand/fib-dark.png",
-    "nav_links": [{"title": "Docs", "url": f"/docs", "external": True}],
+    "nav_links": [{"title": "Docs", "url": "/docs", "external": True}],
     "globaltoc_expand_depth": 1,
 }

--- a/flashinfer_bench/testing/__init__.py
+++ b/flashinfer_bench/testing/__init__.py
@@ -1,0 +1,21 @@
+"""Testing utilities for flashinfer-bench."""
+
+from .comparators import (
+    Comparator,
+    CompareResult,
+    HitRatioComparator,
+    MultiOutputComparator,
+    TensorComparator,
+)
+from .definition import DefinitionTest
+from .pytest_config import requires_torch_cuda
+
+__all__ = [
+    "DefinitionTest",
+    "CompareResult",
+    "Comparator",
+    "TensorComparator",
+    "MultiOutputComparator",
+    "HitRatioComparator",
+    "requires_torch_cuda",
+]

--- a/flashinfer_bench/testing/comparators.py
+++ b/flashinfer_bench/testing/comparators.py
@@ -1,0 +1,255 @@
+"""Comparators for comparing reference and baseline outputs. Used by DefinitionTest."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+
+
+@dataclass
+class CompareResult:
+    """Result of comparing reference and baseline outputs."""
+
+    passed: bool
+    """Whether the comparison passed."""
+    stats: Dict[str, Any] = field(default_factory=dict)
+    """Statistics from the comparison (e.g., max_abs_diff, mse)."""
+    details: Optional[str] = None
+    """Detailed error information if comparison failed."""
+
+
+class Comparator(ABC):
+    """Base class for output comparators."""
+
+    @abstractmethod
+    def compare(self, ref_output: Any, baseline_output: Any) -> CompareResult:
+        """Compare reference output with baseline output.
+
+        Parameters
+        ----------
+        ref_output : Any
+            Output from reference implementation.
+        baseline_output : Any
+            Output from baseline implementation.
+
+        Returns
+        -------
+        CompareResult
+            Comparison result with pass/fail status and statistics.
+        """
+        ...
+
+
+class TensorComparator(Comparator):
+    """Comparator for single tensor outputs using torch.allclose."""
+
+    def __init__(self, atol: float = 1e-2, rtol: float = 5e-2):
+        """Initialize with tolerance values.
+
+        Parameters
+        ----------
+        atol : float
+            Absolute tolerance for comparison.
+        rtol : float
+            Relative tolerance for comparison.
+        """
+        self.atol = atol
+        self.rtol = rtol
+
+    def compare(self, ref_output: torch.Tensor, baseline_output: torch.Tensor) -> CompareResult:
+        """Compare two tensors using torch.allclose.
+
+        Parameters
+        ----------
+        ref_output : torch.Tensor
+            Reference tensor output.
+        baseline_output : torch.Tensor
+            Baseline tensor output.
+
+        Returns
+        -------
+        CompareResult
+            Comparison result with pass/fail status and statistics.
+        """
+        ref = ref_output.float()
+        base = baseline_output.float()
+
+        abs_diff = (ref - base).abs()
+        rel_diff = abs_diff / (base.abs() + 1e-8)
+
+        stats = {
+            "max_abs_diff": abs_diff.max().item(),
+            "mean_abs_diff": abs_diff.mean().item(),
+            "max_rel_diff": rel_diff.max().item(),
+            "mean_rel_diff": rel_diff.mean().item(),
+            "mse": torch.mean((ref - base) ** 2).item(),
+        }
+
+        passed = torch.allclose(ref, base, atol=self.atol, rtol=self.rtol)
+
+        details = None
+        if not passed:
+            details = self._get_error_details(ref, base, abs_diff)
+
+        return CompareResult(passed=passed, stats=stats, details=details)
+
+    def _get_error_details(
+        self, ref: torch.Tensor, base: torch.Tensor, abs_diff: torch.Tensor, top_k: int = 5
+    ) -> str:
+        """Get detailed error information for failed comparisons."""
+        flat_diff = abs_diff.flatten()
+        k = min(top_k, flat_diff.numel())
+        top_errors, top_indices = torch.topk(flat_diff, k)
+
+        lines = [f"Top {k} error locations:"]
+        for i in range(k):
+            idx = top_indices[i].item()
+            ref_val = ref.flatten()[idx].item()
+            base_val = base.flatten()[idx].item()
+            lines.append(
+                f"  [{idx}]: ref={ref_val:.6e}, base={base_val:.6e}, "
+                f"diff={top_errors[i].item():.6e}"
+            )
+
+        return "\n".join(lines)
+
+
+class MultiOutputComparator(Comparator):
+    """Comparator for multiple outputs (tuple or dict)."""
+
+    def __init__(
+        self,
+        output_names: List[str],
+        comparators: Optional[Dict[str, Comparator]] = None,
+        atol: float = 1e-2,
+        rtol: float = 5e-2,
+    ):
+        """Initialize with output names and optional per-output comparators.
+
+        Parameters
+        ----------
+        output_names : List[str]
+            Names of outputs in order (for tuple unpacking).
+        comparators : Dict[str, Comparator], optional
+            Dict mapping output names to specific comparators.
+        atol : float
+            Default absolute tolerance.
+        rtol : float
+            Default relative tolerance.
+        """
+        self.output_names = output_names
+        comparators = comparators or {}
+        self.comparators = {
+            name: comparators[name] if name in comparators else TensorComparator(atol, rtol)
+            for name in output_names
+        }
+
+    def compare(
+        self, ref_output: Union[tuple, dict], baseline_output: Union[tuple, dict]
+    ) -> CompareResult:
+        """Compare multiple outputs.
+
+        Parameters
+        ----------
+        ref_output : Union[tuple, dict]
+            Reference outputs as tuple or dict.
+        baseline_output : Union[tuple, dict]
+            Baseline outputs as tuple or dict.
+
+        Returns
+        -------
+        CompareResult
+            Comparison result with pass/fail status and per-output statistics.
+        """
+        # Convert tuples to dicts
+        if isinstance(ref_output, tuple):
+            ref_dict = dict(zip(self.output_names, ref_output, strict=True))
+        else:
+            ref_dict = ref_output
+
+        if isinstance(baseline_output, tuple):
+            base_dict = dict(zip(self.output_names, baseline_output, strict=True))
+        else:
+            base_dict = baseline_output
+
+        all_passed = True
+        all_stats: Dict[str, Any] = {}
+        all_details: List[str] = []
+
+        for name in self.output_names:
+            if name not in ref_dict or name not in base_dict:
+                continue
+
+            comparator = self.comparators[name]
+            result = comparator.compare(ref_dict[name], base_dict[name])
+
+            all_stats[name] = result.stats
+            if not result.passed:
+                all_passed = False
+                if result.details:
+                    all_details.append(f"[{name}] {result.details}")
+
+        details = "\n".join(all_details) if all_details else None
+        return CompareResult(passed=all_passed, stats=all_stats, details=details)
+
+
+class HitRatioComparator(Comparator):
+    """Comparator that allows a percentage of values to exceed tolerance.
+
+    Useful for low-precision kernels (e.g., FP8) where strict allclose may fail.
+    """
+
+    def __init__(self, atol: float = 1e-1, rtol: float = 2e-1, min_hit_ratio: float = 0.85):
+        """Initialize with tolerance values and minimum hit ratio.
+
+        Parameters
+        ----------
+        atol : float
+            Absolute tolerance for per-element comparison.
+        rtol : float
+            Relative tolerance for per-element comparison.
+        min_hit_ratio : float
+            Minimum fraction of elements that must pass (0.0-1.0).
+        """
+        self.atol = atol
+        self.rtol = rtol
+        self.min_hit_ratio = min_hit_ratio
+
+    def compare(self, ref_output: torch.Tensor, baseline_output: torch.Tensor) -> CompareResult:
+        """Compare tensors with hit ratio criterion.
+
+        Parameters
+        ----------
+        ref_output : torch.Tensor
+            Reference tensor output.
+        baseline_output : torch.Tensor
+            Baseline tensor output.
+
+        Returns
+        -------
+        CompareResult
+            Comparison result with hit ratio statistics.
+        """
+        ref = ref_output.float()
+        base = baseline_output.float()
+
+        abs_diff = (ref - base).abs()
+        threshold = self.atol + self.rtol * base.abs()
+        ok = abs_diff <= threshold
+        hit_ratio = ok.float().mean().item()
+
+        stats = {
+            "hit_ratio": hit_ratio,
+            "required_ratio": self.min_hit_ratio,
+            "max_abs_diff": abs_diff.max().item(),
+            "mean_abs_diff": abs_diff.mean().item(),
+        }
+
+        passed = hit_ratio >= self.min_hit_ratio
+
+        details = None
+        if not passed:
+            details = f"Hit ratio {hit_ratio:.2%} < required {self.min_hit_ratio:.2%}"
+
+        return CompareResult(passed=passed, stats=stats, details=details)

--- a/flashinfer_bench/testing/definition.py
+++ b/flashinfer_bench/testing/definition.py
@@ -1,0 +1,366 @@
+"""Test definitions: schema correctness, reference correctness, etc."""
+
+import json
+import math
+from abc import abstractmethod
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import pytest
+import torch
+
+from flashinfer_bench.data import Definition
+from flashinfer_bench.env import get_fib_dataset_path
+from flashinfer_bench.utils import dtype_str_to_torch_dtype
+
+from .comparators import Comparator, CompareResult, MultiOutputComparator, TensorComparator
+from .pytest_config import requires_torch_cuda
+
+
+class DefinitionRunner:
+    """Runs reference and baseline implementations and compares outputs.
+
+    Handles extracting reference implementation from definition, generating inputs,
+    executing both implementations, and comparing results.
+    """
+
+    def __init__(
+        self,
+        definition: dict,
+        baseline_fn: Callable[..., Any],
+        input_generator: Optional[Callable[..., Dict[str, Any]]] = None,
+        comparator: Optional[Comparator] = None,
+        atol: float = 1e-2,
+        rtol: float = 5e-2,
+        device: str = "cuda",
+    ):
+        """Initialize the runner with definition and baseline function.
+
+        Parameters
+        ----------
+        definition : dict
+            Definition dict (already loaded from JSON).
+        baseline_fn : Callable[..., Any]
+            Baseline function to compare against reference.
+        input_generator : Callable[..., Dict[str, Any]], optional
+            Custom input generator function. If None, uses default generator.
+        comparator : Comparator, optional
+            Custom comparator. If None, auto-inferred from definition outputs.
+        atol : float
+            Absolute tolerance for comparison.
+        rtol : float
+            Relative tolerance for comparison.
+        device : str
+            Device to generate tensors on.
+        """
+        self.definition = definition
+        self.reference_fn = self._extract_reference()
+        self.baseline_fn = baseline_fn
+        self.input_generator = input_generator
+        self.atol = atol
+        self.rtol = rtol
+        self.device = device
+        self.comparator = comparator or self._infer_comparator()
+
+    def _extract_reference(self) -> Callable:
+        """Extract the run() function from definition's reference field.
+
+        Raises
+        ------
+        ValueError
+            If reference code does not contain a 'run' function.
+        """
+        code = self.definition["reference"]
+        namespace: Dict[str, Any] = {"torch": torch, "math": math}
+        exec(code, namespace)  # noqa: S102
+
+        if "run" not in namespace:
+            raise ValueError("Definition reference must contain a 'run' function")
+
+        return namespace["run"]
+
+    def _infer_comparator(self) -> Comparator:
+        """Infer comparator from definition outputs."""
+        outputs = self.definition.get("outputs", {})
+
+        if len(outputs) == 1:
+            return TensorComparator(atol=self.atol, rtol=self.rtol)
+        else:
+            output_names = list(outputs.keys())
+            return MultiOutputComparator(output_names, atol=self.atol, rtol=self.rtol)
+
+    def _generate_inputs(self, **config: Any) -> Dict[str, Any]:
+        """Generate inputs for the test."""
+        if self.input_generator:
+            return self.input_generator(**config)
+        return self._generate_default_inputs(**config)
+
+    def _generate_default_inputs(self, **axis_values: Any) -> Dict[str, Any]:
+        """Generate inputs based on definition schema."""
+        inputs: Dict[str, Any] = {}
+        input_specs = self.definition.get("inputs", {})
+        axes = self.definition.get("axes", {})
+
+        for name, spec in input_specs.items():
+            shape = self._resolve_shape(spec.get("shape"), axes, axis_values)
+            dtype = dtype_str_to_torch_dtype(spec["dtype"])
+
+            if shape is None:
+                # Scalar value
+                if dtype in (torch.float32, torch.float16, torch.bfloat16):
+                    inputs[name] = 1.0
+                elif dtype == torch.bool:
+                    inputs[name] = True
+                else:
+                    inputs[name] = 1
+            else:
+                # Tensor
+                if dtype == torch.bool:
+                    tensor = torch.randint(0, 2, shape, dtype=dtype, device=self.device)
+                elif dtype in (torch.int64, torch.int32, torch.int16, torch.int8):
+                    tensor = torch.randint(0, 100, shape, dtype=dtype, device=self.device)
+                else:
+                    tensor = torch.randn(shape, device=self.device).to(dtype)
+                inputs[name] = tensor
+
+        return inputs
+
+    def _resolve_shape(
+        self, shape_spec: Optional[List[str]], axes: Dict[str, Any], axis_values: Dict[str, Any]
+    ) -> Optional[List[int]]:
+        """Resolve shape specification to concrete dimensions.
+
+        Raises
+        ------
+        ValueError
+            If a variable axis is not provided or an unknown axis is referenced.
+        """
+        if shape_spec is None:
+            return None  # scalar
+
+        resolved = []
+        for dim in shape_spec:
+            if dim in axis_values:
+                resolved.append(int(axis_values[dim]))
+            elif dim in axes:
+                axis = axes[dim]
+                if axis["type"] == "const":
+                    resolved.append(int(axis["value"]))
+                else:
+                    raise ValueError(f"Variable axis '{dim}' not provided in config")
+            else:
+                raise ValueError(f"Unknown axis: {dim}")
+
+        return resolved
+
+    def run(self, **config: Any) -> CompareResult:
+        """Generate inputs, execute reference and baseline, then compare outputs.
+
+        Parameters
+        ----------
+        **config : Any
+            Configuration values for input generation (axis values).
+
+        Returns
+        -------
+        CompareResult
+            Comparison result with pass/fail status and statistics.
+        """
+        inputs = self._generate_inputs(**config)
+
+        # Execute reference and baseline
+        with torch.no_grad():
+            ref_output = self.reference_fn(**inputs)
+            baseline_output = self.baseline_fn(**inputs)
+
+        # Compare outputs
+        return self.comparator.compare(ref_output, baseline_output)
+
+
+class DefinitionTest:
+    """Pytest-compatible test case base class for Definition-based testing.
+
+    Inherit from this class to create parametrized tests that compare
+    a baseline implementation against the reference from a Definition JSON.
+    The baseline function must have the same interface as the reference's run().
+
+    Example::
+
+        class TestGQAPagedDecode(DefinitionTest):
+            definition_path = "definitions/gqa_paged/gqa_paged_decode.json"
+            configs = [{"batch_size": 1}, {"batch_size": 4}]
+
+            def baseline_fn(self, q, k_cache, v_cache, kv_indptr, kv_indices, sm_scale):
+                # Wrap FlashInfer to match reference interface
+                wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(...)
+                wrapper.plan(...)
+                return wrapper.run(...)
+    """
+
+    definition_path: str = ""
+    """Path to definition JSON file (relative to FIB_DATASET_PATH)."""
+    configs: List[Dict[str, Any]] = []
+    """List of test configurations (axis values)."""
+
+    input_generator: Optional[Callable[..., Dict[str, Any]]] = None
+    """Custom input generator function."""
+    comparator: Optional[Comparator] = None
+    """Custom comparator for output comparison."""
+    atol: float = 1e-2
+    """Absolute tolerance for comparison."""
+    rtol: float = 5e-2
+    """Relative tolerance for comparison."""
+    device: str = "cuda"
+    """Device to run tests on."""
+
+    @abstractmethod
+    def baseline_fn(self, **inputs: Any) -> Any:
+        """Baseline implementation with same interface as reference run().
+
+        Parameters
+        ----------
+        **inputs : Any
+            Input tensors matching the definition's input specification.
+
+        Returns
+        -------
+        Any
+            Output tensor(s) matching the definition's output specification.
+        """
+        raise NotImplementedError("Subclass must implement baseline_fn")
+
+    @pytest.fixture(scope="class")
+    def definition(self) -> dict:
+        """Load definition from definition_path.
+
+        Returns
+        -------
+        dict
+            The loaded definition dictionary.
+        """
+        path = Path(self.definition_path)
+        if not path.is_absolute():
+            dataset_path = get_fib_dataset_path()
+            path = dataset_path / path
+        if not path.exists():
+            pytest.fail(f"Definition file not found: {path}")
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Invalid JSON in definition file {path}: {e}")
+
+    @pytest.fixture(params=[])
+    def config(self, request: pytest.FixtureRequest) -> Dict[str, Any]:
+        """Fixture that provides test configurations.
+
+        Parameters
+        ----------
+        request : pytest.FixtureRequest
+            Pytest fixture request object.
+
+        Returns
+        -------
+        Dict[str, Any]
+            A single test configuration (axis values).
+        """
+        return request.param
+
+    def pytest_generate_tests(self, metafunc: pytest.Metafunc) -> None:
+        """Generate parametrized test cases from configs.
+
+        Parameters
+        ----------
+        metafunc : pytest.Metafunc
+            Pytest metafunc object for test parametrization.
+        """
+        if "config" in metafunc.fixturenames and self.configs:
+            ids = [self._config_to_id(c) for c in self.configs]
+            metafunc.parametrize("config", self.configs, ids=ids)
+
+    @staticmethod
+    def _config_to_id(config: Dict[str, Any]) -> str:
+        """Convert config dict to a readable test ID."""
+        return "-".join(f"{k}={v}" for k, v in config.items())
+
+    def test_definition_schema(self, definition: dict) -> None:
+        """Test that the definition conforms to the Definition schema.
+
+        Parameters
+        ----------
+        definition : dict
+            The definition dictionary to validate.
+        """
+        Definition.model_validate(definition)
+
+    def test_reference_executable(self, definition: dict) -> None:
+        """Test that the reference code can be executed and has a callable 'run' function.
+
+        Parameters
+        ----------
+        definition : dict
+            The definition dictionary containing the reference code.
+        """
+        code = definition.get("reference")
+        if code is None:
+            name = definition.get("name", "unknown")
+            pytest.skip(f"No reference code in definition '{name}'")
+
+        namespace: Dict[str, Any] = {"torch": torch, "math": math}
+
+        try:
+            exec(code, namespace)  # noqa: S102
+        except Exception as e:
+            raise AssertionError(f"Reference code failed to execute: {e}") from e
+
+        assert "run" in namespace, "Reference must define a 'run' function"
+        assert callable(namespace["run"]), "Reference 'run' must be callable"
+
+    @requires_torch_cuda
+    def test_reference_correctness(self, definition: dict, config: Dict[str, Any]) -> None:
+        """Test that baseline output matches reference output.
+
+        Parameters
+        ----------
+        definition : dict
+            The definition dictionary.
+        config : Dict[str, Any]
+            Test configuration (axis values).
+        """
+        if definition.get("reference") is None:
+            name = definition.get("name", "unknown")
+            pytest.skip(f"No reference code in definition '{name}'")
+
+        runner = DefinitionRunner(
+            definition=definition,
+            baseline_fn=self.baseline_fn,
+            input_generator=self.input_generator,
+            comparator=self.comparator,
+            atol=self.atol,
+            rtol=self.rtol,
+            device=self.device,
+        )
+        result = runner.run(**config)
+        assert result.passed, self._build_error_message(config, result)
+
+    def _build_error_message(self, config: Dict[str, Any], result: CompareResult) -> str:
+        """Build detailed error message for failed tests."""
+        lines = [f"Definition test failed for config: {config}", "", "Statistics:"]
+
+        if isinstance(result.stats, dict):
+            for key, val in result.stats.items():
+                if isinstance(val, dict):
+                    lines.append(f"  {key}:")
+                    for k, v in val.items():
+                        lines.append(
+                            f"    {k}: {v:.6e}" if isinstance(v, float) else f"    {k}: {v}"
+                        )
+                else:
+                    lines.append(
+                        f"  {key}: {val:.6e}" if isinstance(val, float) else f"  {key}: {val}"
+                    )
+
+        if result.details:
+            lines.extend(["", "Details:", result.details])
+
+        return "\n".join(lines)

--- a/flashinfer_bench/testing/pytest_config.py
+++ b/flashinfer_bench/testing/pytest_config.py
@@ -1,0 +1,10 @@
+"""Pytest configuration helpers (markers and fixtures)."""
+
+import pytest
+
+from flashinfer_bench.utils import is_torch_cuda_available
+
+requires_torch_cuda = pytest.mark.skipif(
+    not is_torch_cuda_available(), reason="CUDA not available from PyTorch"
+)
+"""Marker to skip tests when PyTorch CUDA is not available."""

--- a/flashinfer_bench/utils.py
+++ b/flashinfer_bench/utils.py
@@ -6,7 +6,7 @@ import os
 import platform
 import sys
 from functools import cache
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List
 
 if TYPE_CHECKING:
     import torch
@@ -95,11 +95,14 @@ def is_dtype_integer(dtype: torch.dtype) -> bool:
     return dtype in _get_integer_dtypes()
 
 
-def is_cuda_available() -> bool:
-    """Check if CUDA is available."""
-    import torch
+def is_torch_cuda_available() -> bool:
+    """Check if CUDA is available from PyTorch."""
+    try:
+        import torch
 
-    return torch.cuda.is_available()
+        return torch.cuda.is_available()
+    except ImportError:
+        return False
 
 
 def list_cuda_devices() -> List[str]:

--- a/flashinfer_trace/README.md
+++ b/flashinfer_trace/README.md
@@ -48,3 +48,16 @@ This component encapsulates the concrete input data and configurations used to e
 This component is an atomic and immutable record of a single benchmark run of a Solution. A Trace serves as a detailed log entry, precisely linking a Solution to a Definition for a specific workload configuration (i.e., concrete shapes and input data), and contains the complete evaluation result.
 
 The collection of Traces is the central artifact of the FlashInfer-Bench ecosystem, creating a complete, queryable performance database that enables both high-level analysis and the programmatic discovery of the optimal Solution for any given Definition and environment.
+
+# Testing
+
+Run `pytest` from the `flashinfer_trace` directory to validate all definitions:
+
+```bash
+cd flashinfer_trace
+pytest
+```
+
+The test suite includes:
+- **Schema validation**: Checks that all definition JSON files conform to the schema, and the reference is valid code.
+- **Reference correctness** (requires GPU): Compares the reference implementation output against FlashInfer baseline to ensure correctness.

--- a/flashinfer_trace/tests/conftest.py
+++ b/flashinfer_trace/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Pytest configuration for flashinfer_trace tests."""
+
+import os
+from pathlib import Path
+
+# The references tests are replaced by tests under definitions directory. The references
+# directory will be removed in the future.
+collect_ignore = ["references"]
+
+
+def pytest_configure(config):
+    """Set FIB_DATASET_PATH to flashinfer_trace root for these tests."""
+    trace_root = Path(__file__).parent.parent
+    os.environ["FIB_DATASET_PATH"] = str(trace_root)

--- a/flashinfer_trace/tests/definitions/__init__.py
+++ b/flashinfer_trace/tests/definitions/__init__.py
@@ -1,0 +1,1 @@
+"""Definition-based tests for flashinfer_trace."""

--- a/flashinfer_trace/tests/definitions/test_gqa_paged_decode.py
+++ b/flashinfer_trace/tests/definitions/test_gqa_paged_decode.py
@@ -1,0 +1,166 @@
+"""Tests for GQA paged decode definitions."""
+
+import math
+import sys
+
+import flashinfer
+import pytest
+import torch
+
+from flashinfer_bench.testing import DefinitionTest
+
+
+def generate_gqa_decode_inputs(
+    batch_size: int,
+    max_seq_len: int = 64,
+    num_qo_heads: int = 32,
+    num_kv_heads: int = 4,
+    head_dim: int = 128,
+    page_size: int = 1,
+    device: str = "cuda",
+):
+    """Generate random inputs for GQA paged decode testing.
+
+    Handles the complex dependencies between kv_indptr and kv_indices.
+    """
+    # Generate random sequence lengths for each batch
+    seq_lens = torch.randint(1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device)
+
+    # Calculate total pages needed (page_size=1 means num_pages = total_tokens)
+    total_pages_needed = seq_lens.sum().item()
+
+    # Generate kv_indptr based on sequence lengths
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(seq_lens, dim=0)
+
+    # Generate kv_indices (consecutive page indices)
+    kv_indices = torch.arange(total_pages_needed, dtype=torch.int32, device=device)
+
+    # Generate query tensor
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=torch.bfloat16, device=device)
+
+    # Generate K and V caches with extra pages
+    num_pages = total_pages_needed + 100
+    k_cache = torch.randn(
+        num_pages, page_size, num_kv_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+    v_cache = torch.randn(
+        num_pages, page_size, num_kv_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+
+    # Compute sm_scale
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    return {
+        "q": q,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "sm_scale": sm_scale,
+    }
+
+
+class TestGQAPagedDecodeH32KV4(DefinitionTest):
+    """Test GQA paged decode with 32 QO heads and 4 KV heads."""
+
+    definition_path = "definitions/gqa_paged/gqa_paged_decode_h32_kv4_d128_ps1.json"
+    configs = [
+        {"batch_size": 1, "max_seq_len": 16},
+        {"batch_size": 4, "max_seq_len": 32},
+        {"batch_size": 8, "max_seq_len": 64},
+        {"batch_size": 16, "max_seq_len": 128},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_gqa_decode_inputs(
+            batch_size=config["batch_size"],
+            max_seq_len=config["max_seq_len"],
+            num_qo_heads=32,
+            num_kv_heads=4,
+        )
+
+    def baseline_fn(self, q, k_cache, v_cache, kv_indptr, kv_indices, sm_scale):
+        """FlashInfer baseline implementation."""
+        device = q.device
+        batch_size = q.shape[0]
+
+        # Create workspace buffer
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+        # For page_size=1, last_page_len is always 1
+        kv_last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout="NHD")
+
+        wrapper.plan(
+            indptr=kv_indptr,
+            indices=kv_indices,
+            last_page_len=kv_last_page_len,
+            num_qo_heads=32,
+            num_kv_heads=4,
+            head_dim=128,
+            page_size=1,
+            pos_encoding_mode="NONE",
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+            sm_scale=float(sm_scale),
+        )
+
+        return wrapper.run(q, (k_cache, v_cache), return_lse=True)
+
+
+class TestGQAPagedDecodeH32KV8(DefinitionTest):
+    """Test GQA paged decode with 32 QO heads and 8 KV heads."""
+
+    # Relative path to FIB_DATASET_PATH
+    definition_path = "definitions/gqa_paged/gqa_paged_decode_h32_kv8_d128_ps1.json"
+    configs = [
+        {"batch_size": 1, "max_seq_len": 16},
+        {"batch_size": 4, "max_seq_len": 32},
+        {"batch_size": 8, "max_seq_len": 64},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_gqa_decode_inputs(
+            batch_size=config["batch_size"],
+            max_seq_len=config["max_seq_len"],
+            num_qo_heads=32,
+            num_kv_heads=8,
+        )
+
+    def baseline_fn(self, q, k_cache, v_cache, kv_indptr, kv_indices, sm_scale):
+        """FlashInfer baseline implementation."""
+        device = q.device
+        batch_size = q.shape[0]
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+        kv_last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, kv_layout="NHD")
+
+        wrapper.plan(
+            indptr=kv_indptr,
+            indices=kv_indices,
+            last_page_len=kv_last_page_len,
+            num_qo_heads=32,
+            num_kv_heads=8,
+            head_dim=128,
+            page_size=1,
+            pos_encoding_mode="NONE",
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+            sm_scale=float(sm_scale),
+        )
+
+        return wrapper.run(q, (k_cache, v_cache), return_lse=True)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/definitions/test_gqa_paged_prefill.py
+++ b/flashinfer_trace/tests/definitions/test_gqa_paged_prefill.py
@@ -1,0 +1,186 @@
+"""Tests for GQA paged prefill definitions."""
+
+import math
+import sys
+
+import flashinfer
+import pytest
+import torch
+
+from flashinfer_bench.testing import DefinitionTest
+
+
+def generate_gqa_paged_prefill_inputs(
+    batch_size: int,
+    max_q_len: int = 32,
+    max_kv_len: int = 64,
+    num_qo_heads: int = 32,
+    num_kv_heads: int = 4,
+    head_dim: int = 128,
+    page_size: int = 1,
+    device: str = "cuda",
+):
+    """Generate random inputs for GQA paged prefill testing."""
+    # Generate random query and KV lengths
+    q_lens = torch.randint(1, max_q_len + 1, (batch_size,), dtype=torch.int32)
+    kv_lens = torch.zeros(batch_size, dtype=torch.int32)
+    for i in range(batch_size):
+        kv_lens[i] = torch.randint(q_lens[i].item(), max_kv_len + 1, (1,)).item()
+
+    # Create indptr arrays
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    qo_indptr[1:] = torch.cumsum(q_lens.to(device), dim=0)
+
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(kv_lens.to(device), dim=0)
+
+    # Get total tokens
+    total_q = qo_indptr[-1].item()
+    num_kv_indices = kv_indptr[-1].item()
+
+    # Generate page indices
+    max_pages = max_kv_len * batch_size * 2
+    all_page_ids = torch.randperm(max_pages, device=device)[:num_kv_indices]
+
+    kv_indices = torch.zeros(num_kv_indices, dtype=torch.int32, device=device)
+    idx = 0
+    for i in range(batch_size):
+        seq_len = kv_lens[i].item()
+        kv_indices[idx : idx + seq_len] = all_page_ids[idx : idx + seq_len]
+        idx += seq_len
+
+    # Generate KV cache
+    k_cache = torch.randn(
+        max_pages, page_size, num_kv_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+    v_cache = torch.randn(
+        max_pages, page_size, num_kv_heads, head_dim, dtype=torch.bfloat16, device=device
+    )
+
+    # Generate query tensor
+    q = torch.randn(total_q, num_qo_heads, head_dim, dtype=torch.bfloat16, device=device)
+
+    # Compute sm_scale
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    return {
+        "q": q,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "qo_indptr": qo_indptr,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "sm_scale": sm_scale,
+    }
+
+
+class TestGQAPagedPrefillH32KV4(DefinitionTest):
+    """Test GQA paged prefill with 32 QO heads and 4 KV heads."""
+
+    definition_path = "definitions/gqa_paged/gqa_paged_prefill_causal_h32_kv4_d128_ps1.json"
+    configs = [
+        {"batch_size": 1, "max_q_len": 8, "max_kv_len": 16},
+        {"batch_size": 4, "max_q_len": 16, "max_kv_len": 32},
+        {"batch_size": 8, "max_q_len": 32, "max_kv_len": 64},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_gqa_paged_prefill_inputs(
+            batch_size=config["batch_size"],
+            max_q_len=config["max_q_len"],
+            max_kv_len=config["max_kv_len"],
+            num_qo_heads=32,
+            num_kv_heads=4,
+        )
+
+    def baseline_fn(self, q, k_cache, v_cache, qo_indptr, kv_indptr, kv_indices, sm_scale):
+        """FlashInfer baseline implementation."""
+        device = q.device
+        batch_size = qo_indptr.shape[0] - 1
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+        last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+        paged_kv_cache = torch.stack([k_cache, v_cache], dim=1)
+
+        wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+            workspace_buffer, kv_layout="NHD"
+        )
+        wrapper.plan(
+            qo_indptr=qo_indptr,
+            paged_kv_indptr=kv_indptr,
+            paged_kv_indices=kv_indices,
+            paged_kv_last_page_len=last_page_len,
+            num_qo_heads=32,
+            num_kv_heads=4,
+            head_dim_qk=128,
+            head_dim_vo=128,
+            page_size=1,
+            causal=True,
+            sm_scale=float(sm_scale),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+        return wrapper.run(q, paged_kv_cache, return_lse=True)
+
+
+class TestGQAPagedPrefillH32KV8(DefinitionTest):
+    """Test GQA paged prefill with 32 QO heads and 8 KV heads."""
+
+    definition_path = "definitions/gqa_paged/gqa_paged_prefill_causal_h32_kv8_d128_ps1.json"
+    configs = [
+        {"batch_size": 1, "max_q_len": 8, "max_kv_len": 16},
+        {"batch_size": 4, "max_q_len": 16, "max_kv_len": 32},
+        {"batch_size": 8, "max_q_len": 32, "max_kv_len": 64},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_gqa_paged_prefill_inputs(
+            batch_size=config["batch_size"],
+            max_q_len=config["max_q_len"],
+            max_kv_len=config["max_kv_len"],
+            num_qo_heads=32,
+            num_kv_heads=8,
+        )
+
+    def baseline_fn(self, q, k_cache, v_cache, qo_indptr, kv_indptr, kv_indices, sm_scale):
+        """FlashInfer baseline implementation."""
+        device = q.device
+        batch_size = qo_indptr.shape[0] - 1
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+        last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+        paged_kv_cache = torch.stack([k_cache, v_cache], dim=1)
+
+        wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+            workspace_buffer, kv_layout="NHD"
+        )
+        wrapper.plan(
+            qo_indptr=qo_indptr,
+            paged_kv_indptr=kv_indptr,
+            paged_kv_indices=kv_indices,
+            paged_kv_last_page_len=last_page_len,
+            num_qo_heads=32,
+            num_kv_heads=8,
+            head_dim_qk=128,
+            head_dim_vo=128,
+            page_size=1,
+            causal=True,
+            sm_scale=float(sm_scale),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+        return wrapper.run(q, paged_kv_cache, return_lse=True)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/definitions/test_gqa_ragged_prefill.py
+++ b/flashinfer_trace/tests/definitions/test_gqa_ragged_prefill.py
@@ -1,0 +1,155 @@
+"""Tests for GQA ragged prefill definitions."""
+
+import math
+import sys
+
+import flashinfer
+import pytest
+import torch
+
+from flashinfer_bench.testing import DefinitionTest
+
+
+def generate_gqa_ragged_prefill_inputs(
+    batch_size: int,
+    max_q_len: int = 32,
+    max_kv_len: int = 64,
+    num_qo_heads: int = 32,
+    num_kv_heads: int = 4,
+    head_dim: int = 128,
+    device: str = "cuda",
+):
+    """Generate random inputs for GQA ragged prefill testing."""
+    # Generate random query lengths
+    q_lens = torch.randint(1, max_q_len + 1, (batch_size,), dtype=torch.int32)
+
+    # Generate KV lengths >= query lengths for causal attention
+    kv_lens = torch.zeros(batch_size, dtype=torch.int32)
+    for i in range(batch_size):
+        kv_lens[i] = torch.randint(q_lens[i].item(), max_kv_len + 1, (1,)).item()
+
+    # Create indptr arrays
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    qo_indptr[1:] = torch.cumsum(q_lens.to(device), dim=0)
+
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(kv_lens.to(device), dim=0)
+
+    # Get total tokens
+    total_q = qo_indptr[-1].item()
+    total_kv = kv_indptr[-1].item()
+
+    # Generate tensors
+    q = torch.randn(total_q, num_qo_heads, head_dim, dtype=torch.bfloat16, device=device)
+    k = torch.randn(total_kv, num_kv_heads, head_dim, dtype=torch.bfloat16, device=device)
+    v = torch.randn(total_kv, num_kv_heads, head_dim, dtype=torch.bfloat16, device=device)
+
+    # Compute sm_scale
+    sm_scale = 1.0 / math.sqrt(head_dim)
+
+    return {
+        "q": q,
+        "k": k,
+        "v": v,
+        "qo_indptr": qo_indptr,
+        "kv_indptr": kv_indptr,
+        "sm_scale": sm_scale,
+    }
+
+
+class TestGQARaggedPrefillH32KV4(DefinitionTest):
+    """Test GQA ragged prefill with 32 QO heads and 4 KV heads."""
+
+    definition_path = "definitions/gqa_ragged/gqa_ragged_prefill_causal_h32_kv4_d128.json"
+    configs = [
+        {"batch_size": 1, "max_q_len": 8, "max_kv_len": 16},
+        {"batch_size": 4, "max_q_len": 16, "max_kv_len": 32},
+        {"batch_size": 8, "max_q_len": 32, "max_kv_len": 64},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_gqa_ragged_prefill_inputs(
+            batch_size=config["batch_size"],
+            max_q_len=config["max_q_len"],
+            max_kv_len=config["max_kv_len"],
+            num_qo_heads=32,
+            num_kv_heads=4,
+        )
+
+    def baseline_fn(self, q, k, v, qo_indptr, kv_indptr, sm_scale):
+        """FlashInfer baseline implementation."""
+        device = q.device
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+        wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+            workspace_buffer, kv_layout="NHD"
+        )
+        wrapper.plan(
+            qo_indptr=qo_indptr,
+            kv_indptr=kv_indptr,
+            num_qo_heads=32,
+            num_kv_heads=4,
+            head_dim_qk=128,
+            head_dim_vo=128,
+            causal=True,
+            sm_scale=float(sm_scale),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+        return wrapper.run(q, k, v, return_lse=True)
+
+
+class TestGQARaggedPrefillH32KV8(DefinitionTest):
+    """Test GQA ragged prefill with 32 QO heads and 8 KV heads."""
+
+    definition_path = "definitions/gqa_ragged/gqa_ragged_prefill_causal_h32_kv8_d128.json"
+    configs = [
+        {"batch_size": 1, "max_q_len": 8, "max_kv_len": 16},
+        {"batch_size": 4, "max_q_len": 16, "max_kv_len": 32},
+        {"batch_size": 8, "max_q_len": 32, "max_kv_len": 64},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_gqa_ragged_prefill_inputs(
+            batch_size=config["batch_size"],
+            max_q_len=config["max_q_len"],
+            max_kv_len=config["max_kv_len"],
+            num_qo_heads=32,
+            num_kv_heads=8,
+        )
+
+    def baseline_fn(self, q, k, v, qo_indptr, kv_indptr, sm_scale):
+        """FlashInfer baseline implementation."""
+        device = q.device
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+        wrapper = flashinfer.prefill.BatchPrefillWithRaggedKVCacheWrapper(
+            workspace_buffer, kv_layout="NHD"
+        )
+        wrapper.plan(
+            qo_indptr=qo_indptr,
+            kv_indptr=kv_indptr,
+            num_qo_heads=32,
+            num_kv_heads=8,
+            head_dim_qk=128,
+            head_dim_vo=128,
+            causal=True,
+            sm_scale=float(sm_scale),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+        return wrapper.run(q, k, v, return_lse=True)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/definitions/test_mla_paged.py
+++ b/flashinfer_trace/tests/definitions/test_mla_paged.py
@@ -1,0 +1,208 @@
+"""Tests for MLA paged attention definitions."""
+
+import sys
+
+import flashinfer
+import numpy as np
+import pytest
+import torch
+
+from flashinfer_bench.testing import DefinitionTest
+
+
+def generate_mla_decode_inputs(
+    batch_size: int,
+    max_seq_len: int = 64,
+    num_qo_heads: int = 16,
+    head_dim_ckv: int = 512,
+    head_dim_kpe: int = 64,
+    page_size: int = 1,
+    device: str = "cuda",
+):
+    """Generate random inputs for MLA paged decode testing."""
+    # Generate random sequence lengths
+    seq_lens = torch.randint(1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device)
+
+    total_pages_needed = seq_lens.sum().item()
+
+    # Generate kv_indptr and kv_indices
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(seq_lens, dim=0)
+    kv_indices = torch.arange(total_pages_needed, dtype=torch.int32, device=device)
+
+    # Generate query tensors
+    q_nope = torch.randn(
+        batch_size, num_qo_heads, head_dim_ckv, dtype=torch.bfloat16, device=device
+    )
+    q_pe = torch.randn(batch_size, num_qo_heads, head_dim_kpe, dtype=torch.bfloat16, device=device)
+
+    # Generate KV caches
+    num_pages = total_pages_needed + 100
+    ckv_cache = torch.randn(num_pages, page_size, head_dim_ckv, dtype=torch.bfloat16, device=device)
+    kpe_cache = torch.randn(num_pages, page_size, head_dim_kpe, dtype=torch.bfloat16, device=device)
+
+    # MLA scale
+    sm_scale = 1.0 / np.sqrt(128 + head_dim_kpe)
+
+    return {
+        "q_nope": q_nope,
+        "q_pe": q_pe,
+        "ckv_cache": ckv_cache,
+        "kpe_cache": kpe_cache,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "sm_scale": sm_scale,
+    }
+
+
+def generate_mla_prefill_inputs(
+    batch_size: int,
+    max_q_len: int = 32,
+    max_kv_len: int = 64,
+    num_qo_heads: int = 16,
+    head_dim_ckv: int = 512,
+    head_dim_kpe: int = 64,
+    page_size: int = 1,
+    device: str = "cuda",
+):
+    """Generate random inputs for MLA paged prefill testing."""
+    # Generate random sequence lengths
+    q_lens = torch.randint(1, max_q_len + 1, (batch_size,), dtype=torch.int32, device=device)
+    kv_lens = torch.randint(1, max_kv_len + 1, (batch_size,), dtype=torch.int32, device=device)
+
+    # Ensure kv_len >= q_len for causal attention
+    for i in range(batch_size):
+        kv_lens[i] = max(kv_lens[i], q_lens[i])
+
+    total_q = q_lens.sum().item()
+    total_pages_needed = kv_lens.sum().item()
+
+    # Generate indptrs
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    qo_indptr[1:] = torch.cumsum(q_lens, dim=0)
+
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(kv_lens, dim=0)
+
+    kv_indices = torch.arange(total_pages_needed, dtype=torch.int32, device=device)
+
+    # Generate query tensors
+    q_nope = torch.randn(total_q, num_qo_heads, head_dim_ckv, dtype=torch.bfloat16, device=device)
+    q_pe = torch.randn(total_q, num_qo_heads, head_dim_kpe, dtype=torch.bfloat16, device=device)
+
+    # Generate KV caches
+    num_pages = total_pages_needed + 100
+    ckv_cache = torch.randn(num_pages, page_size, head_dim_ckv, dtype=torch.bfloat16, device=device)
+    kpe_cache = torch.randn(num_pages, page_size, head_dim_kpe, dtype=torch.bfloat16, device=device)
+
+    # MLA scale
+    sm_scale = 1.0 / np.sqrt(128 + head_dim_kpe)
+
+    return {
+        "q_nope": q_nope,
+        "q_pe": q_pe,
+        "ckv_cache": ckv_cache,
+        "kpe_cache": kpe_cache,
+        "qo_indptr": qo_indptr,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "sm_scale": sm_scale,
+    }
+
+
+class TestMLAPagedDecode(DefinitionTest):
+    """Test MLA paged decode with 16 heads, ckv=512, kpe=64."""
+
+    definition_path = "definitions/mla_paged/mla_paged_decode_h16_ckv512_kpe64_ps1.json"
+    configs = [
+        {"batch_size": 1, "max_seq_len": 16},
+        {"batch_size": 4, "max_seq_len": 32},
+        {"batch_size": 8, "max_seq_len": 64},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_mla_decode_inputs(
+            batch_size=config["batch_size"], max_seq_len=config["max_seq_len"]
+        )
+
+    def baseline_fn(self, q_nope, q_pe, ckv_cache, kpe_cache, kv_indptr, kv_indices, sm_scale):
+        """FlashInfer baseline implementation."""
+        device = q_nope.device
+        batch_size = q_nope.shape[0]
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+        qo_indptr = torch.arange(0, batch_size + 1, dtype=torch.int32, device=device)
+        kv_len_arr = kv_indptr[1:] - kv_indptr[:-1]
+
+        wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace_buffer, backend="auto")
+        wrapper.plan(
+            qo_indptr=qo_indptr,
+            kv_indptr=kv_indptr,
+            kv_indices=kv_indices,
+            kv_len_arr=kv_len_arr,
+            num_heads=16,
+            head_dim_ckv=512,
+            head_dim_kpe=64,
+            page_size=1,
+            causal=False,
+            sm_scale=float(sm_scale),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+        return wrapper.run(q_nope, q_pe, ckv_cache, kpe_cache, return_lse=True)
+
+
+class TestMLAPagedPrefill(DefinitionTest):
+    """Test MLA paged prefill with 16 heads, ckv=512, kpe=64."""
+
+    definition_path = "definitions/mla_paged/mla_paged_prefill_causal_h16_ckv512_kpe64_ps1.json"
+    configs = [
+        {"batch_size": 1, "max_q_len": 8, "max_kv_len": 16},
+        {"batch_size": 4, "max_q_len": 16, "max_kv_len": 32},
+        {"batch_size": 8, "max_q_len": 32, "max_kv_len": 64},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_mla_prefill_inputs(
+            batch_size=config["batch_size"],
+            max_q_len=config["max_q_len"],
+            max_kv_len=config["max_kv_len"],
+        )
+
+    def baseline_fn(
+        self, q_nope, q_pe, ckv_cache, kpe_cache, qo_indptr, kv_indptr, kv_indices, sm_scale
+    ):
+        """FlashInfer baseline implementation."""
+        device = q_nope.device
+        kv_len_arr = kv_indptr[1:] - kv_indptr[:-1]
+
+        workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+
+        wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(workspace_buffer, backend="auto")
+        wrapper.plan(
+            qo_indptr=qo_indptr,
+            kv_indptr=kv_indptr,
+            kv_indices=kv_indices,
+            kv_len_arr=kv_len_arr,
+            num_heads=16,
+            head_dim_ckv=512,
+            head_dim_kpe=64,
+            page_size=1,
+            causal=True,
+            sm_scale=float(sm_scale),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+        return wrapper.run(q_nope, q_pe, ckv_cache, kpe_cache, return_lse=True)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/definitions/test_moe_fp8.py
+++ b/flashinfer_trace/tests/definitions/test_moe_fp8.py
@@ -1,0 +1,204 @@
+"""Tests for MoE FP8 block scale definitions.
+
+This test requires workload data from the workloads directory.
+If workloads are not available, tests using workload data will be skipped.
+"""
+
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+from flashinfer_bench.testing import DefinitionTest
+from flashinfer_bench.testing.comparators import HitRatioComparator
+
+try:
+    from flashinfer.fused_moe import trtllm_fp8_block_scale_moe
+
+    FLASHINFER_MOE_AVAILABLE = True
+except ImportError:
+    FLASHINFER_MOE_AVAILABLE = False
+
+# Constants
+HIDDEN_SIZE = 7168
+INTERMEDIATE_SIZE = 2048
+NUM_EXPERTS_GLOBAL = 256
+NUM_EXPERTS_LOCAL = 32
+TOP_K = 8
+N_GROUP = 8
+TOPK_GROUP = 4
+BLOCK_SIZE = 128
+
+
+def next_power_of_2(n: int):
+    return 1 << (n - 1).bit_length() if n > 0 else 1
+
+
+def get_tile_tokens_dim(num_tokens, top_k, num_experts):
+    num_tokens_per_expert = (num_tokens * top_k) // num_experts
+    tile_tokens_dim = next_power_of_2(num_tokens_per_expert)
+    tile_tokens_dim = min(max(tile_tokens_dim, 8), 64)
+    return tile_tokens_dim
+
+
+def _fp8_block_quant_1d(x_bf16: torch.Tensor, block: int = 128):
+    """Quantize [T, H] activations into FP8 with per-block scales."""
+    assert x_bf16.dim() == 2
+    T, H = x_bf16.shape
+    assert H % block == 0
+    nb = H // block
+
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    max_fp8 = finfo.max
+
+    x_f32 = x_bf16.to(torch.float32)
+    x_fp8 = torch.empty((T, H), dtype=torch.float8_e4m3fn, device=x_bf16.device)
+    scales = torch.empty((T, nb), dtype=torch.float32, device=x_bf16.device)
+
+    for j in range(nb):
+        sl = slice(j * block, (j + 1) * block)
+        blk = x_f32[:, sl]
+        amax = torch.amax(torch.abs(blk), dim=1)
+        s = torch.where(amax > 0, amax / max_fp8, torch.ones_like(amax))
+        q = (blk / s.unsqueeze(1)).to(torch.float8_e4m3fn)
+        x_fp8[:, sl] = q
+        scales[:, j] = s
+    return x_fp8, scales
+
+
+def _fp8_block_quant_2d(w_bf16: torch.Tensor, block: int = 128):
+    """Quantize weights with 2D block scales."""
+    assert w_bf16.dim() >= 2
+    *prefix, R, C = w_bf16.shape
+    assert R % block == 0 and C % block == 0
+    nb_r = R // block
+    nb_c = C // block
+
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    max_fp8 = finfo.max
+
+    w_f32 = w_bf16.to(torch.float32).contiguous()
+    w_fp8 = torch.empty_like(w_f32, dtype=torch.float8_e4m3fn)
+    scales = torch.empty((*prefix, nb_r, nb_c), dtype=torch.float32, device=w_bf16.device)
+
+    it = np.ndindex(*prefix) if prefix else [()]
+    for idx in it:
+        sel = idx if isinstance(idx, tuple) else (idx,)
+        for i in range(nb_r):
+            rs = slice(i * block, (i + 1) * block)
+            for j in range(nb_c):
+                cs = slice(j * block, (j + 1) * block)
+                blk = w_f32[(*sel, rs, cs)]
+                amax = torch.amax(torch.abs(blk))
+                s = (amax / max_fp8) if amax > 0 else torch.tensor(1.0, device=w_bf16.device)
+                q = (blk / s).to(torch.float8_e4m3fn)
+                w_fp8[(*sel, rs, cs)] = q
+                scales[(*sel, i, j)] = s
+    return w_fp8, scales
+
+
+@torch.no_grad()
+def generate_moe_fp8_inputs(
+    seq_len: int,
+    num_experts_global: int = NUM_EXPERTS_GLOBAL,
+    num_local_experts: int = NUM_EXPERTS_LOCAL,
+    hidden_size: int = HIDDEN_SIZE,
+    intermediate_size: int = INTERMEDIATE_SIZE,
+    local_expert_offset: int = 0,
+    routed_scaling_factor: float = 2.5,
+    device: str = "cuda",
+):
+    """Generate random inputs for MoE FP8 testing."""
+    T, H, I = seq_len, hidden_size, intermediate_size
+    E_global, E_local = num_experts_global, num_local_experts
+
+    # Routing inputs
+    routing_logits = torch.randn(T, E_global, dtype=torch.float32, device=device)
+    routing_bias = torch.randn(E_global, dtype=torch.bfloat16, device=device)
+
+    # Hidden states with FP8 quantization
+    hidden_bf16 = torch.randn(T, H, dtype=torch.bfloat16, device=device)
+    hidden_states, hidden_states_scale = _fp8_block_quant_1d(hidden_bf16)
+    hidden_states_scale = hidden_states_scale.permute(1, 0).contiguous()
+
+    # Expert weights with FP8 quantization
+    w13_bf16 = torch.randn(E_local, 2 * I, H, dtype=torch.bfloat16, device=device)
+    w2_bf16 = torch.randn(E_local, H, I, dtype=torch.bfloat16, device=device)
+
+    gemm1_weights, gemm1_weights_scale = _fp8_block_quant_2d(w13_bf16)
+    gemm2_weights, gemm2_weights_scale = _fp8_block_quant_2d(w2_bf16)
+
+    return {
+        "routing_logits": routing_logits,
+        "routing_bias": routing_bias,
+        "hidden_states": hidden_states,
+        "hidden_states_scale": hidden_states_scale,
+        "gemm1_weights": gemm1_weights,
+        "gemm1_weights_scale": gemm1_weights_scale,
+        "gemm2_weights": gemm2_weights,
+        "gemm2_weights_scale": gemm2_weights_scale,
+        "local_expert_offset": local_expert_offset,
+        "routed_scaling_factor": routed_scaling_factor,
+    }
+
+
+@pytest.mark.skipif(not FLASHINFER_MOE_AVAILABLE, reason="FlashInfer MoE not available")
+class TestMoEFP8BlockScale(DefinitionTest):
+    """Test MoE FP8 block scale with DeepSeek routing."""
+
+    definition_path = (
+        "definitions/moe/moe_fp8_block_scale_ds_routing_topk8_ng8_kg4_e32_h7168_i2048.json"
+    )
+    configs = [{"seq_len": 64}, {"seq_len": 128}, {"seq_len": 256}]
+    atol = 1e-1
+    rtol = 2e-1
+    comparator = HitRatioComparator(atol=1e-1, rtol=2e-1, min_hit_ratio=0.85)
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_moe_fp8_inputs(seq_len=config["seq_len"])
+
+    def baseline_fn(
+        self,
+        routing_logits,
+        routing_bias,
+        hidden_states,
+        hidden_states_scale,
+        gemm1_weights,
+        gemm1_weights_scale,
+        gemm2_weights,
+        gemm2_weights_scale,
+        local_expert_offset,
+        routed_scaling_factor,
+    ):
+        """FlashInfer TRT-LLM FP8 MoE baseline implementation."""
+        seq_len = hidden_states.shape[0]
+        local_num_experts = gemm1_weights.shape[0]
+        tile_tokens_dim = get_tile_tokens_dim(seq_len, TOP_K, NUM_EXPERTS_GLOBAL)
+
+        return trtllm_fp8_block_scale_moe(
+            routing_logits.to(torch.float32),
+            routing_bias,
+            hidden_states,
+            hidden_states_scale,
+            gemm1_weights,
+            gemm1_weights_scale.to(torch.float32),
+            gemm2_weights,
+            gemm2_weights_scale.to(torch.float32),
+            NUM_EXPERTS_GLOBAL,
+            TOP_K,
+            N_GROUP,
+            TOPK_GROUP,
+            INTERMEDIATE_SIZE,
+            int(local_expert_offset),
+            local_num_experts,
+            float(routed_scaling_factor),
+            tile_tokens_dim=tile_tokens_dim,
+            routing_method_type=2,
+            use_shuffled_weight=False,
+        )
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/definitions/test_nsa_sparse.py
+++ b/flashinfer_trace/tests/definitions/test_nsa_sparse.py
@@ -1,0 +1,269 @@
+"""Tests for NSA (Native Sparse Attention) sparse definitions.
+
+Note: These tests require SGLang sgl_kernel for ground truth comparison.
+If not available, tests will be skipped.
+"""
+
+import sys
+
+import numpy as np
+import pytest
+import torch
+
+from flashinfer_bench.testing import DefinitionTest
+from flashinfer_bench.testing.comparators import HitRatioComparator, MultiOutputComparator
+
+# Check SGLang availability
+try:
+    from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+    SGLANG_AVAILABLE = True
+except ImportError:
+    SGLANG_AVAILABLE = False
+
+# Constants
+NUM_QO_HEADS = 16
+HEAD_DIM_CKV = 512
+HEAD_DIM_KPE = 64
+PAGE_SIZE = 1
+TOPK = 256
+
+
+def generate_nsa_decode_inputs(
+    batch_size: int,
+    max_seq_len: int = 512,
+    num_qo_heads: int = NUM_QO_HEADS,
+    head_dim_ckv: int = HEAD_DIM_CKV,
+    head_dim_kpe: int = HEAD_DIM_KPE,
+    topk: int = TOPK,
+    device: str = "cuda",
+):
+    """Generate random inputs for NSA sparse decode testing."""
+    min_seq_len = max(topk, 256)
+    seq_lens = torch.randint(
+        min_seq_len, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+
+    total_pages_needed = seq_lens.sum().item()
+
+    # Generate page table
+    page_table = torch.zeros(batch_size, max_seq_len, dtype=torch.int32, device=device)
+    page_offset = 0
+    for b in range(batch_size):
+        seq_len = seq_lens[b].item()
+        page_table[b, :seq_len] = torch.arange(
+            page_offset, page_offset + seq_len, dtype=torch.int32, device=device
+        )
+        page_offset += seq_len
+
+    # Generate sparse indices
+    sparse_indices = torch.full((batch_size, topk), -1, dtype=torch.int32, device=device)
+    for b in range(batch_size):
+        seq_len = seq_lens[b].item()
+        actual_topk = min(topk, seq_len)
+        perm = torch.randperm(seq_len, device=device)[:actual_topk]
+        selected_pages = page_table[b, perm]
+        sparse_indices[b, :actual_topk] = selected_pages.to(torch.int32)
+
+    # Generate query tensors
+    q_nope = torch.randn(
+        batch_size, num_qo_heads, head_dim_ckv, dtype=torch.bfloat16, device=device
+    )
+    q_pe = torch.randn(batch_size, num_qo_heads, head_dim_kpe, dtype=torch.bfloat16, device=device)
+
+    # Generate KV caches
+    num_pages = total_pages_needed + 100
+    ckv_cache = torch.randn(num_pages, 1, head_dim_ckv, dtype=torch.bfloat16, device=device)
+    kpe_cache = torch.randn(num_pages, 1, head_dim_kpe, dtype=torch.bfloat16, device=device)
+
+    sm_scale = 1.0 / np.sqrt(128 + head_dim_kpe)
+
+    return {
+        "q_nope": q_nope,
+        "q_pe": q_pe,
+        "ckv_cache": ckv_cache,
+        "kpe_cache": kpe_cache,
+        "sparse_indices": sparse_indices,
+        "sm_scale": sm_scale,
+    }
+
+
+def generate_nsa_prefill_inputs(
+    total_num_tokens: int,
+    num_qo_heads: int = NUM_QO_HEADS,
+    head_dim_ckv: int = HEAD_DIM_CKV,
+    head_dim_kpe: int = HEAD_DIM_KPE,
+    topk: int = TOPK,
+    device: str = "cuda",
+):
+    """Generate random inputs for NSA sparse prefill testing."""
+    num_pages = max(total_num_tokens * 2, 1024)
+
+    sparse_indices = torch.randint(
+        0, num_pages, (total_num_tokens, topk), dtype=torch.int32, device=device
+    )
+
+    q_nope = torch.randn(
+        total_num_tokens, num_qo_heads, head_dim_ckv, dtype=torch.bfloat16, device=device
+    )
+    q_pe = torch.randn(
+        total_num_tokens, num_qo_heads, head_dim_kpe, dtype=torch.bfloat16, device=device
+    )
+
+    ckv_cache = torch.randn(num_pages, 1, head_dim_ckv, dtype=torch.bfloat16, device=device)
+    kpe_cache = torch.randn(num_pages, 1, head_dim_kpe, dtype=torch.bfloat16, device=device)
+
+    sm_scale = 1.0 / np.sqrt(128 + head_dim_kpe)
+
+    return {
+        "q_nope": q_nope,
+        "q_pe": q_pe,
+        "ckv_cache": ckv_cache,
+        "kpe_cache": kpe_cache,
+        "sparse_indices": sparse_indices,
+        "sm_scale": sm_scale,
+    }
+
+
+@pytest.mark.skipif(not SGLANG_AVAILABLE, reason="SGLang sgl_kernel not available")
+class TestNSASparseDecode(DefinitionTest):
+    """Test NSA sparse decode with SGLang as baseline."""
+
+    definition_path = "definitions/nsa_paged/nsa_sparse_decode_h16_ckv512_kpe64_topk256_ps1.json"
+    configs = [
+        {"batch_size": 1, "max_seq_len": 512},
+        {"batch_size": 4, "max_seq_len": 512},
+        {"batch_size": 8, "max_seq_len": 1024},
+    ]
+    atol = 1e-2
+    rtol = 5e-2
+    comparator = MultiOutputComparator(
+        output_names=["output", "lse"],
+        comparators={
+            "output": HitRatioComparator(atol=1e-1, rtol=2e-1, min_hit_ratio=0.85),
+            "lse": HitRatioComparator(atol=1e-1, rtol=2e-1, min_hit_ratio=0.85),
+        },
+    )
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_nsa_decode_inputs(
+            batch_size=config["batch_size"], max_seq_len=config["max_seq_len"]
+        )
+
+    def baseline_fn(self, q_nope, q_pe, ckv_cache, kpe_cache, sparse_indices, sm_scale):
+        """SGLang FlashMLA baseline implementation."""
+        batch_size = q_nope.shape[0]
+        device = q_nope.device
+        head_dim = HEAD_DIM_CKV + HEAD_DIM_KPE
+
+        # Combine q for FlashMLA
+        q_all = torch.cat([q_nope, q_pe], dim=-1)
+
+        # KV cache (combined)
+        kv_cache = torch.cat([ckv_cache.squeeze(1), kpe_cache.squeeze(1)], dim=-1)
+        kv_for_mla = kv_cache.unsqueeze(1)
+
+        # Indices for MLA
+        indices_for_mla = sparse_indices.unsqueeze(1)
+
+        # Handle head padding for FlashMLA
+        device_sm_major = torch.cuda.get_device_properties(device).major
+        required_padding = 128 if device_sm_major >= 10 else 64
+
+        need_padding = NUM_QO_HEADS % required_padding != 0
+        if need_padding:
+            q_padded = q_all.new_zeros((batch_size, required_padding, head_dim))
+            q_padded[:, :NUM_QO_HEADS, :] = q_all
+            q_input = q_padded
+        else:
+            q_input = q_all
+
+        fi_output_full, fi_max_logits, fi_lse_full = flash_mla_sparse_fwd(
+            q=q_input,
+            kv=kv_for_mla,
+            indices=indices_for_mla,
+            sm_scale=float(sm_scale),
+            d_v=HEAD_DIM_CKV,
+        )
+
+        if need_padding:
+            fi_output = fi_output_full[:, :NUM_QO_HEADS, :]
+            fi_lse = fi_lse_full[:, :NUM_QO_HEADS]
+        else:
+            fi_output = fi_output_full
+            fi_lse = fi_lse_full
+
+        return {"output": fi_output, "lse": fi_lse}
+
+
+@pytest.mark.skipif(not SGLANG_AVAILABLE, reason="SGLang sgl_kernel not available")
+class TestNSASparsePrefill(DefinitionTest):
+    """Test NSA sparse prefill with SGLang as baseline."""
+
+    definition_path = (
+        "definitions/nsa_paged/nsa_sparse_prefill_causal_h16_ckv512_kpe64_topk256_ps1.json"
+    )
+    configs = [{"total_num_tokens": 32}, {"total_num_tokens": 64}, {"total_num_tokens": 128}]
+    atol = 1e-2
+    rtol = 5e-2
+    comparator = MultiOutputComparator(
+        output_names=["output", "lse"],
+        comparators={
+            "output": HitRatioComparator(atol=1e-1, rtol=2e-1, min_hit_ratio=0.85),
+            "lse": HitRatioComparator(atol=1e-1, rtol=2e-1, min_hit_ratio=0.85),
+        },
+    )
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_nsa_prefill_inputs(total_num_tokens=config["total_num_tokens"])
+
+    def baseline_fn(self, q_nope, q_pe, ckv_cache, kpe_cache, sparse_indices, sm_scale):
+        """SGLang FlashMLA baseline implementation."""
+        total_num_tokens = q_nope.shape[0]
+        device = q_nope.device
+        head_dim = HEAD_DIM_CKV + HEAD_DIM_KPE
+
+        # Combine q for FlashMLA
+        q_all = torch.cat([q_nope, q_pe], dim=-1)
+
+        # KV cache (combined)
+        kv_cache = torch.cat([ckv_cache.squeeze(1), kpe_cache.squeeze(1)], dim=-1)
+        kv_for_mla = kv_cache.unsqueeze(1)
+
+        # Indices for MLA
+        indices_for_mla = sparse_indices.unsqueeze(1)
+
+        # Handle head padding for FlashMLA
+        device_sm_major = torch.cuda.get_device_properties(device).major
+        required_padding = 128 if device_sm_major >= 10 else 64
+
+        need_padding = NUM_QO_HEADS % required_padding != 0
+        if need_padding:
+            q_padded = q_all.new_zeros((total_num_tokens, required_padding, head_dim))
+            q_padded[:, :NUM_QO_HEADS, :] = q_all
+            q_input = q_padded
+        else:
+            q_input = q_all
+
+        fi_output_full, fi_max_logits, fi_lse_full = flash_mla_sparse_fwd(
+            q=q_input,
+            kv=kv_for_mla,
+            indices=indices_for_mla,
+            sm_scale=float(sm_scale),
+            d_v=HEAD_DIM_CKV,
+        )
+
+        if need_padding:
+            fi_output = fi_output_full[:, :NUM_QO_HEADS, :]
+            fi_lse = fi_lse_full[:, :NUM_QO_HEADS]
+        else:
+            fi_output = fi_output_full
+            fi_lse = fi_lse_full
+
+        return {"output": fi_output, "lse": fi_lse}
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/definitions/test_rmsnorm.py
+++ b/flashinfer_trace/tests/definitions/test_rmsnorm.py
@@ -1,0 +1,105 @@
+"""Tests for RMSNorm definitions."""
+
+import sys
+
+import flashinfer
+import pytest
+import torch
+
+from flashinfer_bench.testing import DefinitionTest
+
+
+def generate_rmsnorm_inputs(batch_size: int, hidden_size: int, device: str = "cuda"):
+    """Generate random inputs for RMSNorm testing.
+
+    Note: Parameter names must match the Definition's inputs spec.
+    For rmsnorm_h128.json, this is 'hidden_states' and 'weight'.
+    """
+    hidden_states = torch.randn(batch_size, hidden_size, dtype=torch.bfloat16, device=device)
+    weight = torch.randn(hidden_size, dtype=torch.bfloat16, device=device)
+
+    return {"hidden_states": hidden_states, "weight": weight}
+
+
+class TestRMSNormH128(DefinitionTest):
+    """Test RMSNorm with hidden_size=128."""
+
+    # Relative path to FIB_DATASET_PATH
+    definition_path = "definitions/rmsnorm/rmsnorm_h128.json"
+    configs = [
+        {"batch_size": 1},
+        {"batch_size": 4},
+        {"batch_size": 8},
+        {"batch_size": 16},
+        {"batch_size": 32},
+    ]
+    atol = 8e-3
+    rtol = 1e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_rmsnorm_inputs(batch_size=config["batch_size"], hidden_size=128)
+
+    def baseline_fn(self, hidden_states, weight):
+        """FlashInfer baseline implementation.
+
+        Note: Interface must match the Definition's run() function signature.
+        """
+        # eps is hardcoded in the definition as 1e-6
+        return flashinfer.norm.rmsnorm(hidden_states.contiguous(), weight.contiguous(), eps=1e-6)
+
+
+class TestRMSNormH2048(DefinitionTest):
+    """Test RMSNorm with hidden_size=2048."""
+
+    # Relative path to FIB_DATASET_PATH
+    definition_path = "definitions/rmsnorm/rmsnorm_h2048.json"
+    configs = [{"batch_size": 1}, {"batch_size": 4}, {"batch_size": 8}]
+    atol = 8e-3
+    rtol = 1e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_rmsnorm_inputs(batch_size=config["batch_size"], hidden_size=2048)
+
+    def baseline_fn(self, hidden_states, weight):
+        """FlashInfer baseline implementation."""
+        return flashinfer.norm.rmsnorm(hidden_states.contiguous(), weight.contiguous(), eps=1e-6)
+
+
+class TestRMSNormH4096(DefinitionTest):
+    """Test RMSNorm with hidden_size=4096."""
+
+    definition_path = "definitions/rmsnorm/rmsnorm_h4096.json"
+    configs = [{"batch_size": 1}, {"batch_size": 4}, {"batch_size": 8}]
+    atol = 8e-3
+    rtol = 1e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_rmsnorm_inputs(batch_size=config["batch_size"], hidden_size=4096)
+
+    def baseline_fn(self, hidden_states, weight):
+        """FlashInfer baseline implementation."""
+        return flashinfer.norm.rmsnorm(hidden_states.contiguous(), weight.contiguous(), eps=1e-6)
+
+
+class TestRMSNormH7168(DefinitionTest):
+    """Test RMSNorm with hidden_size=7168."""
+
+    definition_path = "definitions/rmsnorm/rmsnorm_h7168.json"
+    configs = [{"batch_size": 1}, {"batch_size": 4}, {"batch_size": 8}]
+    atol = 8e-3
+    rtol = 1e-2
+
+    @staticmethod
+    def input_generator(**config):
+        return generate_rmsnorm_inputs(batch_size=config["batch_size"], hidden_size=7168)
+
+    def baseline_fn(self, hidden_states, weight):
+        """FlashInfer baseline implementation."""
+        return flashinfer.norm.rmsnorm(hidden_states.contiguous(), weight.contiguous(), eps=1e-6)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/definitions/test_sampling.py
+++ b/flashinfer_trace/tests/definitions/test_sampling.py
@@ -1,0 +1,157 @@
+"""Tests for sampling definitions.
+
+Note: Sampling tests use frequency-based comparison over many trials instead of
+direct output comparison. This requires a custom test approach.
+"""
+
+import sys
+
+import flashinfer
+import pytest
+import torch
+
+from flashinfer_bench.testing.pytest_config import requires_torch_cuda
+
+
+def generate_sampling_inputs(batch_size: int, vocab_size: int, device: str = "cuda"):
+    """Generate peaked probability distribution for testing."""
+    # Create peaked distribution (some tokens have much higher probability)
+    logits = torch.randn(batch_size, vocab_size, device=device) * 0.1
+    peak_indices = torch.randint(0, vocab_size, (batch_size,), device=device)
+    for i in range(batch_size):
+        logits[i, peak_indices[i]] += 5.0
+    probs = torch.softmax(logits, dim=-1).to(torch.float32)
+    return probs
+
+
+class TestTopPSampling:
+    """Test top-p sampling from probabilities."""
+
+    @requires_torch_cuda
+    @pytest.mark.parametrize(
+        "batch_size,vocab_size",
+        [(2, 128256), (4, 129280), (8, 151936)],
+        ids=["v128256", "v129280", "v151936"],
+    )
+    def test_frequency_comparison(self, batch_size: int, vocab_size: int, num_trials: int = 5000):
+        """Test that sampling frequency matches between reference and FlashInfer."""
+        device = "cuda"
+        torch.manual_seed(42)
+
+        probs = generate_sampling_inputs(batch_size, vocab_size, device)
+        top_p = torch.rand(batch_size, device=device) * 0.8 + 0.1
+
+        fi_counter = torch.zeros(batch_size, vocab_size, dtype=torch.int32, device=device)
+
+        for trial in range(num_trials):
+            torch.manual_seed(42 + trial)
+            # FlashInfer implementation
+            fi_samples = flashinfer.sampling.top_p_sampling_from_probs(probs, top_p)
+            for i in range(batch_size):
+                fi_counter[i, fi_samples[i]] += 1
+
+        # Calculate frequencies and cosine similarity
+        fi_freq = fi_counter.float() / num_trials
+
+        # We compare FlashInfer against itself (sanity check) since reference
+        # would need to match the exact same random number sequence
+        # The key test is that sampling produces valid distributions
+        for i in range(batch_size):
+            mask = fi_freq[i] > 0
+            assert mask.sum() > 0, f"No tokens sampled for batch {i}"
+
+        # Verify samples are within top-p filtered tokens
+        for i in range(batch_size):
+            p = top_p[i].item()
+            sorted_probs, sorted_indices = torch.sort(probs[i], descending=True)
+            cumsum = torch.cumsum(sorted_probs, dim=0)
+            cutoff_idx = (cumsum > p).nonzero(as_tuple=True)[0]
+            if len(cutoff_idx) > 0:
+                valid_tokens = sorted_indices[: cutoff_idx[0].item() + 1]
+                sampled_tokens = fi_freq[i].nonzero(as_tuple=True)[0]
+                # Most sampled tokens should be in valid set
+                overlap = torch.isin(sampled_tokens, valid_tokens).float().mean()
+                assert overlap > 0.95, f"Too many samples outside top-p set: {overlap:.2%}"
+
+
+class TestTopKSampling:
+    """Test top-k sampling from probabilities."""
+
+    @requires_torch_cuda
+    @pytest.mark.parametrize(
+        "batch_size,vocab_size",
+        [(2, 128256), (4, 129280), (8, 151936)],
+        ids=["v128256", "v129280", "v151936"],
+    )
+    def test_frequency_comparison(self, batch_size: int, vocab_size: int, num_trials: int = 5000):
+        """Test that sampling produces valid distributions."""
+        device = "cuda"
+        torch.manual_seed(42)
+
+        probs = generate_sampling_inputs(batch_size, vocab_size, device)
+        top_k = torch.randint(
+            10, min(500, vocab_size // 2), (batch_size,), dtype=torch.int32, device=device
+        )
+
+        fi_counter = torch.zeros(batch_size, vocab_size, dtype=torch.int32, device=device)
+
+        for trial in range(num_trials):
+            torch.manual_seed(42 + trial)
+            fi_samples = flashinfer.sampling.top_k_sampling_from_probs(probs, top_k)
+            for i in range(batch_size):
+                fi_counter[i, fi_samples[i]] += 1
+
+        fi_freq = fi_counter.float() / num_trials
+
+        # Verify samples are within top-k tokens
+        for i in range(batch_size):
+            k = top_k[i].item()
+            _, top_k_indices = torch.topk(probs[i], k)
+            sampled_tokens = fi_freq[i].nonzero(as_tuple=True)[0]
+            overlap = torch.isin(sampled_tokens, top_k_indices).float().mean()
+            assert overlap > 0.95, f"Too many samples outside top-k set: {overlap:.2%}"
+
+
+class TestTopKTopPSampling:
+    """Test combined top-k top-p sampling from probabilities."""
+
+    @requires_torch_cuda
+    @pytest.mark.parametrize(
+        "batch_size,vocab_size",
+        [(2, 128256), (4, 129280), (8, 151936)],
+        ids=["v128256", "v129280", "v151936"],
+    )
+    def test_frequency_comparison(self, batch_size: int, vocab_size: int, num_trials: int = 5000):
+        """Test that sampling produces valid distributions."""
+        device = "cuda"
+        torch.manual_seed(42)
+
+        probs = generate_sampling_inputs(batch_size, vocab_size, device)
+        top_k = torch.randint(
+            10, min(500, vocab_size // 2), (batch_size,), dtype=torch.int32, device=device
+        )
+        top_p = torch.rand(batch_size, device=device) * 0.8 + 0.1
+
+        fi_counter = torch.zeros(batch_size, vocab_size, dtype=torch.int32, device=device)
+
+        for trial in range(num_trials):
+            torch.manual_seed(42 + trial)
+            fi_samples = flashinfer.sampling.top_k_top_p_sampling_from_probs(
+                probs, top_k, top_p, filter_apply_order="top_k_first"
+            )
+            for i in range(batch_size):
+                fi_counter[i, fi_samples[i]] += 1
+
+        fi_freq = fi_counter.float() / num_trials
+
+        # Verify samples are within top-k tokens (top-k is applied first)
+        for i in range(batch_size):
+            k = top_k[i].item()
+            _, top_k_indices = torch.topk(probs[i], k)
+            sampled_tokens = fi_freq[i].nonzero(as_tuple=True)[0]
+            overlap = torch.isin(sampled_tokens, top_k_indices).float().mean()
+            assert overlap > 0.95, f"Too many samples outside top-k set: {overlap:.2%}"
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)

--- a/flashinfer_trace/tests/references/test_gqa_paged_decode_h32_kv4_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_decode_h32_kv4_d128_ps1.py
@@ -222,7 +222,7 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")
@@ -245,7 +245,7 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
     lse_mean_abs_diff = lse_abs_diff.mean().item()
     lse_mean_rel_diff = lse_rel_diff.mean().item()
 
-    print(f"\nLSE comparison:")
+    print("\nLSE comparison:")
     print(f"Max absolute difference: {lse_max_abs_diff:.6e}")
     print(f"Max relative difference: {lse_max_rel_diff:.6e}")
     print(f"Mean absolute difference: {lse_mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_gqa_paged_decode_h32_kv8_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_decode_h32_kv8_d128_ps1.py
@@ -222,7 +222,7 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")
@@ -245,7 +245,7 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
     lse_mean_abs_diff = lse_abs_diff.mean().item()
     lse_mean_rel_diff = lse_rel_diff.mean().item()
 
-    print(f"\nLSE comparison:")
+    print("\nLSE comparison:")
     print(f"Max absolute difference: {lse_max_abs_diff:.6e}")
     print(f"Max relative difference: {lse_max_rel_diff:.6e}")
     print(f"Mean absolute difference: {lse_mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_gqa_paged_prefill_h32_kv4_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_prefill_h32_kv4_d128_ps1.py
@@ -283,7 +283,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")
@@ -306,7 +306,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     lse_mean_abs_diff = lse_abs_diff.mean().item()
     lse_mean_rel_diff = lse_rel_diff.mean().item()
 
-    print(f"\nLSE comparison:")
+    print("\nLSE comparison:")
     print(f"Max absolute difference: {lse_max_abs_diff:.6e}")
     print(f"Max relative difference: {lse_max_rel_diff:.6e}")
     print(f"Mean absolute difference: {lse_mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_gqa_paged_prefill_h32_kv8_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_prefill_h32_kv8_d128_ps1.py
@@ -283,7 +283,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")
@@ -306,7 +306,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     lse_mean_abs_diff = lse_abs_diff.mean().item()
     lse_mean_rel_diff = lse_rel_diff.mean().item()
 
-    print(f"\nLSE comparison:")
+    print("\nLSE comparison:")
     print(f"Max absolute difference: {lse_max_abs_diff:.6e}")
     print(f"Max relative difference: {lse_max_rel_diff:.6e}")
     print(f"Mean absolute difference: {lse_mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_gqa_ragged_prefill_h32_kv4_d128.py
+++ b/flashinfer_trace/tests/references/test_gqa_ragged_prefill_h32_kv4_d128.py
@@ -224,7 +224,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")
@@ -247,7 +247,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     lse_mean_abs_diff = lse_abs_diff.mean().item()
     lse_mean_rel_diff = lse_rel_diff.mean().item()
 
-    print(f"\nLSE comparison:")
+    print("\nLSE comparison:")
     print(f"Max absolute difference: {lse_max_abs_diff:.6e}")
     print(f"Max relative difference: {lse_max_rel_diff:.6e}")
     print(f"Mean absolute difference: {lse_mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_gqa_ragged_prefill_h32_kv8_d128.py
+++ b/flashinfer_trace/tests/references/test_gqa_ragged_prefill_h32_kv8_d128.py
@@ -224,7 +224,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")
@@ -247,7 +247,7 @@ def test_correctness(batch_size=4, max_q_len=32, max_kv_len=64, causal=True, ato
     lse_mean_abs_diff = lse_abs_diff.mean().item()
     lse_mean_rel_diff = lse_rel_diff.mean().item()
 
-    print(f"\nLSE comparison:")
+    print("\nLSE comparison:")
     print(f"Max absolute difference: {lse_max_abs_diff:.6e}")
     print(f"Max relative difference: {lse_max_rel_diff:.6e}")
     print(f"Mean absolute difference: {lse_mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_mla_paged_decode_h16_ckv512_kpe64_ps1.py
+++ b/flashinfer_trace/tests/references/test_mla_paged_decode_h16_ckv512_kpe64_ps1.py
@@ -217,7 +217,7 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")
@@ -240,7 +240,7 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
     lse_mean_abs_diff = lse_abs_diff.mean().item()
     lse_mean_rel_diff = lse_rel_diff.mean().item()
 
-    print(f"\nLSE comparison:")
+    print("\nLSE comparison:")
     print(f"Max absolute difference: {lse_max_abs_diff:.6e}")
     print(f"Max relative difference: {lse_max_rel_diff:.6e}")
     print(f"Mean absolute difference: {lse_mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_moe_fp8_block_scale_ds_routing_topk8_ng8_kg4_e32_h7168_i2048.py
+++ b/flashinfer_trace/tests/references/test_moe_fp8_block_scale_ds_routing_topk8_ng8_kg4_e32_h7168_i2048.py
@@ -159,7 +159,6 @@ def run(
             continue
 
         token_idx = torch.nonzero(sel_mask_per_token, as_tuple=False).squeeze(1)  # [Tk]
-        Tk = token_idx.numel()
 
         # Gather inputs and weights for this expert
         A_e = A.index_select(0, token_idx)  # [Tk, H]
@@ -297,7 +296,7 @@ def _load_workload_tensors(record: dict, *, device: str):
 
         file_path = Path(spec["path"])
         if not file_path.is_absolute():
-            file_path = REPO_ROOT / file_path
+            file_path = TRACE_ROOT / file_path
 
         if file_path not in tensor_cache:
             tensor_cache[file_path] = load_file(file_path)

--- a/flashinfer_trace/tests/references/test_rmsnorm_h128.py
+++ b/flashinfer_trace/tests/references/test_rmsnorm_h128.py
@@ -120,7 +120,7 @@ def test_correctness(batch_size=8, with_residual=True, atol=8e-3, rtol=1e-2):
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_rmsnorm_h2048.py
+++ b/flashinfer_trace/tests/references/test_rmsnorm_h2048.py
@@ -120,7 +120,7 @@ def test_correctness(batch_size=8, with_residual=True, atol=8e-3, rtol=1e-2):
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_rmsnorm_h4096.py
+++ b/flashinfer_trace/tests/references/test_rmsnorm_h4096.py
@@ -120,7 +120,7 @@ def test_correctness(batch_size=8, with_residual=True, atol=8e-3, rtol=1e-2):
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")

--- a/flashinfer_trace/tests/references/test_rmsnorm_h7168.py
+++ b/flashinfer_trace/tests/references/test_rmsnorm_h7168.py
@@ -120,7 +120,7 @@ def test_correctness(batch_size=8, with_residual=True, atol=8e-3, rtol=1e-2):
     mean_abs_diff = abs_diff.mean().item()
     mean_rel_diff = rel_diff.mean().item()
 
-    print(f"\nOutput tensor comparison:")
+    print("\nOutput tensor comparison:")
     print(f"Max absolute difference: {max_abs_diff:.6e}")
     print(f"Max relative difference: {max_rel_diff:.6e}")
     print(f"Mean absolute difference: {mean_abs_diff:.6e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ profile = "black"
 line_length = 100
 
 [tool.ruff]
-include = ["flashinfer_bench/**/*.py", "tests/**/*.py"]
+include = ["flashinfer_bench/**/*.py", "tests/**/*.py", "flashinfer_trace/**/*.py", "docs/**/*.py"]
 line-length = 100
 target-version = "py310"
 
@@ -85,7 +85,6 @@ ignore = ["C901", "E501", "E741", "F402", "F823", "E731"]
 select = ["C", "E", "F", "W", "TID252"]
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401"]
 "tests/*" = ["E741"]
 "flashinfer_bench/compile/builders/triton_builder.py" = ["F401"]
 
@@ -97,8 +96,7 @@ strict = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
-addopts = "-rA --durations=0 --ignore=3rdparty"
-markers = ["requires_torch_cuda: tests that require torch and CUDA available"]
+addopts = "-rA --durations=0 --ignore=3rdparty --ignore=flashinfer_trace"
 log_cli = true
 log_cli_level = "INFO"
 

--- a/tests/bench/test_benchmark.py
+++ b/tests/bench/test_benchmark.py
@@ -23,9 +23,10 @@ from flashinfer_bench.data import (
     save_json_file,
     save_jsonl_file,
 )
+from flashinfer_bench.testing import requires_torch_cuda
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_run_all_empty_trace_set(tmp_path: Path):
     """Test run_all with completely empty trace set."""
     trace_set = TraceSet(root=str(tmp_path), definitions={}, solutions={}, workloads={}, traces={})
@@ -39,7 +40,7 @@ def test_run_all_empty_trace_set(tmp_path: Path):
     assert len(result.traces) == 0
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_run_all_no_solutions(tmp_path: Path, caplog):
     """Test run_all with definitions but no solutions."""
     # Create definition
@@ -72,7 +73,7 @@ def test_run_all_no_solutions(tmp_path: Path, caplog):
     assert len(result.traces) == 0
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_run_all_no_workloads(tmp_path: Path):
     """Test run_all with definitions and solutions but no workloads."""
     # Create definition
@@ -112,7 +113,7 @@ def test_run_all_no_workloads(tmp_path: Path):
     assert len(result.traces) == 0
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_dump_traces_false(tmp_path: Path):
     """Test run_all with dump_traces=False."""
     trace_set = TraceSet(root=str(tmp_path), definitions={}, solutions={}, workloads={}, traces={})
@@ -178,7 +179,7 @@ def test_isolated_runner_runtime_error(mock_runner_class, tmp_path: Path, caplog
     assert len(result.traces) == 0
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_benchmark_with_mixed_results(tmp_path: Path, tmp_cache_dir: Path):
     """Test benchmark with solutions that have different outcomes."""
     # Build dataset structure

--- a/tests/compile/test_torch_builder.py
+++ b/tests/compile/test_torch_builder.py
@@ -15,6 +15,7 @@ from flashinfer_bench.data import (
     SupportedLanguages,
     TensorSpec,
 )
+from flashinfer_bench.testing import requires_torch_cuda
 
 
 @pytest.fixture(autouse=True)
@@ -146,7 +147,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) { m.def("echo", &echo); }
     assert torch.allclose(out, input_tensors[0])
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_cuda_vector_add():
     """Test building and running a simple CUDA vector add kernel."""
     definition = Definition(
@@ -224,7 +225,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     assert torch.allclose(Z, X + Y)
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_cublas_matmul():
     definition = Definition(
         name="touch_cublas_matmul",

--- a/tests/compile/test_triton_builder.py
+++ b/tests/compile/test_triton_builder.py
@@ -14,6 +14,7 @@ from flashinfer_bench.data import (
     SupportedLanguages,
     TensorSpec,
 )
+from flashinfer_bench.testing import requires_torch_cuda
 
 
 @pytest.fixture(autouse=True)
@@ -21,7 +22,7 @@ def _use_tmp_cache_dir(tmp_cache_dir: Path) -> None:
     """Automatically use tmp_cache_dir for all tests in this module."""
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_is_available(monkeypatch: pytest.MonkeyPatch) -> None:
     # Mock the import to make triton unavailable
     import builtins
@@ -38,7 +39,7 @@ def test_is_available(monkeypatch: pytest.MonkeyPatch) -> None:
     assert not TritonBuilder.is_available()
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_vector_add():
     definition = Definition(
         name="vec_add",

--- a/tests/compile/test_tvm_ffi_builder.py
+++ b/tests/compile/test_tvm_ffi_builder.py
@@ -17,6 +17,7 @@ from flashinfer_bench.data import (
     SupportedLanguages,
     TensorSpec,
 )
+from flashinfer_bench.testing import requires_torch_cuda
 
 ADD_ONE_DEFINITION = Definition(
     name="add_one",
@@ -125,7 +126,7 @@ def test_cpu_add_one() -> None:
     torch.testing.assert_close(output_tensor, expected, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.requires_torch_cuda
+@requires_torch_cuda
 def test_cuda_add_one() -> None:
     """Test building and running a simple CUDA kernel."""
     solution = Solution(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,6 @@
 from pathlib import Path
-from typing import List
 
 import pytest
-
-
-def _torch_cuda_available() -> bool:
-    """Check if CUDA is available from PyTorch.
-
-    Returns
-    -------
-    bool
-        True if CUDA is available from PyTorch, False otherwise.
-    """
-    try:
-        import torch
-
-        return torch.cuda.is_available()
-    except ImportError:
-        return False
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: List[pytest.Item]) -> None:
-    """Modify pytest collection to skip tests that require CUDA when CUDA is not available."""
-    if _torch_cuda_available():
-        return
-
-    skip_cuda = pytest.mark.skip(reason="CUDA not available from PyTorch, skip test")
-    for item in items:
-        if any(item.iter_markers(name="requires_torch_cuda")):
-            item.add_marker(skip_cuda)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR provides a framework for dataset validation, especially definition schema and reference correctness.

This PR retires tests in flashinfer_trace/tests/references. Later submission should write tests in flashinfer_trace/tests/definitions instead.

cc @yyihuang this can further simplify your definition submission workflow. It should not be very hard to convert the old tests with genai.

Signed-off-by: Ubospica <ubospica@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Comprehensive testing framework added for validating reference vs baseline outputs (single/multi-output, hit-ratio), plus a CUDA-aware test marker.
  * Large suite of new definition-based tests covering attention variants, MoE FP8, RMSNorm, sampling, and sparse/MLA workflows.

* **Chores**
  * Linting and pre-commit tooling updated to include additional code paths.

* **Documentation**
  * README updated with instructions for running the test suite locally.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->