### PR TITLE
fix: Error in Sphinx Docs Build

### DIFF
--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -1,4 +1,5 @@
 autodoc_pydantic>=2.1,<3
+docstring-parser>=0.16
 myst-parser[linkify]>=4,<5
 setuptools-scm>=8
 shibuya


### PR DESCRIPTION
This PR adds the `docstring_parser` dependency to fix the error in sphinx docs build.

Signed-off-by: Ubospica <ubospica@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation tooling dependencies to enhance docstring parsing capabilities for API documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->