### PR TITLE
feat: add moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048 definition (Kimi K2, EP=8)

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -487,8 +487,8 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `mla_paged_decode_h8_ckv512_kpe64_ps64` | mla_paged TP=8 | ❌ |
 | `mla_ragged_prefill_causal_h8_qk192_vo128` | mla_ragged | ❌ |
 | `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e384_h7168_i2048` | moe EP=1 | 🟡 |
-| `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048` | moe EP=8 | ✅ |
 | `moe_fp8_block_scale_ds_routing_topk8_ng?_kg?_e96_h7168_i2048` | moe EP=4 | ❌ |
+| `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048` | moe EP=8 | 🟡 |
 | `top_k_sampling_from_probs_v160000` | sampling | ❌ |
 | `top_k_top_p_sampling_from_probs_v160000` | sampling | ❌ |
 | `top_p_sampling_from_probs_v160000` | sampling | ❌ |

--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -487,12 +487,13 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `mla_paged_decode_h8_ckv512_kpe64_ps64` | mla_paged TP=8 | ❌ |
 | `mla_ragged_prefill_causal_h8_qk192_vo128` | mla_ragged | ❌ |
 | `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e384_h7168_i2048` | moe EP=1 | 🟡 |
+| `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048` | moe EP=8 | ✅ |
 | `moe_fp8_block_scale_ds_routing_topk8_ng?_kg?_e96_h7168_i2048` | moe EP=4 | ❌ |
 | `top_k_sampling_from_probs_v160000` | sampling | ❌ |
 | `top_k_top_p_sampling_from_probs_v160000` | sampling | ❌ |
 | `top_p_sampling_from_probs_v160000` | sampling | ❌ |
 
-**Coverage**: 5 / 14 definitions present. RMSNorm definitions are shared with DeepSeek V3 (same hidden=7168 and sub-module dims). MoE EP=1 definition added. All MLA defs require new h=8 variants; MoE EP=4 variant (e=96) and sampling (v=160000) still missing.
+**Coverage**: 6 / 15 definitions present. RMSNorm definitions are shared with DeepSeek V3 (same hidden=7168 and sub-module dims). MoE EP=1 and EP=8 definitions added. All MLA defs require new h=8 variants; MoE EP=4 variant (e=96) and sampling (v=160000) still missing.
 
 ---
 

