### PR TITLE
feat: add top_k_top_p_sampling_from_probs_v248320 kernel definition and reference test (Qwen3.5-35B-A3B)

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -31,6 +31,7 @@ This document tracks which kernels are supported in FlashInfer-Bench for each mo
 | Qwen3 32B | GQA + Dense | 🟡 Partial |
 | Qwen3 235B A22B | GQA + MoE | 🟡 Partial |
 | Qwen3 Next 80B A3B | GDN + GQA + MoE | 🟡 Partial |
+| Qwen3.5 35B A3B | GDN + GQA + MoE | 🟡 Partial |
 | Kimi K2 | MLA + MoE | 🟡 Partial |
 | Phi-4 14B | GQA + Dense | 🟡 Partial |
 | Llama 3.1 405B | GQA + Dense | 🟡 Partial |
@@ -170,6 +171,35 @@ DSA introduces a learned TopK indexer that selects a sparse subset of KV pages b
 Missing GDN definitions: TP=1 prefill and decode (qk16_v32). Missing GQA: h=8, kv=1, d=256 (TP=2 of original h=16, kv=2, d=256).
 
 ---
+
+## Qwen3.5 35B A3B
+
+**Architecture**: 28 layers total — 20 GDN (linear attention) + 8 GQA (standard attention), all layers use MoE FFN. Standard serving configuration: **TP=2**. Shares GDN/GQA architecture with Qwen3 Next 80B A3B but at smaller scale (hidden=2048, head_dim=256 for GQA, head_dim=128 for GDN).
+
+| Definition | Op Type | Status |
+|-----------|---------|:------:|
+| `gdn_decode_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
+| `gdn_prefill_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
+| `gdn_mtp_qk8_v16_d128_k_last` | gdn TP=2 | ❌ |
+| `gemm_n16_k2048` | gemm | ❌ |
+| `gemm_n256_k2048` | gemm | ❌ |
+| `gemm_n512_k2048` | gemm | ❌ |
+| `gemm_n2048_k256` | gemm | ❌ |
+| `gemm_n2048_k2048` | gemm | ❌ |
+| `gemm_n4096_k2048` | gemm | ❌ |
+| `gemm_n4608_k2048` | gemm | ❌ |
+| `gqa_paged_decode_h8_kv1_d256_ps1` | gqa_paged TP=2 | ❌ |
+| `gqa_paged_prefill_causal_h8_kv1_d256_ps1` | gqa_paged TP=2 | ❌ |
+| `moe_bf16_topk8_e256_h2048_i256` | moe | ❌ |
+| `gemma_fused_add_rmsnorm_h2048` | rmsnorm | ❌ |
+| `gemma_rmsnorm_h2048` | rmsnorm | ❌ |
+| `gemma_rmsnorm_h256` | rmsnorm | ❌ |
+| `top_k_top_p_sampling_from_probs_v248320` | sampling | ✅ |
+
+**Coverage**: 1 / 17 definitions present.
+
+---
+
 
 ## Llama 3.1 / 3.3 70B
 

