### PR TITLE
feat: add GEMM definitions and reference tests (Qwen3.5-35B-A3B)

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -31,6 +31,7 @@ This document tracks which kernels are supported in FlashInfer-Bench for each mo
 | Qwen3 32B | GQA + Dense | 🟡 Partial |
 | Qwen3 235B A22B | GQA + MoE | 🟡 Partial |
 | Qwen3 Next 80B A3B | GDN + GQA + MoE | 🟡 Partial |
+| Qwen3.5 35B A3B | GDN + GQA + MoE | 🟡 Partial |
 | Kimi K2 | MLA + MoE | 🟡 Partial |
 | Phi-4 14B | GQA + Dense | 🟡 Partial |
 | Llama 3.1 405B | GQA + Dense | 🟡 Partial |
@@ -170,6 +171,35 @@ DSA introduces a learned TopK indexer that selects a sparse subset of KV pages b
 Missing GDN definitions: TP=1 prefill and decode (qk16_v32). Missing GQA: h=8, kv=1, d=256 (TP=2 of original h=16, kv=2, d=256).
 
 ---
+
+## Qwen3.5 35B A3B
+
+**Architecture**: 28 layers total — 20 GDN (linear attention) + 8 GQA (standard attention), all layers use MoE FFN. Standard serving configuration: **TP=2**. Shares GDN/GQA architecture with Qwen3 Next 80B A3B but at smaller scale (hidden=2048, head_dim=256 for GQA, head_dim=128 for GDN).
+
+| Definition | Op Type | Status |
+|-----------|---------|:------:|
+| `gdn_decode_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
+| `gdn_prefill_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
+| `gdn_mtp_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
+| `gemm_n16_k2048` | gemm | ✅ |
+| `gemm_n256_k2048` | gemm | ❌ |
+| `gemm_n512_k2048` | gemm | ❌ |
+| `gemm_n2048_k256` | gemm | ❌ |
+| `gemm_n2048_k2048` | gemm | ❌ |
+| `gemm_n4096_k2048` | gemm | ❌ |
+| `gemm_n4608_k2048` | gemm | ❌ |
+| `gqa_paged_decode_h8_kv1_d256_ps1` | gqa_paged TP=2 | ❌ |
+| `gqa_paged_prefill_causal_h8_kv1_d256_ps1` | gqa_paged TP=2 | ❌ |
+| `moe_bf16_topk8_e256_h2048_i256` | moe | ❌ |
+| `gemma_fused_add_rmsnorm_h2048` | rmsnorm | ❌ |
+| `gemma_rmsnorm_h2048` | rmsnorm | ❌ |
+| `gemma_rmsnorm_h256` | rmsnorm | ❌ |
+| `top_k_top_p_sampling_from_probs_v248320` | sampling | ❌ |
+
+**Coverage**: 1 / 17 definitions present.
+
+---
+
 
 ## Llama 3.1 / 3.3 70B
 

--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -182,12 +182,12 @@ Missing GDN definitions: TP=1 prefill and decode (qk16_v32). Missing GQA: h=8, k
 | `gdn_prefill_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
 | `gdn_mtp_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
 | `gemm_n16_k2048` | gemm | ✅ |
-| `gemm_n256_k2048` | gemm | ❌ |
-| `gemm_n512_k2048` | gemm | ❌ |
-| `gemm_n2048_k256` | gemm | ❌ |
-| `gemm_n2048_k2048` | gemm | ❌ |
-| `gemm_n4096_k2048` | gemm | ❌ |
-| `gemm_n4608_k2048` | gemm | ❌ |
+| `gemm_n256_k2048` | gemm | ✅ |
+| `gemm_n512_k2048` | gemm | ✅ |
+| `gemm_n2048_k256` | gemm | ✅ |
+| `gemm_n2048_k2048` | gemm | ✅ |
+| `gemm_n4096_k2048` | gemm | ✅ |
+| `gemm_n4608_k2048` | gemm | ✅ |
 | `gqa_paged_decode_h8_kv1_d256_ps1` | gqa_paged TP=2 | ❌ |
 | `gqa_paged_prefill_causal_h8_kv1_d256_ps1` | gqa_paged TP=2 | ❌ |
 | `moe_bf16_topk8_e256_h2048_i256` | moe | ❌ |
@@ -196,7 +196,7 @@ Missing GDN definitions: TP=1 prefill and decode (qk16_v32). Missing GQA: h=8, k
 | `gemma_rmsnorm_h256` | rmsnorm | ❌ |
 | `top_k_top_p_sampling_from_probs_v248320` | sampling | ❌ |
 
-**Coverage**: 1 / 17 definitions present.
+**Coverage**: 7 / 17 definitions present.
 
 ---
 

--- a/flashinfer_trace/definitions/gemm/gemm_n16_k2048.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n16_k2048.json
@@ -1,0 +1,49 @@
+{
+    "op_type": "gemm",
+    "tags": [
+        "model:qwen3.5-35b-a3b",
+        "status:reference",
+        "tp:2"
+    ],
+    "inputs": {
+        "A": {
+            "shape": [
+                "M",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        },
+        "B": {
+            "shape": [
+                "N",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "outputs": {
+        "C": {
+            "shape": [
+                "M",
+                "N"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C",
+    "name": "gemm_n16_k2048",
+    "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Qwen3.5-35B-A3B at TP=2. N=16, K=2048.",
+    "axes": {
+        "M": {
+            "type": "var"
+        },
+        "N": {
+            "type": "const",
+            "value": 16
+        },
+        "K": {
+            "type": "const",
+            "value": 2048
+        }
+    }
+}

--- a/flashinfer_trace/definitions/gemm/gemm_n2048_k2048.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n2048_k2048.json
@@ -1,0 +1,49 @@
+{
+    "op_type": "gemm",
+    "tags": [
+        "model:qwen3.5-35b-a3b",
+        "status:reference",
+        "tp:2"
+    ],
+    "inputs": {
+        "A": {
+            "shape": [
+                "M",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        },
+        "B": {
+            "shape": [
+                "N",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "outputs": {
+        "C": {
+            "shape": [
+                "M",
+                "N"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C",
+    "name": "gemm_n2048_k2048",
+    "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Qwen3.5-35B-A3B at TP=2. N=2048, K=2048.",
+    "axes": {
+        "M": {
+            "type": "var"
+        },
+        "N": {
+            "type": "const",
+            "value": 2048
+        },
+        "K": {
+            "type": "const",
+            "value": 2048
+        }
+    }
+}

--- a/flashinfer_trace/definitions/gemm/gemm_n2048_k256.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n2048_k256.json
@@ -1,0 +1,49 @@
+{
+    "op_type": "gemm",
+    "tags": [
+        "model:qwen3.5-35b-a3b",
+        "status:reference",
+        "tp:2"
+    ],
+    "inputs": {
+        "A": {
+            "shape": [
+                "M",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        },
+        "B": {
+            "shape": [
+                "N",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "outputs": {
+        "C": {
+            "shape": [
+                "M",
+                "N"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C",
+    "name": "gemm_n2048_k256",
+    "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Qwen3.5-35B-A3B at TP=2. N=2048, K=256.",
+    "axes": {
+        "M": {
+            "type": "var"
+        },
+        "N": {
+            "type": "const",
+            "value": 2048
+        },
+        "K": {
+            "type": "const",
+            "value": 256
+        }
+    }
+}

--- a/flashinfer_trace/definitions/gemm/gemm_n256_k2048.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n256_k2048.json
@@ -1,0 +1,49 @@
+{
+    "op_type": "gemm",
+    "tags": [
+        "model:qwen3.5-35b-a3b",
+        "status:reference",
+        "tp:2"
+    ],
+    "inputs": {
+        "A": {
+            "shape": [
+                "M",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        },
+        "B": {
+            "shape": [
+                "N",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "outputs": {
+        "C": {
+            "shape": [
+                "M",
+                "N"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C",
+    "name": "gemm_n256_k2048",
+    "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Qwen3.5-35B-A3B at TP=2. N=256, K=2048.",
+    "axes": {
+        "M": {
+            "type": "var"
+        },
+        "N": {
+            "type": "const",
+            "value": 256
+        },
+        "K": {
+            "type": "const",
+            "value": 2048
+        }
+    }
+}

--- a/flashinfer_trace/definitions/gemm/gemm_n4096_k2048.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n4096_k2048.json
@@ -1,0 +1,49 @@
+{
+    "op_type": "gemm",
+    "tags": [
+        "model:qwen3.5-35b-a3b",
+        "status:reference",
+        "tp:2"
+    ],
+    "inputs": {
+        "A": {
+            "shape": [
+                "M",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        },
+        "B": {
+            "shape": [
+                "N",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "outputs": {
+        "C": {
+            "shape": [
+                "M",
+                "N"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C",
+    "name": "gemm_n4096_k2048",
+    "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Qwen3.5-35B-A3B at TP=2. N=4096, K=2048.",
+    "axes": {
+        "M": {
+            "type": "var"
+        },
+        "N": {
+            "type": "const",
+            "value": 4096
+        },
+        "K": {
+            "type": "const",
+            "value": 2048
+        }
+    }
+}

--- a/flashinfer_trace/definitions/gemm/gemm_n4608_k2048.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n4608_k2048.json
@@ -1,0 +1,49 @@
+{
+    "op_type": "gemm",
+    "tags": [
+        "model:qwen3.5-35b-a3b",
+        "status:reference",
+        "tp:2"
+    ],
+    "inputs": {
+        "A": {
+            "shape": [
+                "M",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        },
+        "B": {
+            "shape": [
+                "N",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "outputs": {
+        "C": {
+            "shape": [
+                "M",
+                "N"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C",
+    "name": "gemm_n4608_k2048",
+    "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Qwen3.5-35B-A3B at TP=2. N=4608, K=2048.",
+    "axes": {
+        "M": {
+            "type": "var"
+        },
+        "N": {
+            "type": "const",
+            "value": 4608
+        },
+        "K": {
+            "type": "const",
+            "value": 2048
+        }
+    }
+}

--- a/flashinfer_trace/definitions/gemm/gemm_n512_k2048.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n512_k2048.json
@@ -1,0 +1,49 @@
+{
+    "op_type": "gemm",
+    "tags": [
+        "model:qwen3.5-35b-a3b",
+        "status:reference",
+        "tp:2"
+    ],
+    "inputs": {
+        "A": {
+            "shape": [
+                "M",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        },
+        "B": {
+            "shape": [
+                "N",
+                "K"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "outputs": {
+        "C": {
+            "shape": [
+                "M",
+                "N"
+            ],
+            "dtype": "bfloat16"
+        }
+    },
+    "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C",
+    "name": "gemm_n512_k2048",
+    "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Qwen3.5-35B-A3B at TP=2. N=512, K=2048.",
+    "axes": {
+        "M": {
+            "type": "var"
+        },
+        "N": {
+            "type": "const",
+            "value": 512
+        },
+        "K": {
+            "type": "const",
+            "value": 2048
+        }
+    }
+}

--- a/flashinfer_trace/tests/references/test_gemm_n16_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n16_k2048.py
@@ -61,8 +61,8 @@ def main():
 
     for M in test_configs:
         try:
-            if test_correctness(M):
-                passed += 1
+            test_correctness(M)
+            passed += 1
         except Exception as e:
             print(f"✗ Test failed with exception: {e}")
             import traceback

--- a/flashinfer_trace/tests/references/test_gemm_n16_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n16_k2048.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 
@@ -24,8 +25,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cpu":
-        print("WARNING: CUDA not available, skipping test")
-        return True
+        pytest.skip("CUDA not available")
 
     inputs = generate_random_inputs(M, device=device)
 
@@ -49,7 +49,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
         print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
     else:
         print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
-    return close
+    assert close, f"Outputs differ beyond tolerance (atol={atol}, rtol={rtol})"
 
 
 def main():

--- a/flashinfer_trace/tests/references/test_gemm_n16_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n16_k2048.py
@@ -1,0 +1,77 @@
+import torch
+
+
+def run(A, B):
+    M, K = A.shape
+    N, K2 = B.shape
+    assert K == K2
+    assert N == 16
+    assert K == 2048
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, N=16, K=2048, device="cuda"):
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=32, atol=1e-2, rtol=1e-2):
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=16, K=2048, M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return True
+
+    inputs = generate_random_inputs(M, device=device)
+
+    # Reference
+    ref_C = run(inputs["A"], inputs["B"])
+
+    # Direct torch comparison (fp32)
+    A_f32 = inputs["A"].float()
+    B_f32 = inputs["B"].float()
+    expected = torch.matmul(A_f32, B_f32.T).to(torch.bfloat16)
+
+    abs_diff = torch.abs(ref_C.float() - expected.float())
+    max_abs_diff = abs_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+
+    print(f"Max absolute difference: {max_abs_diff:.6e}")
+    print(f"Mean absolute difference: {mean_abs_diff:.6e}")
+
+    close = torch.allclose(ref_C.float(), expected.float(), atol=atol, rtol=rtol)
+    if close:
+        print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
+    return close
+
+
+def main():
+    print("Testing GEMM N=16, K=2048 Reference Implementation")
+
+    test_configs = [1, 4, 16, 64, 256]
+    passed = 0
+    total = len(test_configs)
+
+    for M in test_configs:
+        try:
+            if test_correctness(M):
+                passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gemm_n2048_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n2048_k2048.py
@@ -1,0 +1,75 @@
+import torch
+
+
+def run(A, B):
+    M, K = A.shape
+    N, K2 = B.shape
+    assert K == K2
+    assert N == 2048
+    assert K == 2048
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, N=2048, K=2048, device="cuda"):
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=32, atol=1e-2, rtol=1e-2):
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=2048, K=2048, M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return True
+
+    inputs = generate_random_inputs(M, device=device)
+
+    ref_C = run(inputs["A"], inputs["B"])
+
+    A_f32 = inputs["A"].float()
+    B_f32 = inputs["B"].float()
+    expected = torch.matmul(A_f32, B_f32.T).to(torch.bfloat16)
+
+    abs_diff = torch.abs(ref_C.float() - expected.float())
+    max_abs_diff = abs_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+
+    print(f"Max absolute difference: {max_abs_diff:.6e}")
+    print(f"Mean absolute difference: {mean_abs_diff:.6e}")
+
+    close = torch.allclose(ref_C.float(), expected.float(), atol=atol, rtol=rtol)
+    if close:
+        print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
+    return close
+
+
+def main():
+    print("Testing GEMM N=2048, K=2048 Reference Implementation")
+
+    test_configs = [1, 4, 16, 64, 256]
+    passed = 0
+    total = len(test_configs)
+
+    for M in test_configs:
+        try:
+            if test_correctness(M):
+                passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gemm_n2048_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n2048_k2048.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 
@@ -24,8 +25,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cpu":
-        print("WARNING: CUDA not available, skipping test")
-        return True
+        pytest.skip("CUDA not available")
 
     inputs = generate_random_inputs(M, device=device)
 
@@ -47,7 +47,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
         print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
     else:
         print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
-    return close
+    assert close, f"Outputs differ beyond tolerance (atol={atol}, rtol={rtol})"
 
 
 def main():

--- a/flashinfer_trace/tests/references/test_gemm_n2048_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n2048_k2048.py
@@ -59,8 +59,8 @@ def main():
 
     for M in test_configs:
         try:
-            if test_correctness(M):
-                passed += 1
+            test_correctness(M)
+            passed += 1
         except Exception as e:
             print(f"✗ Test failed with exception: {e}")
             import traceback

--- a/flashinfer_trace/tests/references/test_gemm_n2048_k256.py
+++ b/flashinfer_trace/tests/references/test_gemm_n2048_k256.py
@@ -1,0 +1,75 @@
+import torch
+
+
+def run(A, B):
+    M, K = A.shape
+    N, K2 = B.shape
+    assert K == K2
+    assert N == 2048
+    assert K == 256
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, N=2048, K=256, device="cuda"):
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=32, atol=1e-2, rtol=1e-2):
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=2048, K=256, M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return True
+
+    inputs = generate_random_inputs(M, device=device)
+
+    ref_C = run(inputs["A"], inputs["B"])
+
+    A_f32 = inputs["A"].float()
+    B_f32 = inputs["B"].float()
+    expected = torch.matmul(A_f32, B_f32.T).to(torch.bfloat16)
+
+    abs_diff = torch.abs(ref_C.float() - expected.float())
+    max_abs_diff = abs_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+
+    print(f"Max absolute difference: {max_abs_diff:.6e}")
+    print(f"Mean absolute difference: {mean_abs_diff:.6e}")
+
+    close = torch.allclose(ref_C.float(), expected.float(), atol=atol, rtol=rtol)
+    if close:
+        print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
+    return close
+
+
+def main():
+    print("Testing GEMM N=2048, K=256 Reference Implementation")
+
+    test_configs = [1, 4, 16, 64, 256]
+    passed = 0
+    total = len(test_configs)
+
+    for M in test_configs:
+        try:
+            if test_correctness(M):
+                passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gemm_n2048_k256.py
+++ b/flashinfer_trace/tests/references/test_gemm_n2048_k256.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 
@@ -24,8 +25,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cpu":
-        print("WARNING: CUDA not available, skipping test")
-        return True
+        pytest.skip("CUDA not available")
 
     inputs = generate_random_inputs(M, device=device)
 
@@ -47,7 +47,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
         print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
     else:
         print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
-    return close
+    assert close, f"Outputs differ beyond tolerance (atol={atol}, rtol={rtol})"
 
 
 def main():

--- a/flashinfer_trace/tests/references/test_gemm_n2048_k256.py
+++ b/flashinfer_trace/tests/references/test_gemm_n2048_k256.py
@@ -59,8 +59,8 @@ def main():
 
     for M in test_configs:
         try:
-            if test_correctness(M):
-                passed += 1
+            test_correctness(M)
+            passed += 1
         except Exception as e:
             print(f"✗ Test failed with exception: {e}")
             import traceback

--- a/flashinfer_trace/tests/references/test_gemm_n256_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n256_k2048.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 
@@ -24,8 +25,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cpu":
-        print("WARNING: CUDA not available, skipping test")
-        return True
+        pytest.skip("CUDA not available")
 
     inputs = generate_random_inputs(M, device=device)
 
@@ -47,7 +47,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
         print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
     else:
         print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
-    return close
+    assert close, f"Outputs differ beyond tolerance (atol={atol}, rtol={rtol})"
 
 
 def main():

--- a/flashinfer_trace/tests/references/test_gemm_n256_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n256_k2048.py
@@ -59,8 +59,8 @@ def main():
 
     for M in test_configs:
         try:
-            if test_correctness(M):
-                passed += 1
+            test_correctness(M)
+            passed += 1
         except Exception as e:
             print(f"✗ Test failed with exception: {e}")
             import traceback

--- a/flashinfer_trace/tests/references/test_gemm_n256_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n256_k2048.py
@@ -1,0 +1,75 @@
+import torch
+
+
+def run(A, B):
+    M, K = A.shape
+    N, K2 = B.shape
+    assert K == K2
+    assert N == 256
+    assert K == 2048
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, N=256, K=2048, device="cuda"):
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=32, atol=1e-2, rtol=1e-2):
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=256, K=2048, M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return True
+
+    inputs = generate_random_inputs(M, device=device)
+
+    ref_C = run(inputs["A"], inputs["B"])
+
+    A_f32 = inputs["A"].float()
+    B_f32 = inputs["B"].float()
+    expected = torch.matmul(A_f32, B_f32.T).to(torch.bfloat16)
+
+    abs_diff = torch.abs(ref_C.float() - expected.float())
+    max_abs_diff = abs_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+
+    print(f"Max absolute difference: {max_abs_diff:.6e}")
+    print(f"Mean absolute difference: {mean_abs_diff:.6e}")
+
+    close = torch.allclose(ref_C.float(), expected.float(), atol=atol, rtol=rtol)
+    if close:
+        print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
+    return close
+
+
+def main():
+    print("Testing GEMM N=256, K=2048 Reference Implementation")
+
+    test_configs = [1, 4, 16, 64, 256]
+    passed = 0
+    total = len(test_configs)
+
+    for M in test_configs:
+        try:
+            if test_correctness(M):
+                passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gemm_n4096_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n4096_k2048.py
@@ -1,0 +1,75 @@
+import torch
+
+
+def run(A, B):
+    M, K = A.shape
+    N, K2 = B.shape
+    assert K == K2
+    assert N == 4096
+    assert K == 2048
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, N=4096, K=2048, device="cuda"):
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=32, atol=1e-2, rtol=1e-2):
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=4096, K=2048, M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return True
+
+    inputs = generate_random_inputs(M, device=device)
+
+    ref_C = run(inputs["A"], inputs["B"])
+
+    A_f32 = inputs["A"].float()
+    B_f32 = inputs["B"].float()
+    expected = torch.matmul(A_f32, B_f32.T).to(torch.bfloat16)
+
+    abs_diff = torch.abs(ref_C.float() - expected.float())
+    max_abs_diff = abs_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+
+    print(f"Max absolute difference: {max_abs_diff:.6e}")
+    print(f"Mean absolute difference: {mean_abs_diff:.6e}")
+
+    close = torch.allclose(ref_C.float(), expected.float(), atol=atol, rtol=rtol)
+    if close:
+        print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
+    return close
+
+
+def main():
+    print("Testing GEMM N=4096, K=2048 Reference Implementation")
+
+    test_configs = [1, 4, 16, 64, 256]
+    passed = 0
+    total = len(test_configs)
+
+    for M in test_configs:
+        try:
+            if test_correctness(M):
+                passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gemm_n4096_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n4096_k2048.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 
@@ -24,8 +25,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cpu":
-        print("WARNING: CUDA not available, skipping test")
-        return True
+        pytest.skip("CUDA not available")
 
     inputs = generate_random_inputs(M, device=device)
 
@@ -47,7 +47,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
         print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
     else:
         print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
-    return close
+    assert close, f"Outputs differ beyond tolerance (atol={atol}, rtol={rtol})"
 
 
 def main():

--- a/flashinfer_trace/tests/references/test_gemm_n4096_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n4096_k2048.py
@@ -59,8 +59,8 @@ def main():
 
     for M in test_configs:
         try:
-            if test_correctness(M):
-                passed += 1
+            test_correctness(M)
+            passed += 1
         except Exception as e:
             print(f"✗ Test failed with exception: {e}")
             import traceback

--- a/flashinfer_trace/tests/references/test_gemm_n4608_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n4608_k2048.py
@@ -1,0 +1,75 @@
+import pytest
+import torch
+
+
+def run(A, B):
+    M, K = A.shape
+    N, K2 = B.shape
+    assert K == K2
+    assert N == 4608
+    assert K == 2048
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, N=4608, K=2048, device="cuda"):
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=32, atol=1e-2, rtol=1e-2):
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=4608, K=2048, M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        pytest.skip("CUDA not available")
+
+    inputs = generate_random_inputs(M, device=device)
+
+    ref_C = run(inputs["A"], inputs["B"])
+
+    A_f32 = inputs["A"].float()
+    B_f32 = inputs["B"].float()
+    expected = torch.matmul(A_f32, B_f32.T).to(torch.bfloat16)
+
+    abs_diff = torch.abs(ref_C.float() - expected.float())
+    max_abs_diff = abs_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+
+    print(f"Max absolute difference: {max_abs_diff:.6e}")
+    print(f"Mean absolute difference: {mean_abs_diff:.6e}")
+
+    close = torch.allclose(ref_C.float(), expected.float(), atol=atol, rtol=rtol)
+    if close:
+        print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
+    assert close, f"Outputs differ beyond tolerance (atol={atol}, rtol={rtol})"
+
+
+def main():
+    print("Testing GEMM N=4608, K=2048 Reference Implementation")
+
+    test_configs = [1, 4, 16, 64, 256]
+    passed = 0
+    total = len(test_configs)
+
+    for M in test_configs:
+        try:
+            test_correctness(M)
+            passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gemm_n512_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n512_k2048.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 
 
@@ -24,8 +25,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     if device == "cpu":
-        print("WARNING: CUDA not available, skipping test")
-        return True
+        pytest.skip("CUDA not available")
 
     inputs = generate_random_inputs(M, device=device)
 
@@ -47,7 +47,7 @@ def test_correctness(M=32, atol=1e-2, rtol=1e-2):
         print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
     else:
         print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
-    return close
+    assert close, f"Outputs differ beyond tolerance (atol={atol}, rtol={rtol})"
 
 
 def main():

--- a/flashinfer_trace/tests/references/test_gemm_n512_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n512_k2048.py
@@ -59,8 +59,8 @@ def main():
 
     for M in test_configs:
         try:
-            if test_correctness(M):
-                passed += 1
+            test_correctness(M)
+            passed += 1
         except Exception as e:
             print(f"✗ Test failed with exception: {e}")
             import traceback

--- a/flashinfer_trace/tests/references/test_gemm_n512_k2048.py
+++ b/flashinfer_trace/tests/references/test_gemm_n512_k2048.py
@@ -1,0 +1,75 @@
+import torch
+
+
+def run(A, B):
+    M, K = A.shape
+    N, K2 = B.shape
+    assert K == K2
+    assert N == 512
+    assert K == 2048
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, N=512, K=2048, device="cuda"):
+    A = torch.randn(M, K, dtype=torch.bfloat16, device=device)
+    B = torch.randn(N, K, dtype=torch.bfloat16, device=device)
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=32, atol=1e-2, rtol=1e-2):
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=512, K=2048, M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return True
+
+    inputs = generate_random_inputs(M, device=device)
+
+    ref_C = run(inputs["A"], inputs["B"])
+
+    A_f32 = inputs["A"].float()
+    B_f32 = inputs["B"].float()
+    expected = torch.matmul(A_f32, B_f32.T).to(torch.bfloat16)
+
+    abs_diff = torch.abs(ref_C.float() - expected.float())
+    max_abs_diff = abs_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+
+    print(f"Max absolute difference: {max_abs_diff:.6e}")
+    print(f"Mean absolute difference: {mean_abs_diff:.6e}")
+
+    close = torch.allclose(ref_C.float(), expected.float(), atol=atol, rtol=rtol)
+    if close:
+        print(f"\n✓ PASSED (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED (atol={atol}, rtol={rtol})")
+    return close
+
+
+def main():
+    print("Testing GEMM N=512, K=2048 Reference Implementation")
+
+    test_configs = [1, 4, 16, 64, 256]
+    passed = 0
+    total = len(test_configs)
+
+    for M in test_configs:
+        try:
+            if test_correctness(M):
+                passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {e}")
+            import traceback
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add 7 GEMM definitions for Qwen3.5 35B A3B:

| Definition | Description | HF Workloads |
|---|---|---|
| `gemm_n16_k2048` | GEMM weight matrix (N=16, K=2048) | [#207](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/207) |
| `gemm_n256_k2048` | GEMM weight matrix (N=256, K=2048) | [#210](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/210) |
| `gemm_n512_k2048` | GEMM weight matrix (N=512, K=2048) | [#213](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/213) |
| `gemm_n2048_k256` | GEMM weight matrix (N=2048, K=256) | [#209](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/209) |
| `gemm_n2048_k2048` | GEMM weight matrix (N=2048, K=2048) | [#208](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/208) |
| `gemm_n4096_k2048` | GEMM weight matrix (N=4096, K=2048) | [#211](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/211) |
| `gemm_n4608_k2048` | GEMM weight matrix (N=4608, K=2048) | [#212](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/212) |

## Test plan
- `pytest flashinfer_trace/tests/references/test_gemm_n16_k2048.py -v` — 1/1 passed
- `pytest flashinfer_trace/tests/references/test_gemm_n256_k2048.py -v` — 1/1 passed
- `pytest flashinfer_trace/tests/references/test_gemm_n512_k2048.py -v` — 1/1 passed
- `pytest flashinfer_trace/tests/references/test_gemm_n2048_k256.py -v` — 1/1 passed
- `pytest flashinfer_trace/tests/references/test_gemm_n2048_k2048.py -v` — 1/1 passed
- `pytest flashinfer_trace/tests/references/test_gemm_n4096_k2048.py -v` — 1/1 passed
- `pytest flashinfer_trace/tests/references/test_gemm_n4608_k2048.py -v` — 1/1 passed
- All definition JSONs are valid and load without errors

## HuggingFace Dataset PRs
- [`gemm_n16_k2048`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/207)
- [`gemm_n256_k2048`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/210)
- [`gemm_n512_k2048`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/213)
- [`gemm_n2048_k256`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/209)
- [`gemm_n2048_k2048`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/208)
- [`gemm_n4096_k2048`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/211)
- [`gemm_n4608_k2048`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/212)

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added model coverage page for Qwen3.5-35B-A3B showing operator presence (7/17 present) and missing attention/GDN/GQA-related definitions.

* **New Features**
  * Added multiple new GEMM operator reference definitions for varied matrix sizes.

* **Tests**
  * Added comprehensive reference tests exercising the new GEMM definitions across several fixed and variable dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->