--- a/flashinfer_trace/definitions/moe/moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.json
+++ b/flashinfer_trace/definitions/moe/moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.json
@@ -1,0 +1,159 @@
+{
+  "name": "moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048",
+  "description": "FP8 block-scale MoE (DeepSeek-style). Kimi K2 (EP=8). DeepSeek routing, n_group=1, topk_group=1. 48 local experts per device (384 total / 8 EP).",
+  "op_type": "moe",
+  "tags": [
+    "status:unverified",
+    "model:kimi-k2",
+    "quantization:float8_e4m3fn",
+    "fi_api:flashinfer.fused_moe.trtllm_fp8_block_scale_moe",
+    "ep:8",
+    "tp:8"
+  ],
+  "axes": {
+    "seq_len": {
+      "type": "var",
+      "description": "Number of input tokens."
+    },
+    "num_experts": {
+      "type": "const",
+      "value": 384,
+      "description": "Total number of experts (global)."
+    },
+    "num_local_experts": {
+      "type": "const",
+      "value": 48,
+      "description": "Number of local experts per device (EP=8 \u2192 384/8=48)."
+    },
+    "hidden_size": {
+      "type": "const",
+      "value": 7168,
+      "description": "Hidden dimension size."
+    },
+    "intermediate_size": {
+      "type": "const",
+      "value": 2048,
+      "description": "MoE expert intermediate size."
+    },
+    "gemm1_out_size": {
+      "type": "const",
+      "value": 4096,
+      "description": "Output size of the first GEMM (W13). Should be 2 * intermediate_size."
+    },
+    "top_k": {
+      "type": "const",
+      "value": 8,
+      "description": "Number of experts selected per token."
+    },
+    "num_hidden_blocks": {
+      "type": "const",
+      "value": 56,
+      "description": "Number of quantized blocks along hidden_size (block_size=128, 7168/128=56)."
+    },
+    "num_intermediate_blocks": {
+      "type": "const",
+      "value": 16,
+      "description": "Number of quantized blocks along intermediate_size (block_size=128, 2048/128=16)."
+    },
+    "num_gemm1_out_blocks": {
+      "type": "const",
+      "value": 32,
+      "description": "Number of quantized blocks along gemm1_out_size (block_size=128, 4096/128=32)."
+    }
+  },
+  "inputs": {
+    "routing_logits": {
+      "shape": [
+        "seq_len",
+        "num_experts"
+      ],
+      "dtype": "float32",
+      "description": "Router logits."
+    },
+    "routing_bias": {
+      "shape": [
+        "num_experts"
+      ],
+      "dtype": "bfloat16",
+      "description": "Routing bias added to sigmoid scores."
+    },
+    "hidden_states": {
+      "shape": [
+        "seq_len",
+        "hidden_size"
+      ],
+      "dtype": "float8_e4m3fn",
+      "description": "Input hidden states (FP8 block-scale quantized)."
+    },
+    "hidden_states_scale": {
+      "shape": [
+        "num_hidden_blocks",
+        "seq_len"
+      ],
+      "dtype": "float32",
+      "description": "Block scales for hidden_states, shape [num_hidden_blocks, seq_len] (transposed)."
+    },
+    "gemm1_weights": {
+      "shape": [
+        "num_local_experts",
+        "gemm1_out_size",
+        "hidden_size"
+      ],
+      "dtype": "float8_e4m3fn",
+      "description": "FC1 weights (gate+up), FP8 block-scale."
+    },
+    "gemm1_weights_scale": {
+      "shape": [
+        "num_local_experts",
+        "num_gemm1_out_blocks",
+        "num_hidden_blocks"
+      ],
+      "dtype": "float32",
+      "description": "Block scales for gemm1_weights."
+    },
+    "gemm2_weights": {
+      "shape": [
+        "num_local_experts",
+        "hidden_size",
+        "intermediate_size"
+      ],
+      "dtype": "float8_e4m3fn",
+      "description": "FC2 weights (down), FP8 block-scale."
+    },
+    "gemm2_weights_scale": {
+      "shape": [
+        "num_local_experts",
+        "num_hidden_blocks",
+        "num_intermediate_blocks"
+      ],
+      "dtype": "float32",
+      "description": "Block scales for gemm2_weights."
+    },
+    "local_expert_offset": {
+      "shape": null,
+      "dtype": "int32",
+      "description": "Offset of local experts in global expert space (0, 48, 96, ... for each EP rank)."
+    },
+    "routed_scaling_factor": {
+      "shape": null,
+      "dtype": "float32",
+      "description": "Scaling factor for routing weights."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "seq_len",
+        "hidden_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Final MoE output tensor."
+    }
+  },
+  "constraints": [
+    "gemm1_weights.shape[1] == 2 * intermediate_size",
+    "gemm2_weights.shape[1] == hidden_size",
+    "gemm2_weights.shape[2] == intermediate_size"
+  ],
+  "reference": "import torch\n\n\n@torch.no_grad()\ndef run(\n    routing_logits: torch.Tensor,\n    routing_bias: torch.Tensor,\n    hidden_states: torch.Tensor,\n    hidden_states_scale: torch.Tensor,\n    gemm1_weights: torch.Tensor,\n    gemm1_weights_scale: torch.Tensor,\n    gemm2_weights: torch.Tensor,\n    gemm2_weights_scale: torch.Tensor,\n    local_expert_offset: int,\n    routed_scaling_factor: float,\n):\n    \"\"\"\n    FP8 block-scale MoE reference \u2014 DeepSeek routing (routing_method_type=2),\n    n_group=1, topk_group=1 (no group selection, direct top-k).\n    Routing: sigmoid(logits) + bias -> Top-K -> normalize s_nobias -> * rsf.\n    FP8 block-scale dequantization: float \u2248 fp8 * scale (block size = 128).\n    Activation: SwiGLU.\n    \"\"\"\n    E_global = 384\n    H = 7168\n    I = 2048\n    TOP_K = 8\n    BLOCK = 128\n\n    T = routing_logits.shape[0]\n    E_local = gemm1_weights.shape[0]  # 48 for EP=8\n    device = routing_logits.device\n\n    num_h_blocks = H // BLOCK\n    num_i_blocks = I // BLOCK\n\n    # 1) FP8 block-scale dequantization of hidden_states\n    A_fp32 = hidden_states.to(torch.float32)\n    A_scale = hidden_states_scale.to(torch.float32)            # [H/128, T]\n    A_scale_TH = A_scale.permute(1, 0).contiguous()           # [T, H/128]\n    A = (A_fp32.view(T, num_h_blocks, BLOCK) *\n         A_scale_TH.unsqueeze(-1)).view(T, H)\n\n    # 2) DeepSeek routing (ng=1, kg=1 => direct top-k)\n    logits = routing_logits.to(torch.float32)\n    bias = routing_bias.to(torch.float32).reshape(-1)\n    s = torch.sigmoid(logits)                                  # [T, E] no bias\n    s_with_bias = s + bias                                     # [T, E]\n    _, topk_idx = torch.topk(s_with_bias, k=TOP_K, dim=-1)   # [T, K]\n\n    # Combination weights: normalize s (without bias) over selected experts\n    M = torch.zeros_like(s)\n    M.scatter_(1, topk_idx, 1.0)\n    weights = s * M\n    weights_sum = weights.sum(dim=-1, keepdim=True).clamp(min=1e-20)\n    weights = weights / weights_sum * routed_scaling_factor    # [T, E]\n\n    # 3) Local expert computation (per-expert dequant to keep peak memory low)\n    output = torch.zeros(T, H, dtype=torch.float32, device=device)\n    local_start = int(local_expert_offset)\n    for le in range(E_local):\n        ge = local_start + le\n        sel_mask = (topk_idx == ge).any(dim=1)\n        if not sel_mask.any():\n            continue\n        tok_idx = torch.nonzero(sel_mask, as_tuple=False).squeeze(1)\n        A_e = A.index_select(0, tok_idx)\n        W13_e = (gemm1_weights[le].to(torch.float32).view(\n            2 * num_i_blocks, BLOCK, num_h_blocks, BLOCK\n        ) * gemm1_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(2 * I, H)\n        g1 = A_e @ W13_e.t()\n        up, gate = g1[:, :I], g1[:, I:]\n        c = torch.nn.functional.silu(gate) * up\n        W2_e = (gemm2_weights[le].to(torch.float32).view(\n            num_h_blocks, BLOCK, num_i_blocks, BLOCK\n        ) * gemm2_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(H, I)\n        o = c @ W2_e.t()\n        w_tok = weights[tok_idx, ge].unsqueeze(1)\n        output.index_add_(0, tok_idx, o * w_tok)\n\n    return output.to(torch.bfloat16)"
+}