--- a/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v248320.json
+++ b/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v248320.json
@@ -1,0 +1,56 @@
+{
+    "name": "top_k_top_p_sampling_from_probs_v248320",
+    "op_type": "sampling",
+    "description": "Top-k top-p (nucleus) sampling from probabilities with vocab_size=248320. Filters probabilities using top-k and top-p constraints, then samples from the filtered distribution. Captured from Qwen3.5-35B-A3B.",
+    "tags": [
+        "status:verified",
+        "model:qwen3.5-35b-a3b",
+        "fi_api:flashinfer.sampling.top_k_top_p_sampling_from_probs",
+        "tp:2"
+    ],
+    "axes": {
+        "batch_size": {
+            "type": "var",
+            "description": "Number of sequences to sample from"
+        },
+        "vocab_size": {
+            "type": "const",
+            "value": 248320,
+            "description": "Size of the vocabulary for Qwen3.5"
+        }
+    },
+    "inputs": {
+        "probs": {
+            "shape": [
+                "batch_size",
+                "vocab_size"
+            ],
+            "dtype": "float32",
+            "description": "Probability distributions (after softmax)"
+        },
+        "top_k": {
+            "shape": [
+                "batch_size"
+            ],
+            "dtype": "int32",
+            "description": "Number of top tokens to consider for sampling per sequence"
+        },
+        "top_p": {
+            "shape": [
+                "batch_size"
+            ],
+            "dtype": "float32",
+            "description": "Cumulative probability threshold for nucleus sampling per sequence"
+        }
+    },
+    "outputs": {
+        "samples": {
+            "shape": [
+                "batch_size"
+            ],
+            "dtype": "int64",
+            "description": "Sampled token indices"
+        }
+    },
+    "reference": "import torch\n\n@torch.no_grad()\ndef run(probs, top_k, top_p):\n    batch_size, vocab_size = probs.shape\n    device = probs.device\n\n    # Check constants\n    assert vocab_size == 248320\n\n    probs = probs.to(torch.float32)\n    samples = torch.empty(batch_size, dtype=torch.int64, device=device)\n\n    for i in range(batch_size):\n        row = probs[i]\n        k = int(top_k[i].item())\n        p = float(top_p[i].item())\n\n        # Apply top-k filtering\n        if 0 < k < vocab_size:\n            idx_sorted = torch.argsort(row, descending=True)\n            keep_idx_k = idx_sorted[:k]\n            filtered_k = torch.zeros_like(row)\n            filtered_k[keep_idx_k] = row[keep_idx_k]\n            row = filtered_k / filtered_k.sum()\n\n        # Then apply top-p filtering\n        if p <= 0.0:\n            samples[i] = torch.argmax(row).to(torch.int64)\n            continue\n\n        if p < 1.0:\n            # FlashInfer official: ascending sort, keep tokens where cdf >= (1-p)\n            sorted_prob, indices = torch.sort(row, descending=False)\n            cdf = torch.cumsum(sorted_prob, dim=0)\n            mask = (cdf >= (1.0 - p))\n            filtered_p = torch.zeros_like(row)\n            filtered_p[indices[mask]] = row[indices[mask]]\n            row = filtered_p / filtered_p.sum()\n\n        # sample\n        samples[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)\n\n    return samples\n"
+}

