### PR TITLE
feat: add gqa_paged_decode_h5_kv1_d128_ps1 definition (Llama 4 Scout, TP=8)

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -533,7 +533,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
-| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
+| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_ragged_prefill_causal_h5_kv1_d128` | gqa_ragged TP=8 | ❌ |
 | MoE experts (top-1, 16 experts, standard routing) | moe | — |
@@ -557,7 +557,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
-| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
+| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_ragged_prefill_causal_h5_kv1_d128` | gqa_ragged TP=8 | ❌ |
 | MoE experts (top-1, 128 experts, standard routing) | moe | — |

--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -533,7 +533,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
-| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_ragged_prefill_causal_h5_kv1_d128` | gqa_ragged TP=8 | ❌ |
 | MoE experts (top-1, 16 experts, standard routing) | moe | — |
@@ -557,7 +557,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
-| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_ragged_prefill_causal_h5_kv1_d128` | gqa_ragged TP=8 | ❌ |
 | MoE experts (top-1, 128 experts, standard routing) | moe | — |

--- a/flashinfer_trace/definitions/gqa_paged/gqa_paged_decode_h5_kv1_d128_ps1.json
+++ b/flashinfer_trace/definitions/gqa_paged/gqa_paged_decode_h5_kv1_d128_ps1.json
@@ -1,0 +1,114 @@
+{
+  "name": "gqa_paged_decode_h5_kv1_d128_ps1",
+  "description": "Batched Grouped Query Attention decode with a paged KV cache (page_size=1). Captured from Llama 4 Scout/Maverick at TP=8. 5 q-heads, 1 kv-heads, head_dim=128.",
+  "op_type": "gqa_paged",
+  "tags": [
+    "stage:decode",
+    "status:reference",
+    "model:llama-4-scout",
+    "fi_api:flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper",
+    "tp:8"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var"
+    },
+    "num_qo_heads": {
+      "type": "const",
+      "value": 5
+    },
+    "num_kv_heads": {
+      "type": "const",
+      "value": 1
+    },
+    "head_dim": {
+      "type": "const",
+      "value": 128
+    },
+    "num_pages": {
+      "type": "var"
+    },
+    "page_size": {
+      "type": "const",
+      "value": 1
+    },
+    "len_indptr": {
+      "type": "var",
+      "description": "Length of kv_indptr array."
+    },
+    "num_kv_indices": {
+      "type": "var",
+      "description": "Total number of KV page indices."
+    }
+  },
+  "constraints": [
+    "len_indptr == batch_size + 1",
+    "num_kv_indices == kv_indptr[-1].item()"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "batch_size",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "k_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "v_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "kv_indptr": {
+      "shape": [
+        "len_indptr"
+      ],
+      "dtype": "int32",
+      "description": "KV page offsets for each sequence."
+    },
+    "kv_indices": {
+      "shape": [
+        "num_kv_indices"
+      ],
+      "dtype": "int32",
+      "description": "Page IDs for KV cache lookups."
+    },
+    "sm_scale": {
+      "shape": null,
+      "dtype": "float32",
+      "description": "Softmax scale. Default is (1/sqrt(head_dim))."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "batch_size",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "lse": {
+      "shape": [
+        "batch_size",
+        "num_qo_heads"
+      ],
+      "dtype": "float32",
+      "description": "The 2-based log-sum-exp of attention logits."
+    }
+  },
+  "reference": "import torch\nimport math\n\n\n@torch.no_grad()\ndef run(q, k_cache, v_cache, kv_indptr, kv_indices, sm_scale):\n    batch_size, num_qo_heads, head_dim = q.shape\n    _, page_size, num_kv_heads, _ = k_cache.shape\n\n    # Check constants\n    assert num_qo_heads == 5\n    assert num_kv_heads == 1\n    assert head_dim == 128\n    assert page_size == 1\n\n    device = q.device\n    output = torch.zeros(\n        (batch_size, num_qo_heads, head_dim), dtype=torch.bfloat16, device=device\n    )\n    lse = torch.full(\n        (batch_size, num_qo_heads), -float(\"inf\"), dtype=torch.float32, device=device\n    )\n\n    gqa_ratio = num_qo_heads // num_kv_heads\n    # page_size=1: squeeze page dim -> [num_pages, num_kv_heads, head_dim]\n    k_flat = k_cache.squeeze(1).to(torch.float32)\n    v_flat = v_cache.squeeze(1).to(torch.float32)\n    q_f32 = q.to(torch.float32)\n\n    for b in range(batch_size):\n        ps = int(kv_indptr[b].item())\n        pe = int(kv_indptr[b + 1].item())\n        if ps >= pe:\n            output[b].zero_()\n            continue\n\n        idx = kv_indices[ps:pe].to(torch.long)\n        k = k_flat[idx].permute(1, 0, 2).repeat_interleave(gqa_ratio, dim=0)\n        v = v_flat[idx].permute(1, 0, 2).repeat_interleave(gqa_ratio, dim=0)\n        q_b = q_f32[b].unsqueeze(1)  # [num_qo_heads, 1, head_dim]\n\n        logits = torch.bmm(q_b, k.transpose(1, 2)).squeeze(1) * sm_scale  # [H, T]\n        lse[b] = torch.logsumexp(logits, dim=-1) / math.log(2.0)\n        attn = torch.softmax(logits, dim=-1)\n        output[b] = torch.bmm(attn.unsqueeze(1), v).squeeze(1).to(torch.bfloat16)\n\n    return output, lse"
+}