--- a/flashinfer_trace/definitions/moe/moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.json
+++ b/flashinfer_trace/definitions/moe/moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.json
@@ -3,7 +3,7 @@
   "description": "FP8 block-scale MoE (DeepSeek-style). Kimi K2 (EP=8). DeepSeek routing, n_group=1, topk_group=1. 48 local experts per device (384 total / 8 EP).",
   "op_type": "moe",
   "tags": [
-    "status:unverified",
+    "status:verified",
     "model:kimi-k2",
     "quantization:float8_e4m3fn",
     "fi_api:flashinfer.fused_moe.trtllm_fp8_block_scale_moe",

--- a/flashinfer_trace/tests/references/test_moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.py
+++ b/flashinfer_trace/tests/references/test_moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.py
@@ -93,16 +93,18 @@ def run(
         tok_idx = torch.nonzero(sel_mask, as_tuple=False).squeeze(1)
         A_e = A.index_select(0, tok_idx)
 
-        W13_e = (gemm1_weights[le].to(torch.float32).view(
-            2 * num_i_blocks, BLOCK, num_h_blocks, BLOCK
-        ) * gemm1_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(2 * I, H)
+        W13_e = (
+            gemm1_weights[le].to(torch.float32).view(2 * num_i_blocks, BLOCK, num_h_blocks, BLOCK)
+            * gemm1_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)
+        ).view(2 * I, H)
         g1 = A_e @ W13_e.t()
         up, gate = g1[:, :I], g1[:, I:]
         c = torch.nn.functional.silu(gate) * up
 
-        W2_e = (gemm2_weights[le].to(torch.float32).view(
-            num_h_blocks, BLOCK, num_i_blocks, BLOCK
-        ) * gemm2_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(H, I)
+        W2_e = (
+            gemm2_weights[le].to(torch.float32).view(num_h_blocks, BLOCK, num_i_blocks, BLOCK)
+            * gemm2_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)
+        ).view(H, I)
         o = c @ W2_e.t()
         w_tok = weights[tok_idx, ge].unsqueeze(1)
         output.index_add_(0, tok_idx, o * w_tok)
@@ -159,7 +161,9 @@ def generate_random_inputs(seq_len: int, local_expert_offset: int = 0, device: s
     }
 
 
-def test_correctness(seq_len: int = 4, local_expert_offset: int = 0, atol: float = 0.5, rtol: float = 0.1):
+def test_correctness(
+    seq_len: int = 4, local_expert_offset: int = 0, atol: float = 0.5, rtol: float = 0.1
+):
     print(f"\n{'='*60}")
     print(f"Testing MoE FP8 e48 (Kimi K2 EP=8), T={seq_len}, offset={local_expert_offset}")
     print(f"{'='*60}")

--- a/flashinfer_trace/tests/references/test_moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.py
+++ b/flashinfer_trace/tests/references/test_moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048.py
@@ -1,0 +1,242 @@
+import torch
+from flashinfer.fused_moe import trtllm_fp8_block_scale_moe
+
+# Kimi K2 EP=8: E_global=384, E_local=48 (384/8), H=7168, I=2048, topk=8, ng=1, kg=1
+E_GLOBAL = 384
+E_LOCAL = 48
+H = 7168
+I = 2048
+TOP_K = 8
+N_GROUP = 1
+TOPK_GROUP = 1
+BLOCK = 128
+ROUTED_SCALING_FACTOR = 2.5
+
+
+def _fp8_block_quant_1d(x_bf16: torch.Tensor, block: int = 128):
+    """Quantize [T, H] activations to FP8 with per-(token, block) scales."""
+    assert x_bf16.dim() == 2
+    T, Hx = x_bf16.shape
+    assert Hx % block == 0
+    nb = Hx // block
+    max_fp8 = torch.finfo(torch.float8_e4m3fn).max
+    x_f32 = x_bf16.to(torch.float32)
+    x_blocked = x_f32.view(T, nb, block)
+    amax = torch.amax(torch.abs(x_blocked), dim=2)
+    scales = torch.where(amax > 0, amax / max_fp8, torch.ones_like(amax))
+    x_fp8 = (x_blocked / scales.unsqueeze(2)).view(T, Hx).to(torch.float8_e4m3fn)
+    return x_fp8, scales  # scales: [T, H/128]
+
+
+def _fp8_block_quant_2d(w_bf16: torch.Tensor, block: int = 128):
+    """Quantize weights [R, C] to FP8 with per-block scales [R/128, C/128]."""
+    R, C = w_bf16.shape
+    assert R % block == 0 and C % block == 0
+    nr, nc = R // block, C // block
+    max_fp8 = torch.finfo(torch.float8_e4m3fn).max
+    w_f32 = w_bf16.to(torch.float32).view(nr, block, nc, block)
+    amax = torch.amax(torch.abs(w_f32), dim=(1, 3))  # [nr, nc]
+    scales = torch.where(amax > 0, amax / max_fp8, torch.ones_like(amax))
+    w_fp8 = (w_f32 / scales[:, None, :, None]).view(R, C).to(torch.float8_e4m3fn)
+    return w_fp8, scales  # scales: [nr, nc]
+
+
+@torch.no_grad()
+def run(
+    routing_logits,
+    routing_bias,
+    hidden_states,
+    hidden_states_scale,
+    gemm1_weights,
+    gemm1_weights_scale,
+    gemm2_weights,
+    gemm2_weights_scale,
+    local_expert_offset,
+    routed_scaling_factor,
+):
+    """
+    FP8 block-scale MoE reference — DeepSeek routing (ng=1, kg=1 => direct top-k).
+    E_local=48 for EP=8 on 8xB200 (384/8=48 local experts per GPU).
+    """
+    T = routing_logits.shape[0]
+    E_local = gemm1_weights.shape[0]  # 48
+    num_h_blocks = H // BLOCK
+    num_i_blocks = I // BLOCK
+    device = routing_logits.device
+
+    # Dequantize hidden_states: hidden_states_scale is [H/128, T]
+    A_fp32 = hidden_states.to(torch.float32)
+    A_scale_TH = hidden_states_scale.permute(1, 0).contiguous()  # [T, H/128]
+    A = (A_fp32.view(T, num_h_blocks, BLOCK) * A_scale_TH.unsqueeze(-1)).view(T, H)
+
+    # DeepSeek routing (ng=1, kg=1 => direct top-k, no group selection)
+    logits = routing_logits.to(torch.float32)
+    bias = routing_bias.to(torch.float32).reshape(-1)
+    s = torch.sigmoid(logits)
+    s_with_bias = s + bias
+    _, topk_idx = torch.topk(s_with_bias, k=TOP_K, dim=-1)  # [T, K]
+
+    M = torch.zeros_like(s)
+    M.scatter_(1, topk_idx, 1.0)
+    weights = s * M
+    weights_sum = weights.sum(dim=-1, keepdim=True).clamp(min=1e-20)
+    weights = weights / weights_sum * routed_scaling_factor
+
+    # Local expert computation
+    output = torch.zeros(T, H, dtype=torch.float32, device=device)
+    local_start = int(local_expert_offset)
+    for le in range(E_local):
+        ge = local_start + le
+        sel_mask = (topk_idx == ge).any(dim=1)
+        if not sel_mask.any():
+            continue
+        tok_idx = torch.nonzero(sel_mask, as_tuple=False).squeeze(1)
+        A_e = A.index_select(0, tok_idx)
+
+        W13_e = (gemm1_weights[le].to(torch.float32).view(
+            2 * num_i_blocks, BLOCK, num_h_blocks, BLOCK
+        ) * gemm1_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(2 * I, H)
+        g1 = A_e @ W13_e.t()
+        up, gate = g1[:, :I], g1[:, I:]
+        c = torch.nn.functional.silu(gate) * up
+
+        W2_e = (gemm2_weights[le].to(torch.float32).view(
+            num_h_blocks, BLOCK, num_i_blocks, BLOCK
+        ) * gemm2_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(H, I)
+        o = c @ W2_e.t()
+        w_tok = weights[tok_idx, ge].unsqueeze(1)
+        output.index_add_(0, tok_idx, o * w_tok)
+
+    return output.to(torch.bfloat16)
+
+
+def generate_random_inputs(seq_len: int, local_expert_offset: int = 0, device: str = "cuda"):
+    """Generate random FP8-quantized MoE inputs for E_local=48."""
+    T = seq_len
+    num_i_blocks = I // BLOCK
+    num_h_blocks = H // BLOCK
+
+    routing_logits = torch.randn(T, E_GLOBAL, dtype=torch.float32, device=device)
+    routing_bias = torch.randn(E_GLOBAL, dtype=torch.bfloat16, device=device)
+
+    a_bf16 = 2.0 * torch.randn(T, H, dtype=torch.bfloat16, device=device)
+    a_fp8, a_scales = _fp8_block_quant_1d(a_bf16)
+    hidden_states = a_fp8
+    hidden_states_scale = a_scales.transpose(0, 1).contiguous()  # [H/128, T]
+    del a_bf16, a_scales
+
+    # Pre-allocate weight tensors (FP8) for E_LOCAL=48
+    w13_fp8 = torch.empty(E_LOCAL, 2 * I, H, dtype=torch.float8_e4m3fn, device=device)
+    w13_scales = torch.empty(E_LOCAL, 2 * num_i_blocks, num_h_blocks, device=device)
+    w2_fp8 = torch.empty(E_LOCAL, H, I, dtype=torch.float8_e4m3fn, device=device)
+    w2_scales = torch.empty(E_LOCAL, num_h_blocks, num_i_blocks, device=device)
+
+    for e in range(E_LOCAL):
+        w13_e = torch.randn(2 * I, H, dtype=torch.bfloat16, device=device) * 0.01
+        fp8_e, sc_e = _fp8_block_quant_2d(w13_e)
+        w13_fp8[e] = fp8_e
+        w13_scales[e] = sc_e
+        del w13_e, fp8_e, sc_e
+
+        w2_e = torch.randn(H, I, dtype=torch.bfloat16, device=device) * 0.01
+        fp8_e, sc_e = _fp8_block_quant_2d(w2_e)
+        w2_fp8[e] = fp8_e
+        w2_scales[e] = sc_e
+        del w2_e, fp8_e, sc_e
+
+    return {
+        "routing_logits": routing_logits,
+        "routing_bias": routing_bias,
+        "hidden_states": hidden_states,
+        "hidden_states_scale": hidden_states_scale,
+        "gemm1_weights": w13_fp8,
+        "gemm1_weights_scale": w13_scales,
+        "gemm2_weights": w2_fp8,
+        "gemm2_weights_scale": w2_scales,
+        "local_expert_offset": local_expert_offset,
+        "local_num_experts": E_LOCAL,
+        "routed_scaling_factor": ROUTED_SCALING_FACTOR,
+    }
+
+
+def test_correctness(seq_len: int = 4, local_expert_offset: int = 0, atol: float = 0.5, rtol: float = 0.1):
+    print(f"\n{'='*60}")
+    print(f"Testing MoE FP8 e48 (Kimi K2 EP=8), T={seq_len}, offset={local_expert_offset}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return True
+
+    inputs = generate_random_inputs(seq_len, local_expert_offset, device)
+
+    # Reference
+    ref_out = run(
+        inputs["routing_logits"],
+        inputs["routing_bias"],
+        inputs["hidden_states"],
+        inputs["hidden_states_scale"],
+        inputs["gemm1_weights"],
+        inputs["gemm1_weights_scale"],
+        inputs["gemm2_weights"],
+        inputs["gemm2_weights_scale"],
+        inputs["local_expert_offset"],
+        inputs["routed_scaling_factor"],
+    )
+
+    # FlashInfer
+    try:
+        fi_out = trtllm_fp8_block_scale_moe(
+            routing_logits=inputs["routing_logits"],
+            routing_bias=inputs["routing_bias"],
+            hidden_states=inputs["hidden_states"],
+            hidden_states_scale=inputs["hidden_states_scale"],
+            gemm1_weights=inputs["gemm1_weights"],
+            gemm1_weights_scale=inputs["gemm1_weights_scale"].to(torch.float32),
+            gemm2_weights=inputs["gemm2_weights"],
+            gemm2_weights_scale=inputs["gemm2_weights_scale"].to(torch.float32),
+            num_experts=E_GLOBAL,
+            top_k=TOP_K,
+            n_group=N_GROUP,
+            topk_group=TOPK_GROUP,
+            intermediate_size=I,
+            local_expert_offset=inputs["local_expert_offset"],
+            local_num_experts=inputs["local_num_experts"],
+            routed_scaling_factor=inputs["routed_scaling_factor"],
+            routing_method_type=2,  # DeepSeek-V3 routing
+            use_shuffled_weight=False,
+            tune_max_num_tokens=max(8, min(seq_len * TOP_K, 8192)),
+        )
+    except Exception as e:
+        print(f"  FlashInfer call failed: {e}")
+        return False
+
+    abs_diff = torch.abs(ref_out.float() - fi_out.float())
+    all_close = torch.allclose(ref_out.float(), fi_out.float(), atol=atol, rtol=rtol)
+
+    if all_close:
+        print(f"✓ PASSED max_abs_diff={abs_diff.max().item():.4e} (atol={atol}, rtol={rtol})")
+    else:
+        print(f"✗ FAILED max_abs_diff={abs_diff.max().item():.4e} (atol={atol}, rtol={rtol})")
+
+    return all_close
+
+
+def main():
+    print("Testing MoE FP8 block-scale ds-routing topk8 ng1 kg1 e48 h7168 i2048 (Kimi K2 EP=8)")
+
+    test_configs = [(1, 0), (4, 0), (8, 48), (16, 0), (32, 96)]
+    passed = sum(1 for T, offset in test_configs if test_correctness(T, offset))
+    total = len(test_configs)
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    if passed == total:
+        print("✓ All tests passed!")
+    else:
+        print(f"✗ {total - passed} tests failed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add definition JSON for `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048` (`moe` op_type)
- Add reference test with 5/5 correctness tests passing against FlashInfer ground truth
- Update `docs/model_coverage.mdx`: add EP=8 row and mark definition as ✅

## Kernel Details

| Field | Value |
|-------|-------|
| Definition name | `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e48_h7168_i2048` |
| Op type | `moe` |
| Model | Kimi K2 (EP=8) |
| `num_experts` (global) | 384 |
| `num_local_experts` | 48 (384 total / EP=8) |
| `hidden_size` | 7168 |
| `intermediate_size` | 2048 |
| `top_k` | 8 |
| `n_group` | 1 |
| `topk_group` | 1 |
| Routing | DeepSeek-V3 style (`routing_method_type=2`) |
| Quantization | FP8 block-scale (`float8_e4m3fn`, block=128) |
| FlashInfer API | `flashinfer.fused_moe.trtllm_fp8_block_scale_moe` |

## Reference Test Output

```
Testing MoE FP8 block-scale ds-routing topk8 ng1 kg1 e48 h7168 i2048 (Kimi K2 EP=8)

============================================================
Testing MoE FP8 e48 (Kimi K2 EP=8), T=1, offset=0
============================================================
✓ PASSED max_abs_diff=5.7617e-02 (atol=0.5, rtol=0.1)

============================================================
Testing MoE FP8 e48 (Kimi K2 EP=8), T=4, offset=0
============================================================
✓ PASSED max_abs_diff=8.5938e-02 (atol=0.5, rtol=0.1)

============================================================
Testing MoE FP8 e48 (Kimi K2 EP=8), T=8, offset=48
============================================================
✓ PASSED max_abs_diff=0.0000e+00 (atol=0.5, rtol=0.1)

============================================================
Testing MoE FP8 e48 (Kimi K2 EP=8), T=16, offset=0
============================================================
✓ PASSED max_abs_diff=8.0078e-02 (atol=0.5, rtol=0.1)

============================================================
Testing MoE FP8 e48 (Kimi K2 EP=8), T=32, offset=96
============================================================
✓ PASSED max_abs_diff=0.0000e+00 (atol=0.5, rtol=0.1)

============================================================
Summary: 5/5 tests passed
✓ All tests passed!
```
