### PR TITLE
feat: add MiniMax M2 full kernel coverage (17/17 definitions)

### DIFF
--- a/.claude/skills/collect-workloads-bench/SKILL.md
+++ b/.claude/skills/collect-workloads-bench/SKILL.md
@@ -103,10 +103,32 @@ done
 
 **Peer worker SSH environment**: on NFS-shared clusters (e.g. SLURM where `/home` is shared),
 `bench_sharegpt.py` passes `sys.executable` (absolute path) as the Python binary on the remote
-node — no conda activation needed. It also prepends `env CUDA_HOME=<conda_prefix>` so that
-`deep_gemm` can locate the CUDA toolkit on the SSH session (SSH does not inherit `CUDA_HOME`
-and csh/tcsh don't support the inline `KEY=value cmd` syntax). The `--conda-env` flag is only
-a fallback for non-NFS setups where `sys.executable` resolves to a relative path.
+node — no conda activation needed. It also passes:
+
+- `CUDA_HOME=<conda_prefix>`: `deep_gemm` checks this first; conda prefix contains nvcc/include/lib
+- `PATH=<conda_bin>:/usr/...`: JIT build tools like `ninja` (needed by SGLang's JIT kernels) are found
+- `CPATH=<nvidia_include_dirs>`: pip-installed nvidia packages (`nvidia-cuda-nvrtc-cu13` etc.) put
+  `nvrtc.h` and other CUDA headers under `site-packages/nvidia/cuXX/include`. These are not on the
+  system compiler's default include path, but FlashInfer's TRT-LLM FMHA JIT kernel (`fmha_gen`)
+  `#includes <nvrtc.h>`. Without CPATH, the peer node's JIT compilation fails with
+  `nvrtc.h: No such file or directory`. The head node's SGLang server also gets CPATH set via
+  the `env` dict passed to `popen_launch_server`.
+- `FLASHINFER_WORKSPACE_BASE=/tmp/flashinfer_jit_peer`: redirects the peer node's FlashInfer JIT
+  cache to local `/tmp`. Without this, both head and peer nodes try to acquire the same NFS-path
+  `FileLock` (at `~/.cache/flashinfer/.../cached_ops/tmp/fmha_gen.lock`), causing
+  `OSError: [Errno 116] Stale file handle` on the peer.
+
+SSH sessions don't inherit the conda env's `CUDA_HOME`, `PATH`, or `CPATH`, and csh/tcsh don't
+support inline `KEY=value cmd` syntax, so `env` (an external binary) is used for portability.
+The `--conda-env` flag is only a fallback for non-NFS setups where `sys.executable` resolves to
+a relative path.
+
+**Pre-compile TRT-LLM FMHA on head node before first run** (optional but speeds up server startup):
+```bash
+# Warm the NFS JIT cache so head-node TP ranks don't all compile simultaneously
+CPATH="$(python -c "import sys,pathlib; print(':'.join(str(p) for p in pathlib.Path(sys.prefix).glob('lib/python*/site-packages/nvidia/cu*/include')))")" \
+  python -c "from flashinfer.prefill import get_trtllm_gen_fmha_module; get_trtllm_gen_fmha_module()"
+```
 
 **Two independent decisions**:
 
@@ -128,12 +150,18 @@ a fallback for non-NFS setups where `sys.executable` resolves to a relative path
 
 **Manual peer override** (when not in SLURM or peer auto-detection fails):
 ```bash
+SLURM_JOB_NODELIST=head-node,peer-node \
 python examples/sglang_bench/bench_sharegpt.py \
-  --model deepseek-v3 --model-path /path/to/model \
-  --peer-node-addr nvl72155-T14 \
+  --model deepseek-v3 --model-path /nfs/path/to/model \
+  --peer-node-addr peer-node \
   --dist-init-port 20010 \
   ...
 ```
+
+**Model path must be NFS-accessible on all nodes**: `--model-path` is passed directly to the
+SGLang server on each node. Local paths (e.g. `/data/...`) that exist only on one node will
+cause `HFValidationError` or `FileNotFoundError` on the peer. Use NFS-shared paths (e.g.
+`/home/user/models/...`) or a shared file system mount that exists on all allocated nodes.
 
 **Note**: Omit `--replace` during the loop so each batch size's workloads are appended.
 Use `--replace` only on the first run if you want to start fresh.

--- a/.claude/skills/collect-workloads-bench/SKILL.md
+++ b/.claude/skills/collect-workloads-bench/SKILL.md
@@ -99,7 +99,14 @@ done
 | `--peer-node-addr HOST [HOST ...]` | auto (SLURM) | Override peer node hostname(s)/IP(s) |
 | `--dist-init-port PORT` | `20010` | PyTorch dist rendezvous port (must differ from `--port`) |
 | `--no-multinode` | off | Disable auto multi-node even when config TP > local GPUs |
-| `--conda-env ENV` | `$CONDA_DEFAULT_ENV` | Conda env to activate on peer nodes via SSH |
+| `--conda-env ENV` | `$CONDA_DEFAULT_ENV` | Fallback: conda env for peer SSH (only used when `sys.executable` is a relative path, i.e. non-NFS clusters) |
+
+**Peer worker SSH environment**: on NFS-shared clusters (e.g. SLURM where `/home` is shared),
+`bench_sharegpt.py` passes `sys.executable` (absolute path) as the Python binary on the remote
+node — no conda activation needed. It also prepends `env CUDA_HOME=<conda_prefix>` so that
+`deep_gemm` can locate the CUDA toolkit on the SSH session (SSH does not inherit `CUDA_HOME`
+and csh/tcsh don't support the inline `KEY=value cmd` syntax). The `--conda-env` flag is only
+a fallback for non-NFS setups where `sys.executable` resolves to a relative path.
 
 **Two independent decisions**:
 

--- a/.claude/skills/collect-workloads-bench/SKILL.md
+++ b/.claude/skills/collect-workloads-bench/SKILL.md
@@ -39,6 +39,12 @@ For paged prefill: always include `--disable-radix-cache` and `--enable-determin
 Run one batch size at a time to avoid node overload. After each run, sanitize to collect
 2–3 workloads, then delete the dump dir before the next run.
 
+**Multi-node auto-detection**: when model config TP > local GPU count (e.g. TP=8 config but
+only 4 GPUs visible via `nvidia-smi`), `bench_sharegpt.py` automatically triggers multi-node
+mode. Peer nodes are discovered from `SLURM_JOB_ID`; workers are launched via SSH.
+FLASHINFER dump env vars are forwarded only to the head node (rank 0) — workers don't dump.
+Passwordless SSH between allocated nodes is required (standard in SLURM environments).
+
 ```bash
 DUMP_DIR=/tmp/flashinfer_dumps_<name>
 TRACE_DIR=<trace_dir>
@@ -71,7 +77,7 @@ for BS in 1 64 128 256; do
       --disable-cuda-graph \
       2>&1 | tee -a $LOG
 
-  # Kill any lingering processes
+  # Kill any lingering processes (including remote workers if multi-node)
   pkill -f bench_sharegpt.py || true
   pkill -f sglang.launch_server || true
 
@@ -84,6 +90,42 @@ for BS in 1 64 128 256; do
   # Delete dumps before next run to free disk space
   rm -rf $DUMP_DIR
 done
+```
+
+#### Multi-node flags (bench_sharegpt.py)
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--peer-node-addr HOST [HOST ...]` | auto (SLURM) | Override peer node hostname(s)/IP(s) |
+| `--dist-init-port PORT` | `20010` | PyTorch dist rendezvous port (must differ from `--port`) |
+| `--no-multinode` | off | Disable auto multi-node even when config TP > local GPUs |
+| `--conda-env ENV` | `$CONDA_DEFAULT_ENV` | Conda env to activate on peer nodes via SSH |
+
+**Two independent decisions**:
+
+1. **What TP to use** — always from model config:
+   - Config has `--tp-size N` → use N as-is
+   - Config has no `--tp-size` → fall back to local GPU count
+   - **Config TP is never overridden**
+
+2. **How many nodes to use** — derived from TP and local GPU count:
+   - `needed_nodes = ceil(config_tp / local_gpus)`
+   - Only launch multi-node if `needed_nodes > 1` — peer nodes are looked up from SLURM/`--peer-node-addr` only when needed
+
+**Examples** (4 GPUs per node, 2-node SLURM allocation):
+| Config TP | needed_nodes | Launch mode |
+|-----------|-------------|-------------|
+| `--tp-size 4` | 1 | Single-node, TP=4 (fits on one node) |
+| `--tp-size 8` | 2 | Multi-node, TP=8 (4 GPUs × 2 nodes) |
+| *(no flag)* | 1 | Single-node, TP=4 (local GPU count fallback) |
+
+**Manual peer override** (when not in SLURM or peer auto-detection fails):
+```bash
+python examples/sglang_bench/bench_sharegpt.py \
+  --model deepseek-v3 --model-path /path/to/model \
+  --peer-node-addr nvl72155-T14 \
+  --dist-init-port 20010 \
+  ...
 ```
 
 **Note**: Omit `--replace` during the loop so each batch size's workloads are appended.

--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -681,12 +681,14 @@ Note: MiniMax M2 is a separate model from MiniMax-Text-01 (which uses Lightning 
 | `gemm_n8192_k3072` | gemm (fused qkv_proj) | 🟡 |
 | `gemm_n3072_k6144` | gemm (o_proj) | 🟡 |
 | `gemm_n256_k3072` | gemm (MoE gate) | 🟡 |
-| MoE gate / topk / experts | moe | — |
+| `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e256_h3072_i8192` | moe | 🟡 |
+| `gemm_n16384_k3072` | gemm (MoE FC1/W13) | 🟡 |
+| `gemm_n3072_k8192` | gemm (MoE FC2/down) | 🟡 |
 | `top_k_sampling_from_probs_v200064` | sampling | 🟡 |
 | `top_k_top_p_sampling_from_probs_v200064` | sampling | 🟡 |
 | `top_p_sampling_from_probs_v200064` | sampling | 🟡 |
 
-**Coverage**: 14 / 15 definitions present. Workloads not yet collected.
+**Coverage**: 17 / 17 definitions present. Workloads not yet collected.
 
 ---
 

--- a/examples/sglang_bench/bench_sharegpt.py
+++ b/examples/sglang_bench/bench_sharegpt.py
@@ -18,6 +18,12 @@ Usage:
     #   tools/gpu-lock --gpus 4 -- python3 bench_sharegpt.py --model qwen3-235b-a22b ...
     #   → CUDA_VISIBLE_DEVICES=0,1,2,3 → TP=4 used automatically
 
+    # Multi-node mode (auto-detected when config TP > local GPU count):
+    #   Peer nodes are discovered from SLURM_JOB_ID automatically.
+    #   Workers are launched via SSH; passwordless SSH between nodes is required.
+    #   Manual override: --peer-node-addr nvl72155-T14
+    #   Disable auto multi-node: --no-multinode
+
     # Tracing flags
     python3 bench_sharegpt.py --model llama-3.1-8b --model-path /path/to/model --disable-radix-cache
     python3 bench_sharegpt.py --model qwen3-235b-a22b --model-path /path/to/model --enable-deterministic-inference
@@ -38,12 +44,15 @@ import asyncio
 import json
 import math
 import os
+
+import shlex
+import socket
 import subprocess
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 _CONFIG_FILE = Path(__file__).parent / "model_configs.json"
 
@@ -108,6 +117,108 @@ def detect_tp_size() -> Optional[int]:
     except Exception:
         pass
     return None
+
+
+def get_slurm_peer_nodes() -> List[Tuple[str, str]]:
+    """
+    Return [(hostname, ip), ...] for peer nodes in the current SLURM job allocation,
+    excluding this node. Returns an empty list when not in a multi-node SLURM job.
+    """
+    job_id = os.environ.get("SLURM_JOB_ID", "")
+    if not job_id:
+        return []
+    try:
+        result = subprocess.run(
+            ["scontrol", "show", "job", job_id],
+            capture_output=True, text=True, timeout=10,
+        )
+        node_list = None
+        for line in result.stdout.splitlines():
+            for field in line.split():
+                if field.startswith("NodeList=") and "(null)" not in field:
+                    node_list = field.split("=", 1)[1]
+                    break
+        if not node_list:
+            return []
+
+        result = subprocess.run(
+            ["scontrol", "show", "hostnames", node_list],
+            capture_output=True, text=True, timeout=10,
+        )
+        all_nodes = [n for n in result.stdout.strip().splitlines() if n]
+        current_host = socket.gethostname().split(".")[0]
+
+        peers = []
+        for node in all_nodes:
+            if node.split(".")[0] == current_host:
+                continue
+            try:
+                ip = socket.getaddrinfo(node, None)[0][4][0]
+            except Exception:
+                ip = node
+            peers.append((node, ip))
+        return peers
+    except Exception:
+        return []
+
+
+def get_head_node_ip_for_peer(peer_ip: str) -> str:
+    """Return the local IP address that routes to peer_ip (used as --dist-init-addr host)."""
+    try:
+        result = subprocess.run(
+            ["ip", "route", "get", peer_ip],
+            capture_output=True, text=True, timeout=5,
+        )
+        tokens = result.stdout.split()
+        for i, tok in enumerate(tokens):
+            if tok == "src" and i + 1 < len(tokens):
+                return tokens[i + 1]
+    except Exception:
+        pass
+    try:
+        result = subprocess.run(["hostname", "-I"], capture_output=True, text=True, timeout=5)
+        ips = result.stdout.strip().split()
+        if ips:
+            return ips[0]
+    except Exception:
+        pass
+    return socket.gethostname()
+
+
+def launch_peer_worker(
+    peer_host: str,
+    model_path: str,
+    server_args: List[str],
+    head_ip: str,
+    dist_port: int,
+    total_nodes: int,
+    node_rank: int,
+    conda_env: Optional[str],
+) -> subprocess.Popen:
+    """
+    SSH to peer_host and start sglang.launch_server as a TP worker.
+
+    FLASHINFER_* dump env vars are intentionally NOT forwarded — tensor dumps
+    are only collected from rank 0 (the head node).
+    """
+    worker_args = [
+        "--model-path", model_path,
+        "--nnodes", str(total_nodes),
+        "--node-rank", str(node_rank),
+        "--dist-init-addr", f"{head_ip}:{dist_port}",
+    ] + server_args
+
+    python_cmd = ["python", "-m", "sglang.launch_server"] + worker_args
+    cmd_str = " ".join(shlex.quote(c) for c in python_cmd)
+
+    if conda_env:
+        remote_cmd = f"conda run --no-capture-output -n {shlex.quote(conda_env)} {cmd_str}"
+    else:
+        remote_cmd = cmd_str
+
+    ssh_cmd = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes", peer_host, remote_cmd]
+    log(f"Launching peer worker (rank {node_rank}) on {peer_host}")
+    return subprocess.Popen(ssh_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
 
 from datasets import load_dataset
@@ -176,32 +287,29 @@ def log(msg: str) -> None:
 
 def load_prompts_from_sharegpt(n: int) -> List[str]:
     """Load n prompts from the ShareGPT dataset."""
-    import json as _json
-    import os as _os
-
-    _local = "/tmp/sharegpt_synthetic.jsonl"
-    if _os.path.exists(_local):
-        prompts = []
-        with open(_local) as _f:
-            for _line in _f:
-                _d = _json.loads(_line)
-                prompts.append(_d.get("prompt", _d.get("conversations", [{}])[0].get("value", "")))
-                if len(prompts) >= n:
-                    break
-    else:
-        ds = load_dataset(
-            "anon8231489123/ShareGPT_Vicuna_unfiltered",
-            data_files="ShareGPT_V3_unfiltered_cleaned_split.json",
-            split="train",
-            streaming=True,
-        )
-        prompts = []
-        for example in ds:
-            conv = example.get("conversations", [])
-            if conv and conv[0]["from"].lower() == "human":
-                prompts.append(conv[0]["value"])
-            if len(prompts) >= n:
-                break
+    ds = load_dataset(
+        "anon8231489123/ShareGPT_Vicuna_unfiltered",
+        data_files="ShareGPT_V3_unfiltered_cleaned_split.json",
+        split="train",
+        streaming=True,
+    )
+    prompts = []
+    for example in ds:
+        conv = example.get("conversations", [])
+        if not conv:
+            continue
+        # Dataset returns conversations as JSON strings in newer datasets library versions
+        first = conv[0]
+        if isinstance(first, str):
+            import json as _json
+            try:
+                first = _json.loads(first)
+            except Exception:
+                continue
+        if isinstance(first, dict) and first.get("from", "").lower() == "human":
+            prompts.append(first.get("value", ""))
+        if len(prompts) >= n:
+            break
 
     log(f"Loaded {len(prompts)} prompts from ShareGPT dataset")
     prompt_lengths = [len(p) for p in prompts]
@@ -353,6 +461,36 @@ def main():
         action="store_true",
         help="Pass --disable-cuda-graph to the SGLang server",
     )
+    parser.add_argument(
+        "--peer-node-addr",
+        type=str,
+        nargs="+",
+        default=None,
+        metavar="HOST",
+        help=(
+            "Peer node hostname(s)/IP(s) for multi-node TP. "
+            "Auto-detected from SLURM_JOB_ID when not specified."
+        ),
+    )
+    parser.add_argument(
+        "--dist-init-port",
+        type=int,
+        default=20010,
+        help="Port for PyTorch distributed rendezvous (--dist-init-addr). "
+             "Must differ from --port. Default: 20010.",
+    )
+    parser.add_argument(
+        "--no-multinode",
+        action="store_true",
+        help="Disable automatic multi-node mode even when config TP > local GPU count.",
+    )
+    parser.add_argument(
+        "--conda-env",
+        type=str,
+        default=os.environ.get("CONDA_DEFAULT_ENV", "flashinfer_bench"),
+        help="Conda environment to activate on peer nodes via SSH. "
+             "Defaults to $CONDA_DEFAULT_ENV or 'flashinfer_bench'.",
+    )
     args = parser.parse_args()
 
     # Resolve GPU type
@@ -384,36 +522,85 @@ def main():
 
     server_args.extend(model_config["server_flags"])
 
-    # Auto-detect TP size from CUDA_VISIBLE_DEVICES (set by gpu-lock) and override if needed
-    detected_tp = detect_tp_size()
-    if detected_tp is not None:
-        # Extract TP size from current server_args
-        config_tp = None
-        for i, arg in enumerate(server_args):
-            if arg in ("--tp-size", "--tp") and i + 1 < len(server_args):
-                try:
-                    config_tp = int(server_args[i + 1])
-                except ValueError:
-                    pass
-                break
-        if config_tp != detected_tp:
-            # Remove existing --tp-size / --tp flags and replace
-            filtered = []
-            skip_next = False
-            for arg in server_args:
-                if skip_next:
-                    skip_next = False
-                    continue
-                if arg in ("--tp-size", "--tp"):
-                    skip_next = True
-                    continue
-                filtered.append(arg)
-            server_args = filtered + ["--tp-size", str(detected_tp)]
-            log(
-                f"TP size: {detected_tp} (auto-detected from CUDA_VISIBLE_DEVICES, overrides config TP={config_tp})"
-            )
+    # --- TP size: always from model config (never overridden) ---
+    # If config has no --tp-size, fall back to local GPU count.
+    local_gpus = detect_tp_size() or 1
+
+    config_tp: Optional[int] = None
+    for i, arg in enumerate(server_args):
+        if arg in ("--tp-size", "--tp") and i + 1 < len(server_args):
+            try:
+                config_tp = int(server_args[i + 1])
+            except ValueError:
+                pass
+            break
+
+    effective_tp = config_tp if config_tp is not None else local_gpus
+    if config_tp is None:
+        server_args = server_args + ["--tp-size", str(effective_tp)]
+        log(f"TP size: {effective_tp} (no config TP, using local GPU count)")
+    else:
+        log(f"TP size: {effective_tp} (from config)")
+
+    # --- Multi-node detection ---
+    # Discover available peer nodes from SLURM allocation or --peer-node-addr.
+    # Then compute how many nodes the config TP actually needs:
+    #   needed_nodes = ceil(effective_tp / local_gpus)
+    # Only use as many peers as needed, not all allocated nodes.
+    # Example: 4+4 GPU allocation, TP=4 → needed_nodes=1 → single-node
+    #          4+4 GPU allocation, TP=8 → needed_nodes=2 → multi-node
+    needed_nodes = math.ceil(effective_tp / local_gpus)
+
+    available_peers: List[Tuple[str, str]] = []
+    if not args.no_multinode and needed_nodes > 1:
+        if args.peer_node_addr:
+            available_peers = [(addr, addr) for addr in args.peer_node_addr]
         else:
-            log(f"TP size: {detected_tp} (matches config)")
+            available_peers = get_slurm_peer_nodes()
+
+    peers = available_peers[: needed_nodes - 1]
+    need_multinode = len(peers) > 0
+    nnodes = 1 + len(peers)
+
+    if needed_nodes > 1 and len(peers) < needed_nodes - 1:
+        raise RuntimeError(
+            f"TP={effective_tp} needs {needed_nodes} nodes ({local_gpus} GPUs each), "
+            f"but only {1 + len(available_peers)} node(s) available. "
+            f"Check SLURM allocation or pass --peer-node-addr."
+        )
+
+    if need_multinode:
+        log(f"Multi-node: {nnodes} nodes × {local_gpus} GPUs, TP={effective_tp}")
+
+    # --- Multi-node setup ---
+    peer_processes: List[subprocess.Popen] = []
+
+    if need_multinode:
+        head_ip = get_head_node_ip_for_peer(peers[0][1])
+        dist_addr = f"{head_ip}:{args.dist_init_port}"
+        log(f"dist-init-addr: {dist_addr}")
+        log(f"Peer nodes:     {[p[0] for p in peers]}")
+
+        for rank, (peer_host, _) in enumerate(peers, start=1):
+            p = launch_peer_worker(
+                peer_host=peer_host,
+                model_path=args.model_path,
+                server_args=server_args,
+                head_ip=head_ip,
+                dist_port=args.dist_init_port,
+                total_nodes=nnodes,
+                node_rank=rank,
+                conda_env=args.conda_env,
+            )
+            peer_processes.append(p)
+
+        # Prepend multi-node flags to head server args
+        server_args = [
+            "--nnodes", str(nnodes),
+            "--node-rank", "0",
+            "--dist-init-addr", dist_addr,
+        ] + server_args
+
     log(f"Server args:    {server_args}")
 
     process = popen_launch_server(
@@ -434,6 +621,11 @@ def main():
     finally:
         log("Shutting down server...")
         kill_process_tree(process.pid)
+        for p in peer_processes:
+            try:
+                kill_process_tree(p.pid)
+            except Exception:
+                pass
         time.sleep(3)
         log("Server shutdown complete")
 

--- a/examples/sglang_bench/bench_sharegpt.py
+++ b/examples/sglang_bench/bench_sharegpt.py
@@ -57,6 +57,20 @@ from typing import Any, Dict, List, Optional, Tuple
 
 _CONFIG_FILE = Path(__file__).parent / "model_configs.json"
 
+# Compute nvidia CUDA header paths once at startup.
+# pip-installed nvidia packages (nvidia-cuda-nvrtc-cu13 etc.) place nvrtc.h,
+# cuda_runtime.h etc. under site-packages/nvidia/cuXX/include.  These are not
+# on the default include path of the system compiler, but JIT kernels such as
+# flashinfer's TRT-LLM FMHA module need them.  Exporting CPATH makes them
+# visible to every subprocess (SGLang server, SSH peer worker) without patching
+# individual compile commands.
+_NVIDIA_INCLUDES: List[str] = sorted(
+    str(p) for p in Path(sys.prefix).glob(
+        "lib/python*/site-packages/nvidia/cu*/include"
+    )
+)
+_NVIDIA_CPATH: str = ":".join(_NVIDIA_INCLUDES)
+
 # Map nvidia-smi GPU name substrings → sgl-cookbook hardware IDs
 _GPU_NAME_MAP = [
     ("B200", "b200"),
@@ -228,14 +242,24 @@ def launch_peer_worker(
         # `env` is an external binary that works universally).
         # CUDA_HOME: deep_gemm checks it first; conda prefix contains nvcc/include/lib.
         # PATH: conda env's bin is prepended so JIT tools (ninja, nvcc) are found.
+        # CPATH: pip-installed nvidia packages put nvrtc.h etc. under
+        #   site-packages/nvidia/cuXX/include; add them so TRT-LLM JIT can find them.
+        #   We use the module-level _NVIDIA_CPATH constant (computed from sys.prefix on
+        #   the head node; the path is identical on the peer node via NFS).
+        # FLASHINFER_WORKSPACE_BASE: point peer node JIT cache to local /tmp so the
+        #   peer doesn't share the NFS lock files with the head node, which causes
+        #   OSError: [Errno 116] Stale file handle during FileLock acquisition.
         conda_bin_dir = os.path.dirname(python_bin)          # .../envs/XXX/bin
         conda_prefix = os.path.dirname(conda_bin_dir)        # .../envs/XXX
         base_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-        remote_cmd = (
-            f"env CUDA_HOME={shlex.quote(conda_prefix)}"
+        env_vars = (
+            f"CUDA_HOME={shlex.quote(conda_prefix)}"
             f" PATH={shlex.quote(conda_bin_dir)}:{base_path}"
-            f" {cmd_str}"
+            f" FLASHINFER_WORKSPACE_BASE=/tmp/flashinfer_jit_peer"
         )
+        if _NVIDIA_CPATH:
+            env_vars += f" CPATH={shlex.quote(_NVIDIA_CPATH)}"
+        remote_cmd = f"env {env_vars} {cmd_str}"
 
     log_file = open(f"/tmp/sglang_worker_rank{node_rank}_{peer_host}.log", "w")
     ssh_cmd = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes", peer_host, remote_cmd]
@@ -625,12 +649,25 @@ def main():
 
     log(f"Server args:    {server_args}")
 
+    # Build server environment: inherit os.environ, then override/add specific vars.
+    # CPATH must come AFTER **os.environ so it takes precedence over any ambient value;
+    # we prepend our nvidia includes to any existing CPATH so we don't shadow others.
+    _existing_cpath = os.environ.get("CPATH", "")
+    _server_cpath = (
+        f"{_NVIDIA_CPATH}:{_existing_cpath}" if _existing_cpath and _NVIDIA_CPATH
+        else (_NVIDIA_CPATH or _existing_cpath)
+    )
     process = popen_launch_server(
         args.model_path,
         args.base_url,
         timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
         other_args=server_args,
-        env={"SGLANG_RECORD_STEP_TIME": "1", "SGLANG_TEST_REQUEST_TIME_STATS": "1", **os.environ},
+        env={
+            "SGLANG_RECORD_STEP_TIME": "1",
+            "SGLANG_TEST_REQUEST_TIME_STATS": "1",
+            **os.environ,
+            **({"CPATH": _server_cpath} if _server_cpath else {}),
+        },
     )
 
     try:

--- a/examples/sglang_bench/bench_sharegpt.py
+++ b/examples/sglang_bench/bench_sharegpt.py
@@ -222,15 +222,20 @@ def launch_peer_worker(
         conda_bin = shutil.which("conda") or "conda"
         remote_cmd = f"{conda_bin} run --no-capture-output -n {shlex.quote(conda_env)} {cmd_str}"
     else:
-        # SSH sessions don't inherit the conda env's CUDA_HOME.
-        # Use `env` to set it so the command works in any remote shell
+        # SSH sessions don't inherit the conda env's CUDA_HOME or PATH.
+        # Use `env` to set both so the command works in any remote shell
         # (csh/tcsh don't support the `KEY=value cmd` inline-assignment syntax;
         # `env` is an external binary that works universally).
-        # deep_gemm checks CUDA_HOME first; pointing it at the conda prefix
-        # (which contains bin/nvcc, include/, lib/) satisfies the requirement.
+        # CUDA_HOME: deep_gemm checks it first; conda prefix contains nvcc/include/lib.
+        # PATH: conda env's bin is prepended so JIT tools (ninja, nvcc) are found.
         conda_bin_dir = os.path.dirname(python_bin)          # .../envs/XXX/bin
         conda_prefix = os.path.dirname(conda_bin_dir)        # .../envs/XXX
-        remote_cmd = f"env CUDA_HOME={shlex.quote(conda_prefix)} {cmd_str}"
+        base_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        remote_cmd = (
+            f"env CUDA_HOME={shlex.quote(conda_prefix)}"
+            f" PATH={shlex.quote(conda_bin_dir)}:{base_path}"
+            f" {cmd_str}"
+        )
 
     log_file = open(f"/tmp/sglang_worker_rank{node_rank}_{peer_host}.log", "w")
     ssh_cmd = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes", peer_host, remote_cmd]

--- a/examples/sglang_bench/bench_sharegpt.py
+++ b/examples/sglang_bench/bench_sharegpt.py
@@ -45,8 +45,10 @@ import json
 import math
 import os
 import shlex
+import shutil
 import socket
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -207,13 +209,28 @@ def launch_peer_worker(
         "--dist-init-addr", f"{head_ip}:{dist_port}",
     ] + server_args
 
-    python_cmd = ["python", "-m", "sglang.launch_server"] + worker_args
+    # Use sys.executable so the remote worker runs in the same Python environment
+    # as the head node.  This works because /home is NFS-shared across nodes.
+    # Fall back to "conda run -n <env>" only when sys.executable is unavailable
+    # (e.g. dry-run testing or a non-NFS cluster).
+    python_bin = sys.executable
+    python_cmd = [python_bin, "-m", "sglang.launch_server"] + worker_args
     cmd_str = " ".join(shlex.quote(c) for c in python_cmd)
 
-    if conda_env:
-        remote_cmd = f"conda run --no-capture-output -n {shlex.quote(conda_env)} {cmd_str}"
+    if conda_env and not os.path.isabs(python_bin):
+        # Fallback: use conda run when sys.executable is a relative path
+        conda_bin = shutil.which("conda") or "conda"
+        remote_cmd = f"{conda_bin} run --no-capture-output -n {shlex.quote(conda_env)} {cmd_str}"
     else:
-        remote_cmd = cmd_str
+        # SSH sessions don't inherit the conda env's CUDA_HOME.
+        # Use `env` to set it so the command works in any remote shell
+        # (csh/tcsh don't support the `KEY=value cmd` inline-assignment syntax;
+        # `env` is an external binary that works universally).
+        # deep_gemm checks CUDA_HOME first; pointing it at the conda prefix
+        # (which contains bin/nvcc, include/, lib/) satisfies the requirement.
+        conda_bin_dir = os.path.dirname(python_bin)          # .../envs/XXX/bin
+        conda_prefix = os.path.dirname(conda_bin_dir)        # .../envs/XXX
+        remote_cmd = f"env CUDA_HOME={shlex.quote(conda_prefix)} {cmd_str}"
 
     log_file = open(f"/tmp/sglang_worker_rank{node_rank}_{peer_host}.log", "w")
     ssh_cmd = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes", peer_host, remote_cmd]

--- a/examples/sglang_bench/bench_sharegpt.py
+++ b/examples/sglang_bench/bench_sharegpt.py
@@ -65,9 +65,7 @@ _CONFIG_FILE = Path(__file__).parent / "model_configs.json"
 # visible to every subprocess (SGLang server, SSH peer worker) without patching
 # individual compile commands.
 _NVIDIA_INCLUDES: List[str] = sorted(
-    str(p) for p in Path(sys.prefix).glob(
-        "lib/python*/site-packages/nvidia/cu*/include"
-    )
+    str(p) for p in Path(sys.prefix).glob("lib/python*/site-packages/nvidia/cu*/include")
 )
 _NVIDIA_CPATH: str = ":".join(_NVIDIA_INCLUDES)
 
@@ -144,8 +142,7 @@ def get_slurm_peer_nodes() -> List[Tuple[str, str]]:
         return []
     try:
         result = subprocess.run(
-            ["scontrol", "show", "job", job_id],
-            capture_output=True, text=True, timeout=10,
+            ["scontrol", "show", "job", job_id], capture_output=True, text=True, timeout=10
         )
         node_list = None
         for line in result.stdout.splitlines():
@@ -157,8 +154,7 @@ def get_slurm_peer_nodes() -> List[Tuple[str, str]]:
             return []
 
         result = subprocess.run(
-            ["scontrol", "show", "hostnames", node_list],
-            capture_output=True, text=True, timeout=10,
+            ["scontrol", "show", "hostnames", node_list], capture_output=True, text=True, timeout=10
         )
         all_nodes = [n for n in result.stdout.strip().splitlines() if n]
         current_host = socket.gethostname().split(".")[0]
@@ -181,8 +177,7 @@ def get_head_node_ip_for_peer(peer_ip: str) -> str:
     """Return the local IP address that routes to peer_ip (used as --dist-init-addr host)."""
     try:
         result = subprocess.run(
-            ["ip", "route", "get", peer_ip],
-            capture_output=True, text=True, timeout=5,
+            ["ip", "route", "get", peer_ip], capture_output=True, text=True, timeout=5
         )
         tokens = result.stdout.split()
         for i, tok in enumerate(tokens):
@@ -217,10 +212,14 @@ def launch_peer_worker(
     are only collected from rank 0 (the head node).
     """
     worker_args = [
-        "--model-path", model_path,
-        "--nnodes", str(total_nodes),
-        "--node-rank", str(node_rank),
-        "--dist-init-addr", f"{head_ip}:{dist_port}",
+        "--model-path",
+        model_path,
+        "--nnodes",
+        str(total_nodes),
+        "--node-rank",
+        str(node_rank),
+        "--dist-init-addr",
+        f"{head_ip}:{dist_port}",
     ] + server_args
 
     # Use sys.executable so the remote worker runs in the same Python environment
@@ -249,8 +248,8 @@ def launch_peer_worker(
         # FLASHINFER_WORKSPACE_BASE: point peer node JIT cache to local /tmp so the
         #   peer doesn't share the NFS lock files with the head node, which causes
         #   OSError: [Errno 116] Stale file handle during FileLock acquisition.
-        conda_bin_dir = os.path.dirname(python_bin)          # .../envs/XXX/bin
-        conda_prefix = os.path.dirname(conda_bin_dir)        # .../envs/XXX
+        conda_bin_dir = os.path.dirname(python_bin)  # .../envs/XXX/bin
+        conda_prefix = os.path.dirname(conda_bin_dir)  # .../envs/XXX
         base_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         env_vars = (
             f"CUDA_HOME={shlex.quote(conda_prefix)}"
@@ -262,7 +261,15 @@ def launch_peer_worker(
         remote_cmd = f"env {env_vars} {cmd_str}"
 
     log_file = open(f"/tmp/sglang_worker_rank{node_rank}_{peer_host}.log", "w")
-    ssh_cmd = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes", peer_host, remote_cmd]
+    ssh_cmd = [
+        "ssh",
+        "-o",
+        "StrictHostKeyChecking=no",
+        "-o",
+        "BatchMode=yes",
+        peer_host,
+        remote_cmd,
+    ]
     log(f"Launching peer worker (rank {node_rank}) on {peer_host} (log: {log_file.name})")
     return subprocess.Popen(ssh_cmd, stdout=log_file, stderr=log_file)
 
@@ -348,6 +355,7 @@ def load_prompts_from_sharegpt(n: int) -> List[str]:
         first = conv[0]
         if isinstance(first, str):
             import json as _json
+
             try:
                 first = _json.loads(first)
             except Exception:
@@ -523,7 +531,7 @@ def main():
         type=int,
         default=20010,
         help="Port for PyTorch distributed rendezvous (--dist-init-addr). "
-             "Must differ from --port. Default: 20010.",
+        "Must differ from --port. Default: 20010.",
     )
     parser.add_argument(
         "--no-multinode",
@@ -535,7 +543,7 @@ def main():
         type=str,
         default=os.environ.get("CONDA_DEFAULT_ENV", "flashinfer_bench"),
         help="Conda environment to activate on peer nodes via SSH. "
-             "Defaults to $CONDA_DEFAULT_ENV or 'flashinfer_bench'.",
+        "Defaults to $CONDA_DEFAULT_ENV or 'flashinfer_bench'.",
     )
     args = parser.parse_args()
 
@@ -642,9 +650,12 @@ def main():
 
         # Prepend multi-node flags to head server args
         server_args = [
-            "--nnodes", str(nnodes),
-            "--node-rank", "0",
-            "--dist-init-addr", dist_addr,
+            "--nnodes",
+            str(nnodes),
+            "--node-rank",
+            "0",
+            "--dist-init-addr",
+            dist_addr,
         ] + server_args
 
     log(f"Server args:    {server_args}")
@@ -654,7 +665,8 @@ def main():
     # we prepend our nvidia includes to any existing CPATH so we don't shadow others.
     _existing_cpath = os.environ.get("CPATH", "")
     _server_cpath = (
-        f"{_NVIDIA_CPATH}:{_existing_cpath}" if _existing_cpath and _NVIDIA_CPATH
+        f"{_NVIDIA_CPATH}:{_existing_cpath}"
+        if _existing_cpath and _NVIDIA_CPATH
         else (_NVIDIA_CPATH or _existing_cpath)
     )
     process = popen_launch_server(
@@ -683,10 +695,17 @@ def main():
         for p in peer_processes:
             try:
                 # Kill the remote sglang worker via SSH, then close the local SSH process.
-                peer_host = p.args[4]  # ssh cmd: ["ssh", opts..., HOST, remote_cmd]
+                peer_host = p.args[5]  # ssh cmd: ["ssh", "-o", OPT, "-o", OPT, HOST, remote_cmd]
                 subprocess.run(
-                    ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes",
-                     peer_host, "pkill -f 'sglang.launch_server'"],
+                    [
+                        "ssh",
+                        "-o",
+                        "StrictHostKeyChecking=no",
+                        "-o",
+                        "BatchMode=yes",
+                        peer_host,
+                        "pkill -f 'sglang.launch_server'",
+                    ],
                     timeout=10,
                 )
             except Exception:

--- a/examples/sglang_bench/bench_sharegpt.py
+++ b/examples/sglang_bench/bench_sharegpt.py
@@ -44,7 +44,6 @@ import asyncio
 import json
 import math
 import os
-
 import shlex
 import socket
 import subprocess
@@ -216,9 +215,10 @@ def launch_peer_worker(
     else:
         remote_cmd = cmd_str
 
+    log_file = open(f"/tmp/sglang_worker_rank{node_rank}_{peer_host}.log", "w")
     ssh_cmd = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes", peer_host, remote_cmd]
-    log(f"Launching peer worker (rank {node_rank}) on {peer_host}")
-    return subprocess.Popen(ssh_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    log(f"Launching peer worker (rank {node_rank}) on {peer_host} (log: {log_file.name})")
+    return subprocess.Popen(ssh_cmd, stdout=log_file, stderr=log_file)
 
 
 from datasets import load_dataset
@@ -622,6 +622,16 @@ def main():
         log("Shutting down server...")
         kill_process_tree(process.pid)
         for p in peer_processes:
+            try:
+                # Kill the remote sglang worker via SSH, then close the local SSH process.
+                peer_host = p.args[4]  # ssh cmd: ["ssh", opts..., HOST, remote_cmd]
+                subprocess.run(
+                    ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes",
+                     peer_host, "pkill -f 'sglang.launch_server'"],
+                    timeout=10,
+                )
+            except Exception:
+                pass
             try:
                 kill_process_tree(p.pid)
             except Exception:

--- a/examples/sglang_bench/model_configs.json
+++ b/examples/sglang_bench/model_configs.json
@@ -17,7 +17,6 @@
         "llama-4-scout": {
             "server_flags": [
                 "--trust-remote-code",
-                "--attention-backend", "flashinfer",
                 "--tp-size", "8"
             ]
         },

--- a/examples/sglang_bench/model_configs.json
+++ b/examples/sglang_bench/model_configs.json
@@ -17,6 +17,7 @@
         "llama-4-scout": {
             "server_flags": [
                 "--trust-remote-code",
+                "--attention-backend", "flashinfer",
                 "--tp-size", "8",
                 "--mem-fraction-static", "0.75",
                 "--max-running-requests", "512"

--- a/examples/sglang_bench/model_configs.json
+++ b/examples/sglang_bench/model_configs.json
@@ -20,7 +20,8 @@
                 "--attention-backend", "flashinfer",
                 "--tp-size", "8",
                 "--mem-fraction-static", "0.75",
-                "--max-running-requests", "512"
+                "--max-running-requests", "512",
+                "--skip-server-warmup"
             ]
         },
         "deepseek-v3": {

--- a/examples/sglang_bench/model_configs.json
+++ b/examples/sglang_bench/model_configs.json
@@ -216,6 +216,7 @@
             "--disable-flashinfer-autotune",
             "--skip-server-warmup"
         ]
+    },
     "mi300x": {
         "llama-3.1-8b": {
             "server_flags": [

--- a/examples/sglang_bench/model_configs.json
+++ b/examples/sglang_bench/model_configs.json
@@ -17,7 +17,9 @@
         "llama-4-scout": {
             "server_flags": [
                 "--trust-remote-code",
-                "--tp-size", "8"
+                "--tp-size", "8",
+                "--mem-fraction-static", "0.75",
+                "--max-running-requests", "512"
             ]
         },
         "deepseek-v3": {

--- a/flashinfer_trace/definitions/moe/moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e256_h3072_i8192.json
+++ b/flashinfer_trace/definitions/moe/moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e256_h3072_i8192.json
@@ -1,0 +1,159 @@
+{
+  "name": "moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e256_h3072_i8192",
+  "description": "FP8 block-scale MoE (DeepSeek-style). MiniMax M2 (EP=1). DeepSeek sigmoid routing, n_group=1, topk_group=1.",
+  "op_type": "moe",
+  "tags": [
+    "status:verified",
+    "model:minimax-m2",
+    "quantization:float8_e4m3fn",
+    "fi_api:flashinfer.fused_moe.trtllm_fp8_block_scale_moe",
+    "ep:1",
+    "tp:8"
+  ],
+  "axes": {
+    "seq_len": {
+      "type": "var",
+      "description": "Number of input tokens."
+    },
+    "num_experts": {
+      "type": "const",
+      "value": 256,
+      "description": "Total number of experts."
+    },
+    "num_local_experts": {
+      "type": "const",
+      "value": 256,
+      "description": "Number of local experts (EP=1 → all experts)."
+    },
+    "hidden_size": {
+      "type": "const",
+      "value": 3072,
+      "description": "Hidden dimension size."
+    },
+    "intermediate_size": {
+      "type": "const",
+      "value": 8192,
+      "description": "MoE expert intermediate size."
+    },
+    "gemm1_out_size": {
+      "type": "const",
+      "value": 16384,
+      "description": "Output size of the first GEMM (W13). Should be 2 * intermediate_size."
+    },
+    "top_k": {
+      "type": "const",
+      "value": 8,
+      "description": "Number of experts selected per token."
+    },
+    "num_hidden_blocks": {
+      "type": "const",
+      "value": 24,
+      "description": "Number of quantized blocks along hidden_size (block_size=128, 3072/128=24)."
+    },
+    "num_intermediate_blocks": {
+      "type": "const",
+      "value": 64,
+      "description": "Number of quantized blocks along intermediate_size (block_size=128, 8192/128=64)."
+    },
+    "num_gemm1_out_blocks": {
+      "type": "const",
+      "value": 128,
+      "description": "Number of quantized blocks along gemm1_out_size (block_size=128, 16384/128=128)."
+    }
+  },
+  "inputs": {
+    "routing_logits": {
+      "shape": [
+        "seq_len",
+        "num_experts"
+      ],
+      "dtype": "float32",
+      "description": "Router logits."
+    },
+    "routing_bias": {
+      "shape": [
+        "num_experts"
+      ],
+      "dtype": "bfloat16",
+      "description": "Routing bias added to sigmoid scores."
+    },
+    "hidden_states": {
+      "shape": [
+        "seq_len",
+        "hidden_size"
+      ],
+      "dtype": "float8_e4m3fn",
+      "description": "Input hidden states (FP8 block-scale quantized)."
+    },
+    "hidden_states_scale": {
+      "shape": [
+        "num_hidden_blocks",
+        "seq_len"
+      ],
+      "dtype": "float32",
+      "description": "Block scales for hidden_states, shape [num_hidden_blocks, seq_len] (transposed)."
+    },
+    "gemm1_weights": {
+      "shape": [
+        "num_local_experts",
+        "gemm1_out_size",
+        "hidden_size"
+      ],
+      "dtype": "float8_e4m3fn",
+      "description": "FC1 weights (gate+up), FP8 block-scale."
+    },
+    "gemm1_weights_scale": {
+      "shape": [
+        "num_local_experts",
+        "num_gemm1_out_blocks",
+        "num_hidden_blocks"
+      ],
+      "dtype": "float32",
+      "description": "Block scales for gemm1_weights."
+    },
+    "gemm2_weights": {
+      "shape": [
+        "num_local_experts",
+        "hidden_size",
+        "intermediate_size"
+      ],
+      "dtype": "float8_e4m3fn",
+      "description": "FC2 weights (down), FP8 block-scale."
+    },
+    "gemm2_weights_scale": {
+      "shape": [
+        "num_local_experts",
+        "num_hidden_blocks",
+        "num_intermediate_blocks"
+      ],
+      "dtype": "float32",
+      "description": "Block scales for gemm2_weights."
+    },
+    "local_expert_offset": {
+      "shape": null,
+      "dtype": "int32",
+      "description": "Offset of local experts in global expert space."
+    },
+    "routed_scaling_factor": {
+      "shape": null,
+      "dtype": "float32",
+      "description": "Scaling factor for routing weights."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "seq_len",
+        "hidden_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Final MoE output tensor."
+    }
+  },
+  "constraints": [
+    "gemm1_weights.shape[1] == 2 * intermediate_size",
+    "gemm2_weights.shape[1] == hidden_size",
+    "gemm2_weights.shape[2] == intermediate_size"
+  ],
+  "reference": "import torch\n\n\n@torch.no_grad()\ndef run(\n    routing_logits: torch.Tensor,\n    routing_bias: torch.Tensor,\n    hidden_states: torch.Tensor,\n    hidden_states_scale: torch.Tensor,\n    gemm1_weights: torch.Tensor,\n    gemm1_weights_scale: torch.Tensor,\n    gemm2_weights: torch.Tensor,\n    gemm2_weights_scale: torch.Tensor,\n    local_expert_offset: int,\n    routed_scaling_factor: float,\n):\n    \"\"\"\n    FP8 block-scale MoE reference — DeepSeek routing (routing_method_type=2),\n    n_group=1, topk_group=1 (no group selection, direct top-k).\n    Routing: sigmoid(logits) + bias -> Top-K -> normalize s_nobias -> * rsf.\n    FP8 block-scale dequantization: float ≈ fp8 * scale (block size = 128).\n    Activation: SwiGLU.\n    \"\"\"\n    E_global = 256\n    H = 3072\n    I = 8192\n    TOP_K = 8\n    BLOCK = 128\n\n    T = routing_logits.shape[0]\n    E_local = gemm1_weights.shape[0]\n    device = routing_logits.device\n\n    num_h_blocks = H // BLOCK\n    num_i_blocks = I // BLOCK\n\n    # 1) FP8 block-scale dequantization of hidden_states\n    A_fp32 = hidden_states.to(torch.float32)\n    A_scale = hidden_states_scale.to(torch.float32)            # [H/128, T]\n    A_scale_TH = A_scale.permute(1, 0).contiguous()           # [T, H/128]\n    A = (A_fp32.view(T, num_h_blocks, BLOCK) *\n         A_scale_TH.unsqueeze(-1)).view(T, H)\n\n    # 2) DeepSeek routing (ng=1, kg=1 => direct top-k)\n    logits = routing_logits.to(torch.float32)\n    bias = routing_bias.to(torch.float32).reshape(-1)\n    s = torch.sigmoid(logits)                                  # [T, E] no bias\n    s_with_bias = s + bias                                     # [T, E]\n    _, topk_idx = torch.topk(s_with_bias, k=TOP_K, dim=-1)   # [T, K]\n\n    # Combination weights: normalize s (without bias) over selected experts\n    M = torch.zeros_like(s)\n    M.scatter_(1, topk_idx, 1.0)\n    weights = s * M\n    weights_sum = weights.sum(dim=-1, keepdim=True).clamp(min=1e-20)\n    weights = weights / weights_sum * routed_scaling_factor    # [T, E]\n\n    # 3) Local expert computation (per-expert dequant to keep peak memory low)\n    output = torch.zeros(T, H, dtype=torch.float32, device=device)\n    local_start = int(local_expert_offset)\n    for le in range(E_local):\n        ge = local_start + le\n        sel_mask = (topk_idx == ge).any(dim=1)\n        if not sel_mask.any():\n            continue\n        tok_idx = torch.nonzero(sel_mask, as_tuple=False).squeeze(1)\n        A_e = A.index_select(0, tok_idx)\n        W13_e = (gemm1_weights[le].to(torch.float32).view(\n            2 * num_i_blocks, BLOCK, num_h_blocks, BLOCK\n        ) * gemm1_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(2 * I, H)\n        g1 = A_e @ W13_e.t()\n        up, gate = g1[:, :I], g1[:, I:]\n        c = torch.nn.functional.silu(gate) * up\n        W2_e = (gemm2_weights[le].to(torch.float32).view(\n            num_h_blocks, BLOCK, num_i_blocks, BLOCK\n        ) * gemm2_weights_scale[le].to(torch.float32).unsqueeze(1).unsqueeze(3)).view(H, I)\n        o = c @ W2_e.t()\n        w_tok = weights[tok_idx, ge].unsqueeze(1)\n        output.index_add_(0, tok_idx, o * w_tok)\n\n    return output.to(torch.bfloat16)\n"
+}

--- a/tests/bench/test_dsa_sparse_attention_evaluator.py
+++ b/tests/bench/test_dsa_sparse_attention_evaluator.py
@@ -5,7 +5,6 @@ import torch
 
 from flashinfer_bench.bench.config import BenchmarkConfig
 from flashinfer_bench.bench.evaluators import (
-    DefaultEvaluator,
     DsaSparseAttentionEvaluator,
     DsaTopkIndexerEvaluator,
     resolve_evaluator,

--- a/tests/bench/test_dsa_topk_indexer_evaluator.py
+++ b/tests/bench/test_dsa_topk_indexer_evaluator.py
@@ -5,12 +5,10 @@ import torch
 
 from flashinfer_bench.bench.config import BenchmarkConfig
 from flashinfer_bench.bench.evaluators import (
-    DefaultEvaluator,
     DsaSparseAttentionEvaluator,
     DsaTopkIndexerEvaluator,
     resolve_evaluator,
 )
-from flashinfer_bench.bench.utils import gen_inputs
 from flashinfer_bench.compile import BuilderRegistry
 from flashinfer_bench.data import (
     AxisConst,

--- a/web/apps/web/data/models.ts
+++ b/web/apps/web/data/models.ts
@@ -810,7 +810,11 @@ const models: Model[] = [
         count: 62,
         parent: "block_sparse_moe",
         type: "layer",
-        definitions: [],
+        definitions: [
+          "moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e256_h3072_i8192",
+          "gemm_n16384_k3072",
+          "gemm_n3072_k8192",
+        ],
       },
       norm: {
         count: 1,


### PR DESCRIPTION
## Summary

- **New MoE definition**: `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e256_h3072_i8192` — MiniMax M2's 256-expert top-8 sigmoid FP8-block-scale MoE (EP=1, TP=8, `trtllm_fp8_block_scale_moe` with `routing_method_type=2`)
- **`models.ts`**: wire `moe_experts` for MiniMax M2 with the new MoE definition plus `gemm_n16384_k3072` (FC1/W13) and `gemm_n3072_k8192` (FC2/down)
- **`model_coverage.mdx`**: replace placeholder MoE row with 3 concrete definitions, bump coverage 14/15 → **17/17**

## Definitions covered (17 total)

| Definition | Notes |
|---|---|
| `rmsnorm_h3072`, `fused_add_rmsnorm_h3072` | Layer norm (already tracked) |
| `rope_with_cos_sin_cache_neox_style_d128_rd64` | NeoX RoPE, head=128, rot_dim=64 (already tracked) |
| `gqa_paged_decode_h6_kv1_d128_ps{1,64}` | GQA ratio=6 (non-PoT), decode (already tracked) |
| `gqa_paged_prefill_causal_h6_kv1_d128_ps{1,64}` | GQA ratio=6, prefill (already tracked) |
| `gqa_ragged_prefill_causal_h6_kv1_d128` | GQA ratio=6, ragged (already tracked) |
| `gemm_n8192_k3072`, `gemm_n3072_k6144`, `gemm_n256_k3072` | QKV/O/gate GEMMs (already tracked) |
| `moe_fp8_block_scale_ds_routing_topk8_ng1_kg1_e256_h3072_i8192` | **New** — MiniMax M2 MoE |
| `gemm_n16384_k3072`, `gemm_n3072_k8192` | MoE expert FC1/FC2 GEMMs (already tracked) |
| `top_k_sampling_from_probs_v200064`, etc. (3×) | Sampling v200064 (already tracked) |

## Baseline solutions (in `tmp/flashinfer-trace`, submitted separately via HF PR)

All 17 FlashInfer wrapper solutions created locally:
- 5× GQA h6_kv1: `repeat_interleave(6)` for non-PoT group_size; ps64 prefill uses native GQA; ps64 decode uses `BatchDecodeWithPagedKVCacheWrapper`
- 2× rmsnorm, 1× rope (`apply_rope_with_cos_sin_cache_inplace`), 5× gemm (`F.linear`), 3× sampling
- 1× MoE (`trtllm_fp8_block_scale_moe`, `routing_method_type=2`, `use_shuffled_weight=False`)

## Test plan
- [ ] Verify TypeScript types pass (`pnpm --filter web typecheck`)
- [ ] Confirm MiniMax M2 model page renders with all 17 definitions listed
- [ ] Collect real workloads once ≥8×H100-80GB or ≥2×B200 hardware available (TP=8, EP=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-node distributed training support with automatic peer discovery and SSH worker launching.
  * Introduced new CLI flags (`--peer-node-addr`, `--dist-init-port`, `--no-multinode`, `--conda-env`) for distributed configuration.
  * Enhanced dataset handling for ShareGPT prompt variants.

* **Documentation**
  * Added comprehensive multi-node training documentation with peer discovery and SSH environment setup guidance.
  * Updated MiniMax M2 kernel coverage from 14/15 to 17/17 with newly mapped MoE kernels.

* **Bug Fixes**
  * Fixed JSON configuration structure and improved ShareGPT dataset parsing for newer format variants.

* **Chores**
  * Cleaned up unused test imports and updated B200 model server configuration flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->