--- a/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps1.py
@@ -106,9 +106,9 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
 
 
 def main():
-    configs = [(1, 16), (4, 64), (8, 128)]
+    configs = [(1, 16), (4, 32), (8, 64), (16, 128)]
     passed = sum(1 for b, s in configs if test_correctness(b, s))
-    print(f"{passed}/{len(configs)} passed")
+    print(f"\nSummary: {passed}/{len(configs)} tests passed")
 
 
 if __name__ == "__main__":

--- a/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps1.py
@@ -1,0 +1,115 @@
+"""Reference test for gqa_paged_decode_h5_kv1_d128_ps1."""
+
+import math
+from pathlib import Path
+
+import flashinfer
+import torch
+
+from flashinfer_bench.data import Definition, load_json_file
+
+DEFINITIONS_DIR = Path(__file__).parent.parent.parent / "definitions"
+
+NUM_QO_HEADS = 5
+NUM_KV_HEADS = 1
+HEAD_DIM = 128
+PAGE_SIZE = 1
+
+
+def load_definition(name: str) -> Definition:
+    for op_dir in DEFINITIONS_DIR.iterdir():
+        if op_dir.is_dir():
+            def_file = op_dir / f"{name}.json"
+            if def_file.exists():
+                return load_json_file(Definition, def_file)
+    raise FileNotFoundError(f"Definition {name} not found")
+
+
+def compile_reference(reference_code: str):
+    namespace = {"torch": torch, "math": math}
+    exec(reference_code, namespace)
+    return namespace["run"]
+
+
+def generate_random_inputs(batch_size, max_seq_len, device="cuda"):
+    seq_lens = torch.randint(1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device)
+    total_pages = seq_lens.sum().item()
+
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(seq_lens, dim=0)
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
+
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    num_cache_pages = total_pages + 100
+    k_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    v_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    sm_scale = torch.tensor(1.0 / math.sqrt(HEAD_DIM), dtype=torch.float32, device=device)
+
+    return {
+        "q": q,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "kv_last_page_len": kv_last_page_len,
+        "sm_scale": sm_scale,
+    }
+
+
+def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        return False
+
+    definition = load_definition("gqa_paged_decode_h5_kv1_d128_ps1")
+    run = compile_reference(definition.reference)
+    inputs = generate_random_inputs(batch_size, max_seq_len, device)
+
+    ref_o, ref_lse = run(
+        inputs["q"],
+        inputs["k_cache"],
+        inputs["v_cache"],
+        inputs["kv_indptr"],
+        inputs["kv_indices"],
+        inputs["sm_scale"],
+    )
+
+    # group_size=5 is not a power of 2; expand KV heads to Q heads (group_size=1)
+    k_cache_exp = inputs["k_cache"].repeat_interleave(5, dim=2)
+    v_cache_exp = inputs["v_cache"].repeat_interleave(5, dim=2)
+    fi_kv_heads = NUM_QO_HEADS
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+    wrapper.plan(
+        indptr=inputs["kv_indptr"],
+        indices=inputs["kv_indices"],
+        last_page_len=inputs["kv_last_page_len"],
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=fi_kv_heads,
+        head_dim=HEAD_DIM,
+        page_size=PAGE_SIZE,
+        pos_encoding_mode="NONE",
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+        sm_scale=inputs["sm_scale"].item(),
+    )
+    fi_o, fi_lse = wrapper.run((k_cache_exp, v_cache_exp), return_lse=True)
+
+    out_ok = torch.allclose(ref_o.float(), fi_o.float(), atol=atol, rtol=rtol)
+    lse_ok = torch.allclose(ref_lse, fi_lse, atol=atol, rtol=rtol)
+    return out_ok and lse_ok
+
+
+def main():
+    configs = [(1, 16), (4, 64), (8, 128)]
+    passed = sum(1 for b, s in configs if test_correctness(b, s))
+    print(f"{passed}/{len(configs)} passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps1.py
@@ -98,7 +98,7 @@ def test_correctness(batch_size=4, max_seq_len=64, atol=1e-2, rtol=5e-2):
         kv_data_type=torch.bfloat16,
         sm_scale=inputs["sm_scale"].item(),
     )
