### PR TITLE
feat: add gqa_paged_prefill_causal_h5_kv1_d128_ps1 definition (Llama 4 Scout, TP=8)

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -531,7 +531,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 |-----------|---------|:------:|
 | `rmsnorm_h5120` | rmsnorm | 🟡 |
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
-| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
@@ -555,7 +555,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 |-----------|---------|:------:|
 | `rmsnorm_h5120` | rmsnorm | 🟡 |
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
-| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |

--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -531,7 +531,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 |-----------|---------|:------:|
 | `rmsnorm_h5120` | rmsnorm | 🟡 |
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
-| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
+| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
@@ -555,7 +555,7 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 |-----------|---------|:------:|
 | `rmsnorm_h5120` | rmsnorm | 🟡 |
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
-| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | ✅ |
+| `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | ❌ |
 | `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |

--- a/flashinfer_trace/definitions/gqa_paged/gqa_paged_prefill_causal_h5_kv1_d128_ps1.json
+++ b/flashinfer_trace/definitions/gqa_paged/gqa_paged_prefill_causal_h5_kv1_d128_ps1.json
@@ -1,0 +1,122 @@
+{
+  "name": "gqa_paged_prefill_causal_h5_kv1_d128_ps1",
+  "description": "Batched Grouped Query Attention prefill with a paged KV cache (page_size=1). Causal mask applied. From Llama 4 Scout/Maverick at TP=8. 5 q-heads, 1 kv-heads, head_dim=128.",
+  "op_type": "gqa_paged",
+  "tags": [
+    "stage:prefill",
+    "status:reference",
+    "model:llama-4-scout",
+    "fi_api:flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper",
+    "tp:8"
+  ],
+  "axes": {
+    "num_qo_heads": {
+      "type": "const",
+      "value": 5
+    },
+    "num_kv_heads": {
+      "type": "const",
+      "value": 1
+    },
+    "head_dim": {
+      "type": "const",
+      "value": 128
+    },
+    "page_size": {
+      "type": "const",
+      "value": 1
+    },
+    "len_indptr": {
+      "type": "var",
+      "description": "Length of indptr arrays."
+    },
+    "total_q": {
+      "type": "var",
+      "description": "Total number of query tokens."
+    },
+    "num_kv_indices": {
+      "type": "var",
+      "description": "Total number of KV page indices."
+    },
+    "num_pages": {
+      "type": "var"
+    }
+  },
+  "constraints": [
+    "total_q == qo_indptr[-1].item()",
+    "num_kv_indices == kv_indptr[-1].item()"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "total_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "k_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "v_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "qo_indptr": {
+      "shape": [
+        "len_indptr"
+      ],
+      "dtype": "int32",
+      "description": "Query offsets for each sequence."
+    },
+    "kv_indptr": {
+      "shape": [
+        "len_indptr"
+      ],
+      "dtype": "int32",
+      "description": "KV page offsets for each sequence."
+    },
+    "kv_indices": {
+      "shape": [
+        "num_kv_indices"
+      ],
+      "dtype": "int32",
+      "description": "Page IDs for KV cache lookups."
+    },
+    "sm_scale": {
+      "shape": null,
+      "dtype": "float32",
+      "description": "Softmax scale. Default is (1/sqrt(head_dim))."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "total_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "lse": {
+      "shape": [
+        "total_q",
+        "num_qo_heads"
+      ],
+      "dtype": "float32",
+      "description": "The 2-based log-sum-exp of attention logits."
+    }
+  },
+  "reference": "import torch\nimport math\n\nCHUNK_Q = 512  # chunk query tokens to bound peak memory for large prefills\n\n\n@torch.no_grad()\ndef run(q, k_cache, v_cache, qo_indptr, kv_indptr, kv_indices, sm_scale):\n    total_q, num_qo_heads, head_dim = q.shape\n    num_pages, page_size, num_kv_heads, _ = k_cache.shape\n    batch_size = int(qo_indptr.shape[0]) - 1\n\n    # Check constants\n    assert num_qo_heads == 5\n    assert num_kv_heads == 1\n    assert head_dim == 128\n    assert page_size == 1\n\n    device = q.device\n    output = torch.zeros((total_q, num_qo_heads, head_dim), dtype=torch.bfloat16, device=device)\n    lse = torch.full((total_q, num_qo_heads), -float(\"inf\"), dtype=torch.float32, device=device)\n\n    gqa_ratio = num_qo_heads // num_kv_heads\n    q_f32 = q.to(torch.float32)\n    # page_size=1: squeeze page dim -> [num_pages, num_kv_heads, head_dim]\n    k_flat = k_cache.squeeze(1).to(torch.float32)\n    v_flat = v_cache.squeeze(1).to(torch.float32)\n\n    for b in range(batch_size):\n        qs = int(qo_indptr[b].item())\n        qe = int(qo_indptr[b + 1].item())\n        kvs = int(kv_indptr[b].item())\n        kve = int(kv_indptr[b + 1].item())\n        if qs >= qe or kvs >= kve:\n            continue\n\n        page_ids = kv_indices[kvs:kve].to(torch.long)\n        k = k_flat[page_ids]  # [num_kv, num_kv_heads, head_dim]\n        v = v_flat[page_ids]\n        num_kv = k.shape[0]\n        num_q = qe - qs\n        delta = num_kv - num_q\n\n        k_exp = k.permute(1, 0, 2).repeat_interleave(gqa_ratio, dim=0)\n        v_exp = v.permute(1, 0, 2).repeat_interleave(gqa_ratio, dim=0)\n        kv_pos = torch.arange(num_kv, device=device)\n\n        for chunk_start in range(0, num_q, CHUNK_Q):\n            chunk_end = min(chunk_start + CHUNK_Q, num_q)\n            q_chunk = q_f32[qs + chunk_start:qs + chunk_end]\n\n            logits = torch.einsum(\"qhd,hkd->hqk\", q_chunk, k_exp) * sm_scale\n\n            q_pos = torch.arange(chunk_start, chunk_end, device=device).unsqueeze(1)\n            mask = kv_pos.unsqueeze(0) > q_pos + delta\n            logits.masked_fill_(mask.unsqueeze(0), float(\"-inf\"))\n\n            lse[qs + chunk_start:qs + chunk_end] = (\n                torch.logsumexp(logits, dim=-1) / math.log(2.0)\n            ).permute(1, 0)\n\n            attn = torch.softmax(logits, dim=-1)\n            output[qs + chunk_start:qs + chunk_end] = torch.einsum(\n                \"hqk,hkd->qhd\", attn, v_exp\n            ).to(torch.bfloat16)\n\n    return output, lse"
+}

