### PR TITLE
feat: add DsaTopkIndexerEvaluator for DSA top-k indexer kernels

### DIFF
--- a/flashinfer_bench/bench/evaluators/__init__.py
+++ b/flashinfer_bench/bench/evaluators/__init__.py
@@ -2,6 +2,7 @@
 
 from .default import DefaultEvaluator
 from .dsa_sparse_attention import DsaSparseAttentionEvaluator
+from .dsa_topk_indexer import DsaTopkIndexerEvaluator
 from .lowbit import LowBitEvaluator
 from .registry import resolve_evaluator
 from .sampling import SamplingEvaluator
@@ -9,6 +10,7 @@ from .sampling import SamplingEvaluator
 __all__ = [
     "DefaultEvaluator",
     "DsaSparseAttentionEvaluator",
+    "DsaTopkIndexerEvaluator",
     "LowBitEvaluator",
     "SamplingEvaluator",
     "resolve_evaluator",

--- a/flashinfer_bench/bench/evaluators/dsa_topk_indexer.py
+++ b/flashinfer_bench/bench/evaluators/dsa_topk_indexer.py
@@ -1,0 +1,433 @@
+"""Evaluator for DSA top-k indexer kernels using sorted-score comparison."""
+
+from __future__ import annotations
+
+import sys
+import time
+import traceback
+import uuid as uuid_mod
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+import torch
+from typing_extensions import override
+
+from flashinfer_bench.bench.config import BenchmarkConfig
+from flashinfer_bench.bench.runner.runner import BaselineHandle, DeviceBaseline
+from flashinfer_bench.bench.timing import time_runnable
+from flashinfer_bench.bench.utils import gen_inputs, load_safetensors, make_eval
+from flashinfer_bench.compile import BuilderRegistry, Runnable
+from flashinfer_bench.data import Correctness, Definition, Evaluation, EvaluationStatus, Workload
+
+from .default import DefaultEvaluator
+from .utils import allocate_outputs, normalize_result
+
+
+def _dequant_all_pages(k_cache_fp8: torch.Tensor) -> torch.Tensor:
+    """Dequantize all pages from deep_gemm FP8 packed layout.
+
+    Input:  [num_pages, page_size, 1, head_dim+4] int8
+    Output: [num_pages, page_size, head_dim] float32
+
+    The packed layout stores fp8 data first, then per-token float32 scales,
+    at the page level (not per-token).
+    """
+    k_uint8 = k_cache_fp8.view(torch.uint8)
+    num_pages, page_size, _, head_dim_with_scale = k_uint8.shape
+    head_dim = head_dim_with_scale - 4
+    flat = k_uint8.view(num_pages, page_size * head_dim_with_scale)
+    fp8_data = (
+        flat[:, : page_size * head_dim]
+        .contiguous()
+        .view(num_pages, page_size, head_dim)
+        .view(torch.float8_e4m3fn)
+        .float()
+    )
+    scale = (
+        flat[:, page_size * head_dim :]
+        .contiguous()
+        .view(num_pages, page_size, 4)
+        .view(torch.float32)
+    )
+    return fp8_data * scale
+
+
+def _compute_scores_at_indices(
+    indices: torch.Tensor,
+    k_all: torch.Tensor,
+    q_fp8: torch.Tensor,
+    weights: torch.Tensor,
+    page_size: int,
+) -> torch.Tensor:
+    """Compute weighted ReLU scores at given global token indices.
+
+    All operations are batched — no Python loop over the batch dimension.
+
+    Input:
+      indices:  [B, N] int32, global page indices, -1 = padding
+      k_all:    [num_pages, page_size, D] float32
+      q_fp8:    [B, H, D] float8_e4m3fn
+      weights:  [B, H] float32
+    Output:
+      scores:   [B, N] float32
+    """
+    valid_mask = indices >= 0
+    safe = indices.clamp(min=0).long()
+    page_id = safe // page_size
+    offset = safe % page_size
+    k_gathered = k_all[page_id, offset]  # [B, N, D]
+    q_f32 = q_fp8.float()  # [B, H, D]
+    per_head = torch.bmm(q_f32, k_gathered.transpose(1, 2))  # [B, H, N]
+    per_head = torch.relu(per_head)
+    scores = (per_head * weights.unsqueeze(2)).sum(dim=1)  # [B, N]
+    scores[~valid_mask] = float("-inf")
+    return scores
+
+
+def _validate_indices(
+    indices: torch.Tensor,
+    num_pages: int,
+    page_size: int,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Vectorized index validity check: reachability and duplicates.
+
+    Uses [B, K, M] broadcasting instead of [B, num_pages*page_size] dense mask.
+
+    Input:
+      indices: [B, K] int32
+      seq_lens: [B] int32
+      block_table: [B, M] int32  (M = max_num_pages per sequence)
+    Output: out_of_range [B] bool, has_dup [B] bool
+    """
+    valid_mask = indices >= 0
+    safe = indices.clamp(min=0).long()
+
+    index_page_id = safe // page_size  # [B, K]
+    index_offset = safe % page_size  # [B, K]
+
+    # Check page membership: [B, K, 1] == [B, 1, M] -> [B, K, M]
+    page_match = index_page_id.unsqueeze(2) == block_table.long().unsqueeze(1)
+    matched_slot = page_match.any(dim=2)  # [B, K] — page found in block_table
+
+    # Which slot matched (argmax gives first match), used for offset range check
+    slot_idx = page_match.long().argmax(dim=2)  # [B, K]
+    token_position = slot_idx * page_size + index_offset  # [B, K] position within seq
+    within_seq = token_position < seq_lens.unsqueeze(1)  # [B, K]
+
+    reachable = matched_slot & within_seq
+    out_of_range = (valid_mask & ~reachable).any(dim=1)
+
+    # Duplicate check
+    sorted_idx = indices.sort(dim=1).values
+    consecutive_eq = sorted_idx[:, 1:] == sorted_idx[:, :-1]
+    valid_pair = sorted_idx[:, 1:] >= 0
+    has_dup = (consecutive_eq & valid_pair).any(dim=1)
+    return out_of_range, has_dup
+
+
+def _compute_sorted_score_error_stats(
+    output: torch.Tensor, reference: torch.Tensor, cfg: BenchmarkConfig
+) -> Tuple[float, float, bool, float]:
+    """Compute score error stats while ignoring shared padding sentinels.
+
+    DSA top-k outputs use `-1` padding. After score reconstruction and sorting,
+    both reference and solution contain trailing `-inf` sentinels for those
+    padded slots. Those positions should count as matched rather than producing
+    `nan` through `-inf - -inf`.
+    """
+    x = output.to(torch.float32)
+    y = reference.to(torch.float32)
+
+    shared_nonfinite_mask = (torch.isnan(x) & torch.isnan(y)) | (
+        torch.isinf(x) & torch.isinf(y) & (torch.signbit(x) == torch.signbit(y))
+    )
+    finite_mask = torch.isfinite(x) & torch.isfinite(y)
+    invalid_mismatch_mask = (~shared_nonfinite_mask) & (~finite_mask)
+
+    eps = 1e-8
+    abs_error = torch.zeros_like(x)
+    rel_error = torch.zeros_like(x)
+    abs_error[finite_mask] = torch.abs(x[finite_mask] - y[finite_mask])
+    rel_error[finite_mask] = abs_error[finite_mask] / (torch.abs(y[finite_mask]) + eps)
+
+    total_elements = x.numel()
+    if total_elements == 0:
+        return 0.0, 0.0, False, 1.0
+
+    required_matched_ratio = (
+        cfg.required_matched_ratio if cfg.required_matched_ratio is not None else 1.0
+    )
+    exceeds_tol_mask = invalid_mismatch_mask | (
+        finite_mask & (abs_error > cfg.atol) & (rel_error > cfg.rtol)
+    )
+    exceeds_count = float(exceeds_tol_mask.sum().item())
+    matched_ratio = 1.0 - (exceeds_count / float(total_elements))
+    matched_ratio = max(0.0, min(1.0, matched_ratio))
+    exceeds_tol = matched_ratio < required_matched_ratio
+
+    max_abs = float(abs_error.max().item()) if finite_mask.any().item() else 0.0
+    max_rel = float(rel_error.max().item()) if finite_mask.any().item() else 0.0
+    if invalid_mismatch_mask.any().item():
+        max_abs = float("inf")
+        max_rel = float("inf")
+    return max_abs, max_rel, exceeds_tol, matched_ratio
+
+
+def _pack_fp8_k_cache(
+    key_cache_bfloat16: torch.Tensor, page_size: int, head_dim: int
+) -> torch.Tensor:
+    """Pack bfloat16 key cache into deep_gemm FP8 format.
+
+    Input:  [num_pages, page_size, 1, head_dim] bfloat16
+    Output: [num_pages, page_size, 1, head_dim+4] int8
+    """
+    absolute_max = key_cache_bfloat16.abs().float().amax(dim=3, keepdim=True).clamp(1e-4)
+    scale = absolute_max / 448.0
+    fp8_data = (key_cache_bfloat16 * (1.0 / scale)).to(torch.float8_e4m3fn)
+
+    num_pages = key_cache_bfloat16.shape[0]
+    packed = torch.empty(
+        num_pages, page_size * (head_dim + 4), device=key_cache_bfloat16.device, dtype=torch.uint8
+    )
+    packed[:, : page_size * head_dim] = fp8_data.view(num_pages, page_size * head_dim).view(
+        torch.uint8
+    )
+    packed[:, page_size * head_dim :] = scale.view(num_pages, page_size).view(torch.uint8)
+    return packed.view(num_pages, page_size, 1, head_dim + 4).view(torch.int8)
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+class DsaTopkIndexerEvaluator(DefaultEvaluator):
+    @override
+    @classmethod
+    def can_evaluate(cls, definition: Definition) -> bool:
+        return definition.name.startswith("dsa_topk_indexer")
+
+    @override
+    @classmethod
+    def build_baseline(
+        cls,
+        definition: Definition,
+        workload: Workload,
+        cfg: BenchmarkConfig,
+        device: str,
+        trace_set_root: Optional[Path] = None,
+    ) -> DeviceBaseline:
+        ref_runnable = BuilderRegistry.get_instance().build_reference(definition)
+        loaded_safe_tensors = (
+            load_safetensors(definition, workload, trace_set_root)
+            if any(d.type == "safetensors" for d in workload.inputs.values())
+            else {}
+        )
+
+        page_size = definition.axes["page_size"].value
+        head_dim = definition.axes["index_head_dim"].value
+        input_names = list(definition.inputs.keys())
+        k_cache_idx = input_names.index("k_index_cache_fp8")
+        k_cache_is_random = (
+            "k_index_cache_fp8" in workload.inputs
+            and workload.inputs["k_index_cache_fp8"].type == "random"
+        )
+
+        inputs: List[List[Any]] = []
+        outputs: List[List[torch.Tensor]] = []
+        dev = torch.device(device)
+
+        for _ in range(cfg.num_trials):
+            inp = gen_inputs(definition, workload, device=device, safe_tensors=loaded_safe_tensors)
+
+            if k_cache_is_random:
+                num_pages = inp[k_cache_idx].shape[0]
+                k_bf16 = torch.randn(
+                    num_pages, page_size, 1, head_dim, dtype=torch.bfloat16, device=dev
+                )
+                inp[k_cache_idx] = _pack_fp8_k_cache(k_bf16, page_size, head_dim)
+
+            inputs.append(inp)
+            with torch.no_grad():
+                result = ref_runnable(*inp)
+            torch.cuda.synchronize(device)
+            outputs.append(normalize_result(definition, result, device))
+
+        if cfg.profile_baseline:
+            latencies: List[float] = []
+            for inp in inputs:
+                ms = time_runnable(ref_runnable, inp, cfg.warmup_runs, cfg.iterations, device)
+                latencies.append(ms)
+            mean_latency_ms = sum(latencies) / float(len(latencies))
+        else:
+            mean_latency_ms = 0.0
+
+        handle = BaselineHandle(uuid_mod.uuid4().hex)
+        return DeviceBaseline(
+            handle=handle,
+            definition=definition,
+            device=device,
+            inputs=inputs,
+            outputs=outputs,
+            mean_latency_ms=mean_latency_ms,
+        )
+
+    @override
+    @classmethod
+    def check_correctness(
+        cls,
+        definition: Definition,
+        sol_runnable: Runnable,
+        inputs: List[List[Any]],
+        ref_outputs: List[List[torch.Tensor]],
+        cfg: BenchmarkConfig,
+        log_path: str,
+        device: str,
+    ) -> Tuple[Optional[Correctness], Optional[Evaluation]]:
+        max_abs = 0.0
+        max_rel = 0.0
+        numerical_incorrect = False
+        is_dps = sol_runnable.metadata.destination_passing_style
+
+        page_size = definition.axes["page_size"].value
+        topk = definition.axes["topk"].value
+
+        for trial, inp in enumerate(inputs):
+            _log(f"[dsa_topk_indexer] trial {trial}:")
+
+            # --- run solution ---
+            t0 = time.perf_counter()
+            try:
+                if is_dps:
+                    out = allocate_outputs(definition, inp, device)
+                    with torch.no_grad():
+                        sol_runnable(*inp, *out)
+                    torch.cuda.synchronize(device)
+                else:
+                    with torch.no_grad():
+                        result = sol_runnable(*inp)
+                    torch.cuda.synchronize(device)
+                    out = normalize_result(definition, result, device)
+            except Exception:
+                traceback.print_exc()
+                return None, make_eval(
+                    status=EvaluationStatus.RUNTIME_ERROR, device=device, log_path=log_path
+                )
+            t1 = time.perf_counter()
+            _log(f"  run_solution:     {(t1 - t0) * 1000:.2f} ms")
+
+            sol_indices = out[0]
+            ref_indices = ref_outputs[trial][0]
+
+            if tuple(sol_indices.shape) != tuple(ref_indices.shape):
+                return None, make_eval(
+                    status=EvaluationStatus.INCORRECT_SHAPE, device=device, log_path=log_path
+                )
+            if sol_indices.dtype != ref_indices.dtype:
+                return None, make_eval(
+                    status=EvaluationStatus.INCORRECT_DTYPE, device=device, log_path=log_path
+                )
+
+            # --- extract inputs ---
+            input_names = list(definition.inputs.keys())
+            inputs_by_name = dict(zip(input_names, inp))
+            q_fp8 = inputs_by_name["q_index_fp8"]
+            k_cache_fp8 = inputs_by_name["k_index_cache_fp8"]
+            weights = inputs_by_name["weights"]
+            seq_lens = inputs_by_name["seq_lens"]
+            block_table = inputs_by_name["block_table"]
+            num_pages = k_cache_fp8.shape[0]
+
+            # --- validate indices ---
+            t0 = time.perf_counter()
+            out_of_range, has_dup = _validate_indices(
+                sol_indices, num_pages, page_size, seq_lens, block_table
+            )
+            torch.cuda.synchronize(device)
+            t1 = time.perf_counter()
+            _log(f"  validate_indices: {(t1 - t0) * 1000:.2f} ms")
+
+            if out_of_range.any().item():
+                bad_batches = out_of_range.nonzero(as_tuple=True)[0].tolist()
+                msg = f"out-of-range indices in batch {bad_batches}"
+                _log(f"  ERROR: {msg}")
+                correctness = Correctness(
+                    max_relative_error=float("inf"), max_absolute_error=float("inf")
+                )
+                return correctness, make_eval(
+                    status=EvaluationStatus.INCORRECT_NUMERICAL,
+                    device=device,
+                    log_path=log_path,
+                    correctness=correctness,
+                    extra_msg=msg,
+                )
+
+            if has_dup.any().item():
+                bad_batches = has_dup.nonzero(as_tuple=True)[0].tolist()
+                msg = f"duplicate indices in batch {bad_batches}"
+                _log(f"  ERROR: {msg}")
+                correctness = Correctness(
+                    max_relative_error=float("inf"), max_absolute_error=float("inf")
+                )
+                return correctness, make_eval(
+                    status=EvaluationStatus.INCORRECT_NUMERICAL,
+                    device=device,
+                    log_path=log_path,
+                    correctness=correctness,
+                    extra_msg=msg,
+                )
+
+            # --- dequant ---
+            t0 = time.perf_counter()
+            k_all = _dequant_all_pages(k_cache_fp8)
+            torch.cuda.synchronize(device)
+            t1 = time.perf_counter()
+            _log(f"  dequant:          {(t1 - t0) * 1000:.2f} ms")
+
+            # --- compute scores (ref+sol combined in one bmm) ---
+            t0 = time.perf_counter()
+            combined = torch.cat([ref_indices, sol_indices], dim=1)
+            all_scores = _compute_scores_at_indices(combined, k_all, q_fp8, weights, page_size)
+            ref_scores, sol_scores = all_scores.split(topk, dim=1)
+            torch.cuda.synchronize(device)
+            t1 = time.perf_counter()
+            _log(f"  compute_scores:   {(t1 - t0) * 1000:.2f} ms")
+
+            # --- sort and compare ---
+            t0 = time.perf_counter()
+            ref_sorted = ref_scores.sort(dim=1, descending=True).values
+            sol_sorted = sol_scores.sort(dim=1, descending=True).values
+            abs_err, rel_err, exceeds_tol, matched_ratio = _compute_sorted_score_error_stats(
+                sol_sorted, ref_sorted, cfg
+            )
+            torch.cuda.synchronize(device)
+            t1 = time.perf_counter()
+            _log(f"  sort_and_compare: {(t1 - t0) * 1000:.2f} ms")
+            _log(
+                f"  result: max_abs={abs_err:.6f} max_rel={rel_err:.6f} "
+                f"matched_ratio={matched_ratio:.4f}"
+            )
+
+            if exceeds_tol:
+                msg = (
+                    f"score mismatch: max_abs={abs_err:.6f} "
+                    f"max_rel={rel_err:.6f} matched_ratio={matched_ratio:.4f}"
+                )
+                _log(f"  ERROR: {msg}")
+                numerical_incorrect = True
+
+            max_abs = max(max_abs, abs_err)
+            max_rel = max(max_rel, rel_err)
+
+        correctness = Correctness(max_relative_error=max_rel, max_absolute_error=max_abs)
+
+        if numerical_incorrect:
+            return correctness, make_eval(
+                status=EvaluationStatus.INCORRECT_NUMERICAL,
+                device=device,
+                log_path=log_path,
+                correctness=correctness,
+            )
+
+        return correctness, None

--- a/flashinfer_bench/bench/evaluators/dsa_topk_indexer.py
+++ b/flashinfer_bench/bench/evaluators/dsa_topk_indexer.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-import time
 import traceback
 import uuid as uuid_mod
 from pathlib import Path
@@ -294,10 +293,6 @@ class DsaTopkIndexerEvaluator(DefaultEvaluator):
         topk = definition.axes["topk"].value
 
         for trial, inp in enumerate(inputs):
-            _log(f"[dsa_topk_indexer] trial {trial}:")
-
-            # --- run solution ---
-            t0 = time.perf_counter()
             try:
                 if is_dps:
                     out = allocate_outputs(definition, inp, device)
@@ -314,8 +309,6 @@ class DsaTopkIndexerEvaluator(DefaultEvaluator):
                 return None, make_eval(
                     status=EvaluationStatus.RUNTIME_ERROR, device=device, log_path=log_path
                 )
-            t1 = time.perf_counter()
-            _log(f"  run_solution:     {(t1 - t0) * 1000:.2f} ms")
 
             sol_indices = out[0]
             ref_indices = ref_outputs[trial][0]
@@ -329,7 +322,6 @@ class DsaTopkIndexerEvaluator(DefaultEvaluator):
                     status=EvaluationStatus.INCORRECT_DTYPE, device=device, log_path=log_path
                 )
 
-            # --- extract inputs ---
             input_names = list(definition.inputs.keys())
             inputs_by_name = dict(zip(input_names, inp))
             q_fp8 = inputs_by_name["q_index_fp8"]
@@ -339,19 +331,14 @@ class DsaTopkIndexerEvaluator(DefaultEvaluator):
             block_table = inputs_by_name["block_table"]
             num_pages = k_cache_fp8.shape[0]
 
-            # --- validate indices ---
-            t0 = time.perf_counter()
             out_of_range, has_dup = _validate_indices(
                 sol_indices, num_pages, page_size, seq_lens, block_table
             )
-            torch.cuda.synchronize(device)
-            t1 = time.perf_counter()
-            _log(f"  validate_indices: {(t1 - t0) * 1000:.2f} ms")
 
             if out_of_range.any().item():
                 bad_batches = out_of_range.nonzero(as_tuple=True)[0].tolist()
                 msg = f"out-of-range indices in batch {bad_batches}"
-                _log(f"  ERROR: {msg}")
+                _log(f"ERROR: {msg}")
                 correctness = Correctness(
                     max_relative_error=float("inf"), max_absolute_error=float("inf")
                 )
@@ -366,7 +353,7 @@ class DsaTopkIndexerEvaluator(DefaultEvaluator):
             if has_dup.any().item():
                 bad_batches = has_dup.nonzero(as_tuple=True)[0].tolist()
                 msg = f"duplicate indices in batch {bad_batches}"
-                _log(f"  ERROR: {msg}")
+                _log(f"ERROR: {msg}")
                 correctness = Correctness(
                     max_relative_error=float("inf"), max_absolute_error=float("inf")
                 )
@@ -378,34 +365,19 @@ class DsaTopkIndexerEvaluator(DefaultEvaluator):
                     extra_msg=msg,
                 )
 
-            # --- dequant ---
-            t0 = time.perf_counter()
             k_all = _dequant_all_pages(k_cache_fp8)
-            torch.cuda.synchronize(device)
-            t1 = time.perf_counter()
-            _log(f"  dequant:          {(t1 - t0) * 1000:.2f} ms")
-
-            # --- compute scores (ref+sol combined in one bmm) ---
-            t0 = time.perf_counter()
             combined = torch.cat([ref_indices, sol_indices], dim=1)
             all_scores = _compute_scores_at_indices(combined, k_all, q_fp8, weights, page_size)
             ref_scores, sol_scores = all_scores.split(topk, dim=1)
-            torch.cuda.synchronize(device)
-            t1 = time.perf_counter()
-            _log(f"  compute_scores:   {(t1 - t0) * 1000:.2f} ms")
 
-            # --- sort and compare ---
-            t0 = time.perf_counter()
             ref_sorted = ref_scores.sort(dim=1, descending=True).values
             sol_sorted = sol_scores.sort(dim=1, descending=True).values
             abs_err, rel_err, exceeds_tol, matched_ratio = _compute_sorted_score_error_stats(
                 sol_sorted, ref_sorted, cfg
             )
-            torch.cuda.synchronize(device)
-            t1 = time.perf_counter()
-            _log(f"  sort_and_compare: {(t1 - t0) * 1000:.2f} ms")
+
             _log(
-                f"  result: max_abs={abs_err:.6f} max_rel={rel_err:.6f} "
+                f"trial {trial}: max_abs={abs_err:.6f} max_rel={rel_err:.6f} "
                 f"matched_ratio={matched_ratio:.4f}"
             )
 
@@ -414,7 +386,7 @@ class DsaTopkIndexerEvaluator(DefaultEvaluator):
                     f"score mismatch: max_abs={abs_err:.6f} "
                     f"max_rel={rel_err:.6f} matched_ratio={matched_ratio:.4f}"
                 )
-                _log(f"  ERROR: {msg}")
+                _log(f"ERROR: {msg}")
                 numerical_incorrect = True
 
             max_abs = max(max_abs, abs_err)

--- a/flashinfer_bench/bench/evaluators/registry.py
+++ b/flashinfer_bench/bench/evaluators/registry.py
@@ -8,13 +8,19 @@ from flashinfer_bench.data import Definition
 
 from .default import DefaultEvaluator
 from .dsa_sparse_attention import DsaSparseAttentionEvaluator
+from .dsa_topk_indexer import DsaTopkIndexerEvaluator
 from .evaluator import Evaluator
 from .lowbit import LowBitEvaluator
 from .sampling import SamplingEvaluator
 
 EvaluatorType = Type[Evaluator]
 
-_EVALUATORS: List[EvaluatorType] = [SamplingEvaluator, LowBitEvaluator, DsaSparseAttentionEvaluator]
+_EVALUATORS: List[EvaluatorType] = [
+    SamplingEvaluator,
+    LowBitEvaluator,
+    DsaSparseAttentionEvaluator,
+    DsaTopkIndexerEvaluator,
+]
 _DEFAULT_EVALUATOR: EvaluatorType = DefaultEvaluator
 
 

--- a/flashinfer_bench/bench/utils.py
+++ b/flashinfer_bench/bench/utils.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+import safetensors.torch as st
 import torch
 
 from flashinfer_bench.bench.config import BenchmarkConfig
@@ -219,11 +220,6 @@ def _ensure_lfs_downloaded(
 def load_safetensors(
     definition: Definition, workload: Workload, trace_set_root: Optional[Path] = None
 ) -> Dict[str, torch.Tensor]:
-    try:
-        import safetensors.torch as st
-    except Exception as e:
-        raise RuntimeError("safetensors is not available in the current environment") from e
-
     shapes_list = definition.get_input_shapes(workload.axes)
     input_names = list(definition.inputs.keys())
     expected = dict(zip(input_names, shapes_list))

--- a/tests/bench/test_dsa_sparse_attention_evaluator.py
+++ b/tests/bench/test_dsa_sparse_attention_evaluator.py
@@ -7,6 +7,7 @@ from flashinfer_bench.bench.config import BenchmarkConfig
 from flashinfer_bench.bench.evaluators import (
     DefaultEvaluator,
     DsaSparseAttentionEvaluator,
+    DsaTopkIndexerEvaluator,
     resolve_evaluator,
 )
 from flashinfer_bench.bench.utils import gen_inputs
@@ -157,7 +158,7 @@ def _make_trial(defn: Definition, device: str):
             _make_dsa_sparse_attention_def("dsa_sparse_attention_h16_ckv512_kpe64_topk2048_ps64"),
             DsaSparseAttentionEvaluator,
         ),
-        (_make_dsa_topk_indexer_def(), DefaultEvaluator),
+        (_make_dsa_topk_indexer_def(), DsaTopkIndexerEvaluator),
     ],
 )
 def test_resolve(definition, expected):

--- a/tests/bench/test_dsa_topk_indexer_evaluator.py
+++ b/tests/bench/test_dsa_topk_indexer_evaluator.py
@@ -1,0 +1,422 @@
+"""Tests for DsaTopkIndexerEvaluator."""
+
+import pytest
+import torch
+
+from flashinfer_bench.bench.config import BenchmarkConfig
+from flashinfer_bench.bench.evaluators import (
+    DefaultEvaluator,
+    DsaSparseAttentionEvaluator,
+    DsaTopkIndexerEvaluator,
+    resolve_evaluator,
+)
+from flashinfer_bench.bench.utils import gen_inputs
+from flashinfer_bench.compile import BuilderRegistry
+from flashinfer_bench.data import (
+    AxisConst,
+    AxisVar,
+    BuildSpec,
+    Definition,
+    EvaluationStatus,
+    RandomInput,
+    Solution,
+    SourceFile,
+    SupportedLanguages,
+    TensorSpec,
+    Workload,
+)
+
+_NUM_HEADS = 8
+_HEAD_DIM = 16
+_PAGE_SIZE = 8
+_TOPK = 16
+_NUM_PAGES = 9
+_HEAD_DIM_WITH_SCALE = _HEAD_DIM + 4
+
+_REFERENCE_CODE = f"""\
+import torch
+
+def run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table):
+    batch_size = q_index_fp8.shape[0]
+    num_heads = {_NUM_HEADS}
+    head_dim = {_HEAD_DIM}
+    page_size = {_PAGE_SIZE}
+    topk = {_TOPK}
+    device = q_index_fp8.device
+
+    # dequant
+    k_uint8 = k_index_cache_fp8.view(torch.uint8)
+    num_pages = k_uint8.shape[0]
+    hds = {_HEAD_DIM_WITH_SCALE}
+    flat = k_uint8.view(num_pages, page_size * hds)
+    fp8 = flat[:, :page_size * head_dim].contiguous().view(num_pages, page_size, head_dim).view(torch.float8_e4m3fn).float()
+    sc = flat[:, page_size * head_dim:].contiguous().view(num_pages, page_size, 4).view(torch.float32)
+    K_all = fp8 * sc
+
+    q = q_index_fp8.float()
+    topk_indices = torch.full((batch_size, topk), -1, dtype=torch.int32, device=device)
+    for b in range(batch_size):
+        sl = int(seq_lens[b].item())
+        if sl == 0:
+            continue
+        npb = (sl + page_size - 1) // page_size
+        pids = block_table[b, :npb].long()
+        K = K_all[pids].reshape(-1, head_dim)[:sl]
+        scores = torch.relu(q[b] @ K.T)
+        final = (scores * weights[b, :, None]).sum(dim=0)
+        actual_k = min(topk, sl)
+        _, idx = torch.topk(final, actual_k)
+        page_of = idx // page_size
+        off = idx % page_size
+        topk_indices[b, :actual_k] = (pids[page_of] * page_size + off).int()
+    return (topk_indices,)
+"""
+
+
+def _make_definition() -> Definition:
+    return Definition(
+        name="dsa_topk_indexer_fp8_test",
+        op_type="dsa_paged",
+        axes={
+            "batch_size": AxisVar(),
+            "num_index_heads": AxisConst(value=_NUM_HEADS),
+            "index_head_dim": AxisConst(value=_HEAD_DIM),
+            "page_size": AxisConst(value=_PAGE_SIZE),
+            "topk": AxisConst(value=_TOPK),
+            "max_num_pages": AxisVar(),
+            "num_pages": AxisVar(),
+            "kv_cache_num_heads": AxisConst(value=1),
+            "head_dim_with_scale": AxisConst(value=_HEAD_DIM_WITH_SCALE),
+        },
+        inputs={
+            "q_index_fp8": TensorSpec(
+                shape=["batch_size", "num_index_heads", "index_head_dim"], dtype="float8_e4m3fn"
+            ),
+            "k_index_cache_fp8": TensorSpec(
+                shape=["num_pages", "page_size", "kv_cache_num_heads", "head_dim_with_scale"],
+                dtype="int8",
+            ),
+            "weights": TensorSpec(shape=["batch_size", "num_index_heads"], dtype="float32"),
+            "seq_lens": TensorSpec(shape=["batch_size"], dtype="int32"),
+            "block_table": TensorSpec(shape=["batch_size", "max_num_pages"], dtype="int32"),
+        },
+        outputs={"topk_indices": TensorSpec(shape=["batch_size", "topk"], dtype="int32")},
+        reference=_REFERENCE_CODE,
+    )
+
+
+def _make_workload() -> Workload:
+    return Workload(
+        axes={"batch_size": 4, "num_pages": _NUM_PAGES, "max_num_pages": _NUM_PAGES},
+        inputs={
+            "q_index_fp8": RandomInput(),
+            "k_index_cache_fp8": RandomInput(),
+            "weights": RandomInput(),
+            "seq_lens": RandomInput(),
+            "block_table": RandomInput(),
+        },
+        uuid="test-dsa-topk-indexer",
+    )
+
+
+def _make_solution(name: str, body: str) -> Solution:
+    return Solution(
+        name=name,
+        definition="dsa_topk_indexer_fp8_test",
+        author="test",
+        spec=BuildSpec(
+            language=SupportedLanguages.PYTHON,
+            target_hardware=["NVIDIA_B200"],
+            entry_point="main.py::run",
+            destination_passing_style=False,
+        ),
+        sources=[SourceFile(path="main.py", content=body)],
+    )
+
+
+def _make_valid_inputs(definition: Definition, device: str):
+    """Build deterministic valid inputs for the small test definition."""
+    torch.manual_seed(42)
+    batch_size = 4
+    q = torch.randn(batch_size, _NUM_HEADS, _HEAD_DIM, device=device).to(torch.float8_e4m3fn)
+
+    k_bf16 = torch.randn(_NUM_PAGES, _PAGE_SIZE, 1, _HEAD_DIM, dtype=torch.bfloat16, device=device)
+    amax = k_bf16.abs().float().amax(dim=3, keepdim=True).clamp(1e-4)
+    scale = amax / 448.0
+    fp8_data = (k_bf16 * (1.0 / scale)).to(torch.float8_e4m3fn)
+    packed = torch.empty(_NUM_PAGES, _PAGE_SIZE * (_HEAD_DIM + 4), device=device, dtype=torch.uint8)
+    packed[:, : _PAGE_SIZE * _HEAD_DIM] = fp8_data.view(_NUM_PAGES, _PAGE_SIZE * _HEAD_DIM).view(
+        dtype=torch.uint8
+    )
+    packed[:, _PAGE_SIZE * _HEAD_DIM :] = scale.view(_NUM_PAGES, _PAGE_SIZE).view(dtype=torch.uint8)
+    k_fp8 = packed.view(_NUM_PAGES, _PAGE_SIZE, 1, _HEAD_DIM_WITH_SCALE).view(torch.int8)
+
+    weights = torch.randn(batch_size, _NUM_HEADS, device=device, dtype=torch.float32).abs()
+    sequence_lengths = torch.tensor(
+        [
+            _NUM_PAGES * _PAGE_SIZE,
+            _NUM_PAGES * _PAGE_SIZE - 3,
+            _NUM_PAGES * _PAGE_SIZE - 7,
+            _NUM_PAGES * _PAGE_SIZE - 11,
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    block_table = (
+        torch.arange(_NUM_PAGES, dtype=torch.int32, device=device)
+        .unsqueeze(0)
+        .expand(batch_size, -1)
+        .contiguous()
+    )
+
+    return [q, k_fp8, weights, sequence_lengths, block_table]
+
+
+def _build_ref_outputs(definition: Definition, inputs, device: str):
+    from flashinfer_bench.bench.evaluators.utils import normalize_result
+
+    registry = BuilderRegistry.get_instance()
+    ref_runnable = registry.build_reference(definition)
+    with torch.no_grad():
+        result = ref_runnable(*inputs)
+    torch.cuda.synchronize(device)
+    return normalize_result(definition, result, device)
+
+
+# ---- resolve tests ----
+
+
+def _make_dsa_sparse_attention_def() -> Definition:
+    return Definition(
+        name="dsa_sparse_attention_h16_ckv512_kpe64_topk2048_ps64",
+        op_type="dsa_paged",
+        axes={"num_tokens": AxisVar(), "num_pages": AxisVar()},
+        inputs={"x": TensorSpec(shape=["num_tokens"], dtype="float32")},
+        outputs={"y": TensorSpec(shape=["num_tokens"], dtype="float32")},
+        reference="def run(x): return x",
+    )
+
+
+@pytest.mark.parametrize(
+    "definition,expected",
+    [
+        (_make_definition(), DsaTopkIndexerEvaluator),
+        (_make_dsa_sparse_attention_def(), DsaSparseAttentionEvaluator),
+    ],
+)
+def test_resolve(definition, expected):
+    assert resolve_evaluator(definition) is expected
+
+
+# ---- correctness tests ----
+
+
+@pytest.mark.requires_torch_cuda
+def test_correct(tmp_path, tmp_cache_dir):
+    definition = _make_definition()
+    device = "cuda:0"
+    inputs = _make_valid_inputs(definition, device)
+    ref_outputs = _build_ref_outputs(definition, inputs, device)
+
+    solution = _make_solution("correct", _REFERENCE_CODE)
+    registry = BuilderRegistry.get_instance()
+    sol_runnable = registry.build(definition, solution)
+    cfg = BenchmarkConfig(num_trials=1, warmup_runs=0, iterations=1)
+
+    correctness, evaluation = DsaTopkIndexerEvaluator.check_correctness(
+        definition=definition,
+        sol_runnable=sol_runnable,
+        inputs=[inputs],
+        ref_outputs=[ref_outputs],
+        cfg=cfg,
+        log_path=str(tmp_path / "log"),
+        device=device,
+    )
+    assert evaluation is None
+    assert correctness is not None
+    assert torch.isfinite(torch.tensor(correctness.max_absolute_error))
+    assert torch.isfinite(torch.tensor(correctness.max_relative_error))
+    assert correctness.max_absolute_error < 1e-3
+
+
+@pytest.mark.requires_torch_cuda
+def test_shuffled(tmp_path, tmp_cache_dir):
+    """Indices in different order should still pass — the core test."""
+    definition = _make_definition()
+    device = "cuda:0"
+    inputs = _make_valid_inputs(definition, device)
+    ref_outputs = _build_ref_outputs(definition, inputs, device)
+
+    shuffle_code = _REFERENCE_CODE.replace(
+        "_, idx = torch.topk(final, actual_k)",
+        "idx = torch.argsort(final, descending=True)[:actual_k]\n        idx = idx[torch.randperm(actual_k, device=device)]",
+    )
+    solution = _make_solution("shuffled", shuffle_code)
+    registry = BuilderRegistry.get_instance()
+    sol_runnable = registry.build(definition, solution)
+    cfg = BenchmarkConfig(num_trials=1, warmup_runs=0, iterations=1)
+
+    correctness, evaluation = DsaTopkIndexerEvaluator.check_correctness(
+        definition=definition,
+        sol_runnable=sol_runnable,
+        inputs=[inputs],
+        ref_outputs=[ref_outputs],
+        cfg=cfg,
+        log_path=str(tmp_path / "log"),
+        device=device,
+    )
+    assert evaluation is None
+    assert correctness is not None
+
+
+@pytest.mark.requires_torch_cuda
+def test_wrong(tmp_path, tmp_cache_dir):
+    definition = _make_definition()
+    device = "cuda:0"
+    inputs = _make_valid_inputs(definition, device)
+    ref_outputs = _build_ref_outputs(definition, inputs, device)
+
+    wrong_code = (
+        "import torch\n\n"
+        f"def run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table):\n"
+        f"    batch_size = q_index_fp8.shape[0]\n"
+        f"    page_size = {_PAGE_SIZE}\n"
+        f"    topk = {_TOPK}\n"
+        "    base_page = block_table[:, :1].to(torch.int32)\n"
+        "    offsets = torch.arange(topk, dtype=torch.int32, device=q_index_fp8.device).unsqueeze(0)\n"
+        "    wrong_indices = base_page * page_size + offsets\n"
+        "    return (wrong_indices.expand(batch_size, -1).contiguous(),)\n"
+    )
+    solution = _make_solution("wrong", wrong_code)
+    registry = BuilderRegistry.get_instance()
+    sol_runnable = registry.build(definition, solution)
+    cfg = BenchmarkConfig(num_trials=1, warmup_runs=0, iterations=1, atol=1e-6, rtol=1e-6)
+
+    correctness, evaluation = DsaTopkIndexerEvaluator.check_correctness(
+        definition=definition,
+        sol_runnable=sol_runnable,
+        inputs=[inputs],
+        ref_outputs=[ref_outputs],
+        cfg=cfg,
+        log_path=str(tmp_path / "log"),
+        device=device,
+    )
+    assert evaluation is not None
+    assert evaluation.status == EvaluationStatus.INCORRECT_NUMERICAL
+    assert correctness is not None
+    assert torch.isfinite(torch.tensor(correctness.max_absolute_error))
+    assert torch.isfinite(torch.tensor(correctness.max_relative_error))
+
+
+@pytest.mark.requires_torch_cuda
+def test_duplicate(tmp_path, tmp_cache_dir):
+    definition = _make_definition()
+    device = "cuda:0"
+    inputs = _make_valid_inputs(definition, device)
+    ref_outputs = _build_ref_outputs(definition, inputs, device)
+
+    dup_code = (
+        _REFERENCE_CODE
+        + "\n"
+        + (
+            "_original_run = run\n"
+            "def run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table):\n"
+            "    result = _original_run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table)\n"
+            "    idx = result[0].clone()\n"
+            "    idx[:, 0] = idx[:, 1]\n"
+            "    return (idx,)\n"
+        )
+    )
+    solution = _make_solution("duplicate", dup_code)
+    registry = BuilderRegistry.get_instance()
+    sol_runnable = registry.build(definition, solution)
+    cfg = BenchmarkConfig(num_trials=1, warmup_runs=0, iterations=1)
+
+    correctness, evaluation = DsaTopkIndexerEvaluator.check_correctness(
+        definition=definition,
+        sol_runnable=sol_runnable,
+        inputs=[inputs],
+        ref_outputs=[ref_outputs],
+        cfg=cfg,
+        log_path=str(tmp_path / "log"),
+        device=device,
+    )
+    assert evaluation is not None
+    assert evaluation.status == EvaluationStatus.INCORRECT_NUMERICAL
+    assert "duplicate" in evaluation.log.lower()
+
+
+@pytest.mark.requires_torch_cuda
+def test_out_of_range(tmp_path, tmp_cache_dir):
+    definition = _make_definition()
+    device = "cuda:0"
+    inputs = _make_valid_inputs(definition, device)
+    ref_outputs = _build_ref_outputs(definition, inputs, device)
+
+    oor_code = (
+        _REFERENCE_CODE
+        + "\n"
+        + (
+            "_original_run = run\n"
+            "def run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table):\n"
+            "    result = _original_run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table)\n"
+            "    idx = result[0].clone()\n"
+            f"    idx[:, 0] = {_NUM_PAGES * _PAGE_SIZE + 100}\n"
+            "    return (idx,)\n"
+        )
+    )
+    solution = _make_solution("out_of_range", oor_code)
+    registry = BuilderRegistry.get_instance()
+    sol_runnable = registry.build(definition, solution)
+    cfg = BenchmarkConfig(num_trials=1, warmup_runs=0, iterations=1)
+
+    correctness, evaluation = DsaTopkIndexerEvaluator.check_correctness(
+        definition=definition,
+        sol_runnable=sol_runnable,
+        inputs=[inputs],
+        ref_outputs=[ref_outputs],
+        cfg=cfg,
+        log_path=str(tmp_path / "log"),
+        device=device,
+    )
+    assert evaluation is not None
+    assert evaluation.status == EvaluationStatus.INCORRECT_NUMERICAL
+    assert "out-of-range" in evaluation.log.lower()
+
+
+@pytest.mark.requires_torch_cuda
+def test_unreachable_index(tmp_path, tmp_cache_dir):
+    definition = _make_definition()
+    device = "cuda:0"
+    inputs = _make_valid_inputs(definition, device)
+    ref_outputs = _build_ref_outputs(definition, inputs, device)
+
+    unreachable_code = (
+        _REFERENCE_CODE
+        + "\n"
+        + (
+            "_original_run = run\n"
+            "def run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table):\n"
+            "    result = _original_run(q_index_fp8, k_index_cache_fp8, weights, seq_lens, block_table)\n"
+            "    idx = result[0].clone()\n"
+            f"    idx[1:, 0] = {_NUM_PAGES * _PAGE_SIZE - 1}\n"
+            "    return (idx,)\n"
+        )
+    )
+    solution = _make_solution("unreachable_index", unreachable_code)
+    registry = BuilderRegistry.get_instance()
+    sol_runnable = registry.build(definition, solution)
+    cfg = BenchmarkConfig(num_trials=1, warmup_runs=0, iterations=1)
+
+    correctness, evaluation = DsaTopkIndexerEvaluator.check_correctness(
+        definition=definition,
+        sol_runnable=sol_runnable,
+        inputs=[inputs],
+        ref_outputs=[ref_outputs],
+        cfg=cfg,
+        log_path=str(tmp_path / "log"),
+        device=device,
+    )
+    assert evaluation is not None
+    assert evaluation.status == EvaluationStatus.INCORRECT_NUMERICAL
+    assert "out-of-range" in evaluation.log.lower()

--- a/tests/bench/test_isolated_runner.py
+++ b/tests/bench/test_isolated_runner.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+import safetensors.torch as st
 import torch
 
 from flashinfer_bench.bench import BenchmarkConfig
@@ -124,7 +125,6 @@ def test_gen_inputs_random_and_scalar_cpu():
     __import__("safetensors", fromlist=["torch"]) is None, reason="safetensors not available"
 )
 def test_load_safetensors_and_gen_inputs_cpu(tmp_path: Path):
-    import safetensors.torch as st
 
     definition = _def2d()
     data = {"X": torch.zeros((2, 3), dtype=torch.float32)}


### PR DESCRIPTION
## Summary
- Add `DsaTopkIndexerEvaluator` that compares sorted value vectors instead of raw indices to correctly handle tie-breaking and rounding differences across DSA top-k indexer kernel implementations
- Custom `build_baseline` that correctly packs random `k_index_cache_fp8` inputs into deep_gemm FP8 format (fixes false negatives where correct FlashInfer kernels were rejected)
- Vectorized index validation using `[B, K, M]` broadcasting instead of `[B, num_pages * page_size]` dense mask (~10x less intermediate memory)
- Move `safetensors` import to module level to avoid ~200ms cold-start cost per `load_safetensors()` call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DSA Top‑K Indexer evaluator to benchmark FP8-packed key‑cache top‑k workloads with robust scoring, index validation, and tolerance-aware error comparison.

* **Tests**
  * Added end‑to‑end test suite covering evaluator resolution and multiple correctness scenarios (including duplicates, out‑of‑range, shuffled, and wrong outputs).

* **Chores**
  * Updated evaluator registry and adjusted safetensors import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->