-    fi_o, fi_lse = wrapper.run((k_cache_exp, v_cache_exp), return_lse=True)
+    fi_o, fi_lse = wrapper.run(inputs["q"], (k_cache_exp, v_cache_exp), return_lse=True)
 
     out_ok = torch.allclose(ref_o.float(), fi_o.float(), atol=atol, rtol=rtol)
     lse_ok = torch.allclose(ref_lse, fi_lse, atol=atol, rtol=rtol)


### PR DESCRIPTION
## Summary

- Add definition JSON for `gqa_paged_decode_h5_kv1_d128_ps1` (`gqa_paged` op_type)
- Add reference test with 4/4 correctness tests passing against FlashInfer ground truth
- Update `docs/model_coverage.mdx`: mark definition as 🟡 for Llama 4 Scout 17B-16E and Llama 4 Maverick 17B-128E

## Kernel Details

| Field | Value |
|-------|-------|
| Definition name | `gqa_paged_decode_h5_kv1_d128_ps1` |
| Op type | `gqa_paged` |
| Stage | decode |
| Model | Llama 4 Scout 17B-16E (TP=8) |
| `num_qo_heads` | 5 (40 total / TP=8) |
| `num_kv_heads` | 1 (8 total / TP=8) |
| `head_dim` | 128 |
| `page_size` | 1 |
| FlashInfer API | `flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper` |

**Note**: GQA decode with group_size=5 is handled via KV head expansion (`repeat_interleave(5, dim=2)`) since FlashInfer decode requires standard GQA ratios.

## Reference Test Output

Ran on NVIDIA GB200 (CUDA 12.8, torch 2.7.0+cu128, flashinfer 0.6.7.post3):

```
$ python flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps1.py

Summary: 4/4 tests passed
```

Test configurations: `(batch_size=1, max_seq_len=16)`, `(batch_size=4, max_seq_len=32)`, `(batch_size=8, max_seq_len=64)`, `(batch_size=16, max_seq_len=128)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new GQA paged decode operator definition with support for grouped multi-head query-key-value attention, configurable page sizing, and variable head dimensions.

* **Tests**
  * Added comprehensive correctness test suite for validating the new operator against reference implementations.

* **Documentation**
  * Updated model coverage documentation to reflect the current status of operator availability across all supported model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->