--- a/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps1.py
@@ -32,17 +32,26 @@ def compile_reference(reference_code: str):
 
 
 def generate_random_inputs(batch_size, max_seq_len, device="cuda"):
-    total_q_per_seq = torch.randint(
+    q_len_per_seq = torch.randint(
         1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device
     )
-    total_q = total_q_per_seq.sum().item()
-    total_pages = total_q_per_seq.sum().item()
-    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
-    kv_indptr[1:] = torch.cumsum(total_q_per_seq, dim=0)
-    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    # kv_len >= q_len to test the general prefill case (query attending to pre-existing KV cache)
+    kv_len_per_seq = torch.tensor(
+        [torch.randint(int(q.item()), max_seq_len + 1, (1,)).item() for q in q_len_per_seq],
+        dtype=torch.int32,
+        device=device,
+    )
+
+    total_q = int(q_len_per_seq.sum().item())
+    total_pages = int(kv_len_per_seq.sum().item())
 
     qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
-    qo_indptr[1:] = torch.cumsum(total_q_per_seq, dim=0)
+    qo_indptr[1:] = torch.cumsum(q_len_per_seq, dim=0)
+
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(kv_len_per_seq, dim=0)
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = torch.ones(batch_size, dtype=torch.int32, device=device)
 
     q = torch.randn(total_q, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
     num_cache_pages = total_pages + 100
@@ -54,17 +63,16 @@ def generate_random_inputs(batch_size, max_seq_len, device="cuda"):
     )
     sm_scale = torch.tensor(1.0 / math.sqrt(HEAD_DIM), dtype=torch.float32, device=device)
 
-    result = {
+    return {
         "q": q,
         "k_cache": k_cache,
         "v_cache": v_cache,
         "qo_indptr": qo_indptr,
         "kv_indptr": kv_indptr,
         "kv_indices": kv_indices,
+        "kv_last_page_len": kv_last_page_len,
         "sm_scale": sm_scale,
     }
-
-    return result
 
 
 def test_correctness(batch_size=2, max_seq_len=64, atol=1e-2, rtol=5e-2):
@@ -97,16 +105,17 @@ def test_correctness(batch_size=2, max_seq_len=64, atol=1e-2, rtol=5e-2):
         qo_indptr=inputs["qo_indptr"],
         paged_kv_indptr=inputs["kv_indptr"],
         paged_kv_indices=inputs["kv_indices"],
+        paged_kv_last_page_len=inputs["kv_last_page_len"],
         num_qo_heads=NUM_QO_HEADS,
         num_kv_heads=fi_kv_heads,
-        head_dim=HEAD_DIM,
+        head_dim_qk=HEAD_DIM,
         page_size=PAGE_SIZE,
         causal=True,
         q_data_type=torch.bfloat16,
         kv_data_type=torch.bfloat16,
         sm_scale=inputs["sm_scale"].item(),
     )
-    fi_o, fi_lse = wrapper.run((k_cache_exp, v_cache_exp), return_lse=True)
+    fi_o, fi_lse = wrapper.run(inputs["q"], (k_cache_exp, v_cache_exp), return_lse=True)
 
     out_ok = torch.allclose(ref_o.float(), fi_o.float(), atol=atol, rtol=rtol)
     lse_ok = torch.allclose(ref_lse, fi_lse, atol=atol, rtol=rtol)
@@ -114,9 +123,9 @@ def test_correctness(batch_size=2, max_seq_len=64, atol=1e-2, rtol=5e-2):
 
 
 def main():
-    configs = [(1, 16), (2, 64)]
+    configs = [(1, 16), (4, 32), (8, 64), (16, 128)]
     passed = sum(1 for b, s in configs if test_correctness(b, s))
-    print(f"{passed}/{len(configs)} passed")
+    print(f"\nSummary: {passed}/{len(configs)} tests passed")
 
 
 if __name__ == "__main__":

--- a/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps1.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps1.py
@@ -1,0 +1,123 @@
+"""Reference test for gqa_paged_prefill_causal_h5_kv1_d128_ps1."""
+
+import math
+from pathlib import Path
+
+import flashinfer
+import torch
+
+from flashinfer_bench.data import Definition, load_json_file
+
+DEFINITIONS_DIR = Path(__file__).parent.parent.parent / "definitions"
+
+NUM_QO_HEADS = 5
+NUM_KV_HEADS = 1
+HEAD_DIM = 128
+PAGE_SIZE = 1
+
+
+def load_definition(name: str) -> Definition:
+    for op_dir in DEFINITIONS_DIR.iterdir():
+        if op_dir.is_dir():
+            def_file = op_dir / f"{name}.json"
+            if def_file.exists():
+                return load_json_file(Definition, def_file)
+    raise FileNotFoundError(f"Definition {name} not found")
+
+
+def compile_reference(reference_code: str):
+    namespace = {"torch": torch, "math": math}
+    exec(reference_code, namespace)
+    return namespace["run"]
+
+
+def generate_random_inputs(batch_size, max_seq_len, device="cuda"):
+    total_q_per_seq = torch.randint(
+        1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    total_q = total_q_per_seq.sum().item()
+    total_pages = total_q_per_seq.sum().item()
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(total_q_per_seq, dim=0)
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    qo_indptr[1:] = torch.cumsum(total_q_per_seq, dim=0)
+
+    q = torch.randn(total_q, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    num_cache_pages = total_pages + 100
+    k_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    v_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    sm_scale = torch.tensor(1.0 / math.sqrt(HEAD_DIM), dtype=torch.float32, device=device)
+
+    result = {
+        "q": q,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "qo_indptr": qo_indptr,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "sm_scale": sm_scale,
+    }
+
+    return result
+
+
+def test_correctness(batch_size=2, max_seq_len=64, atol=1e-2, rtol=5e-2):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        return False
+
+    definition = load_definition("gqa_paged_prefill_causal_h5_kv1_d128_ps1")
+    run = compile_reference(definition.reference)
+    inputs = generate_random_inputs(batch_size, max_seq_len, device)
+
+    run_args = [
+        inputs["q"],
+        inputs["k_cache"],
+        inputs["v_cache"],
+        inputs["qo_indptr"],
+        inputs["kv_indptr"],
+        inputs["kv_indices"],
+        inputs["sm_scale"],
+    ]
+
+    ref_o, ref_lse = run(*run_args)
+
+    k_cache_exp = inputs["k_cache"].repeat_interleave(5, dim=2)
+    v_cache_exp = inputs["v_cache"].repeat_interleave(5, dim=2)
+    fi_kv_heads = NUM_QO_HEADS
+    workspace = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=device)
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+    wrapper.plan(
+        qo_indptr=inputs["qo_indptr"],
+        paged_kv_indptr=inputs["kv_indptr"],
+        paged_kv_indices=inputs["kv_indices"],
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=fi_kv_heads,
+        head_dim=HEAD_DIM,
+        page_size=PAGE_SIZE,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+        sm_scale=inputs["sm_scale"].item(),
+    )
+    fi_o, fi_lse = wrapper.run((k_cache_exp, v_cache_exp), return_lse=True)
+
+    out_ok = torch.allclose(ref_o.float(), fi_o.float(), atol=atol, rtol=rtol)
+    lse_ok = torch.allclose(ref_lse, fi_lse, atol=atol, rtol=rtol)
+    return out_ok and lse_ok
+
+
+def main():
+    configs = [(1, 16), (2, 64)]
+    passed = sum(1 for b, s in configs if test_correctness(b, s))
+    print(f"{passed}/{len(configs)} passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add definition JSON for `gqa_paged_prefill_causal_h5_kv1_d128_ps1` (`gqa_paged` op_type)
- Add reference test with 4/4 correctness tests passing against FlashInfer ground truth
- Update `docs/model_coverage.mdx`: mark definition as 🟡 for Llama 4 Scout 17B-16E and Llama 4 Maverick 17B-128E

## Kernel Details

| Field | Value |
|-------|-------|
| Definition name | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` |
| Op type | `gqa_paged` |
| Stage | prefill (causal) |
| Model | Llama 4 Scout 17B-16E (TP=8) |
| `num_qo_heads` | 5 (40 total / TP=8) |
| `num_kv_heads` | 1 (8 total / TP=8) |
| `head_dim` | 128 |
| `page_size` | 1 |
| FlashInfer API | `flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper` |

## Changes from Review

- `generate_random_inputs`: KV lengths are now sampled independently with `kv_len >= q_len` to exercise the causal delta path in the reference implementation
- `wrapper.plan()`: `head_dim` → `head_dim_qk`; added required `paged_kv_last_page_len`
- `wrapper.run()`: added missing `q` tensor as first argument
- `main()`: configs expanded to `[(1,16),(4,32),(8,64),(16,128)]`

## Reference Test Output

Ran on NVIDIA GB200 (CUDA 12.8, torch 2.7.0+cu128, flashinfer 0.6.7.post3):

```
$ python flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps1.py

Summary: 4/4 tests passed
```

Test configurations: `(batch_size=1, max_seq_len=16)`, `(batch_size=4, max_seq_len=32)`, `(batch_size=8, max_seq_len=64)`, `(batch_size=16, max_seq_len=128)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for a new grouped-query attention kernel variant with paged KV cache implementation.

* **Documentation**
  * Updated model coverage status to reflect new kernel definition availability for Llama 4 Scout and Maverick models.

* **Tests**
  * Added comprehensive validation tests for the new kernel variant across multiple batch and sequence length configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->