--- a/flashinfer_trace/tests/references/test_top_k_top_p_sampling_from_probs_v248320.py
+++ b/flashinfer_trace/tests/references/test_top_k_top_p_sampling_from_probs_v248320.py
@@ -1,0 +1,144 @@
+import flashinfer
+import torch
+
+
+@torch.no_grad()
+def run(probs, top_k, top_p):
+    batch_size, vocab_size = probs.shape
+    device = probs.device
+
+    # Check constants
+    assert vocab_size == 248320
+
+    probs = probs.to(torch.float32)
+    samples = torch.empty(batch_size, dtype=torch.int64, device=device)
+
+    for i in range(batch_size):
+        row = probs[i]
+        k = int(top_k[i].item())
+        p = float(top_p[i].item())
+
+        # Apply top-k filtering
+        if 0 < k < vocab_size:
+            idx_sorted = torch.argsort(row, descending=True)
+            keep_idx_k = idx_sorted[:k]
+            filtered_k = torch.zeros_like(row)
+            filtered_k[keep_idx_k] = row[keep_idx_k]
+            row = filtered_k / filtered_k.sum()
+
+        # Then apply top-p filtering
+        if p <= 0.0:
+            samples[i] = torch.argmax(row).to(torch.int64)
+            continue
+
+        if p < 1.0:
+            # FlashInfer official: ascending sort, keep tokens where cdf >= (1-p)
+            sorted_prob, indices = torch.sort(row, descending=False)
+            cdf = torch.cumsum(sorted_prob, dim=0)
+            mask = (cdf >= (1.0 - p))
+            filtered_p = torch.zeros_like(row)
+            filtered_p[indices[mask]] = row[indices[mask]]
+            row = filtered_p / filtered_p.sum()
+
+        # sample
+        samples[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)
+
+    return samples
+
+
+def generate_random_inputs(batch_size, vocab_size=248320, distribution="peaked", device="cuda"):
+    if distribution == "normal":
+        logits = torch.randn(batch_size, vocab_size, device=device)
+    elif distribution == "peaked":
+        logits = torch.randn(batch_size, vocab_size, device=device) * 0.1
+        peak_indices = torch.randint(0, vocab_size, (batch_size,), device=device)
+        for i in range(batch_size):
+            logits[i, peak_indices[i]] += 5.0
+    elif distribution == "uniform":
+        logits = torch.zeros(batch_size, vocab_size, device=device)
+    else:
+        raise ValueError(f"Unknown distribution: {distribution}")
+
+    probs = torch.softmax(logits, dim=-1).to(torch.float32)
+    top_k = torch.randint(
+        10, min(500, vocab_size // 2), (batch_size,), dtype=torch.int32, device=device
+    )
+    top_p = torch.rand(batch_size, dtype=torch.float32, device=device) * 0.5 + 0.5  # [0.5, 1.0)
+    return probs, top_k, top_p
+
+
+def test_correctness(batch_size=4, vocab_size=248320, num_trials=10000):
+    print(f"\n{'='*60}")
+    print(f"Testing top_k_top_p_sampling_from_probs v248320")
+    print(f"batch_size={batch_size}, num_trials={num_trials}")
+    print(f"{'='*60}")
+
+    device = "cuda"
+    torch.manual_seed(42)
+
+    probs, top_k, top_p = generate_random_inputs(batch_size, vocab_size, "peaked", device)
+
+    ref_counter = torch.zeros(batch_size, vocab_size, dtype=torch.int32, device=device)
+    fi_counter = torch.zeros(batch_size, vocab_size, dtype=torch.int32, device=device)
+
+    for trial in range(num_trials):
+        progress_interval = max(1000, num_trials // 5)
+        if trial % progress_interval == 0:
+            print(f"  Trial {trial}/{num_trials}...")
+
+        torch.manual_seed(42 + trial)
+        ref_samples = run(probs, top_k, top_p)
+        for i in range(batch_size):
+            ref_counter[i, ref_samples[i]] += 1
+
+        torch.manual_seed(42 + trial)
+        fi_samples = flashinfer.sampling.top_k_top_p_sampling_from_probs(probs, top_k, top_p)
+        for i in range(batch_size):
+            fi_counter[i, fi_samples[i]] += 1
+
+    ref_freq = ref_counter.float() / num_trials
+    fi_freq = fi_counter.float() / num_trials
+
+    similarities = []
+    for i in range(batch_size):
+        mask = (ref_freq[i] > 0) | (fi_freq[i] > 0)
+        if mask.sum() > 0:
+            ref = ref_freq[i][mask]
+            fi = fi_freq[i][mask]
+            similarity = torch.nn.functional.cosine_similarity(ref.unsqueeze(0), fi.unsqueeze(0))
+            similarities.append(similarity.item())
+            print(f"  Sequence {i}: Cosine similarity = {similarity.item():.4f}")
+
+    avg_similarity = sum(similarities) / len(similarities)
+    print(f"\n  Average cosine similarity: {avg_similarity:.4f}")
+
+    assert avg_similarity > 0.95, f"Implementations diverge too much: {avg_similarity:.4f} < 0.95"
+    print("  Correctness test passed!")
+
+
+def main():
+    print("Testing Top-K Top-P Sampling from Probabilities (vocab_size=248320)")
+
+    passed = 0
+    test_configs = [(2, 248320, 10000), (4, 248320, 10000)]
+    total = len(test_configs)
+
+    for batch_size, vocab_size, num_trials in test_configs:
+        try:
+            test_correctness(batch_size, vocab_size, num_trials)
+            passed += 1
+        except Exception as e:
+            print(f"✗ Test failed: {e}")
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+    if passed == total:
+        print("✓ All tests passed!")
+    else:
+        print(f"✗ {total - passed} tests failed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds kernel definition for `top_k_top_p_sampling_from_probs_v248320` (sampling)
- Model: Qwen3.5 35B A3B sampling with vocab_size=248320
- Adds reference test validating the definition against FlashInfer sampling unit tests
- Updates `docs/model_coverage.mdx` to mark Qwen3.5 35B A3B as covered
- Workloads are submitted in a companion PR to flashinfer-ai/flashinfer-trace.

## Test plan
- Reference test passes: `pytest flashinfer_trace/tests/references/test_top_k_top_p_sampling_from_probs_v248320.py -v` — 1/1 passed
- Definition JSON is valid and loads without errors
- Coverage doc reflects ✅ for `top_k_top_p_sampling_from_probs_v248320`

## Reference Test Results
```
============================= test session starts ==============================
platform linux -- Python 3.12.10, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /root
collecting ... collected 1 item

tests/references/test_top_k_top_p_sampling_from_probs_v248320.py::test_correctness PASSED [100%]

======================== 1 passed in 121.24s (0:02:01) =========================
```

## HuggingFace Dataset PR
[Workloads + baseline solution](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/220)

🤖 Generated with [Claude Code](https://claude.ai/code)
