### PR TITLE
feat: add gemm_n3072_k8192 definition and reference test

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -681,12 +681,13 @@ Note: MiniMax M2 is a separate model from MiniMax-Text-01 (which uses Lightning 
 | `gemm_n8192_k3072` | gemm (fused qkv_proj) | 🟡 |
 | `gemm_n3072_k6144` | gemm (o_proj) | 🟡 |
 | `gemm_n256_k3072` | gemm (MoE gate) | 🟡 |
+| `gemm_n3072_k8192` | gemm (MoE FC2/down) | 🟡 |
 | MoE gate / topk / experts | moe | — |
 | `top_k_sampling_from_probs_v200064` | sampling | 🟡 |
 | `top_k_top_p_sampling_from_probs_v200064` | sampling | 🟡 |
 | `top_p_sampling_from_probs_v200064` | sampling | 🟡 |
 
-**Coverage**: 14 / 15 definitions present. Workloads not yet collected.
+**Coverage**: 15 / 16 definitions present. Workloads not yet collected.
 
 ---
 

--- a/flashinfer_trace/definitions/gemm/gemm_n3072_k8192.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n3072_k8192.json
@@ -1,0 +1,49 @@
+{
+  "name": "gemm_n3072_k8192",
+  "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Llama 3.2 3B mlp.down_proj (intermediate=8192 → hidden=3072). Also used by MiniMax M2 MoE FC2/down proj.",
+  "op_type": "gemm",
+  "tags": [
+    "status:unverified",
+    "model:llama-3.2-3b",
+    "model:minimax-m2"
+  ],
+  "axes": {
+    "M": {
+      "type": "var"
+    },
+    "N": {
+      "type": "const",
+      "value": 3072
+    },
+    "K": {
+      "type": "const",
+      "value": 8192
+    }
+  },
+  "inputs": {
+    "A": {
+      "shape": [
+        "M",
+        "K"
+      ],
+      "dtype": "float16"
+    },
+    "B": {
+      "shape": [
+        "N",
+        "K"
+      ],
+      "dtype": "float16"
+    }
+  },
+  "outputs": {
+    "C": {
+      "shape": [
+        "M",
+        "N"
+      ],
+      "dtype": "float16"
+    }
+  },
+  "reference": "import torch\n\ndef run(A, B):\n    C = torch.matmul(A, B.T)\n    return C"
+}

--- a/flashinfer_trace/definitions/gemm/gemm_n3072_k8192.json
+++ b/flashinfer_trace/definitions/gemm/gemm_n3072_k8192.json
@@ -1,11 +1,10 @@
 {
   "name": "gemm_n3072_k8192",
-  "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Llama 3.2 3B mlp.down_proj (intermediate=8192 → hidden=3072). Also used by MiniMax M2 MoE FC2/down proj.",
+  "description": "General matrix multiply (GEMM) C = A @ B.T. Captured from Llama 3.2 3B mlp.down_proj (intermediate=8192 → hidden=3072).",
   "op_type": "gemm",
   "tags": [
     "status:unverified",
-    "model:llama-3.2-3b",
-    "model:minimax-m2"
+    "model:llama-3.2-3b"
   ],
   "axes": {
     "M": {

--- a/flashinfer_trace/tests/references/test_gemm_n3072_k8192.py
+++ b/flashinfer_trace/tests/references/test_gemm_n3072_k8192.py
@@ -1,0 +1,126 @@
+import torch
+import torch.nn.functional as F
+
+
+@torch.no_grad()
+def run(A, B):
+    """
+    Reference implementation of GEMM C = A @ B.T with N=3072, K=8192.
+
+    This corresponds to MiniMax M2 MoE FC2/down projection (W2):
+      Input: intermediate_size = 8192
+      Output: hidden_size = 3072
+
+    Args:
+        A: Input tensor of shape (M, 8192) in float16
+        B: Weight tensor of shape (3072, 8192) in float16
+
+    Returns:
+        C: Output tensor of shape (M, 3072) in float16
+    """
+    N, K = B.shape
+    assert K == 8192, f"Expected K=8192, got {K}"
+    assert N == 3072, f"Expected N=3072, got {N}"
+    assert A.shape[1] == K, f"Expected A.shape[1]={K}, got {A.shape[1]}"
+
+    C = torch.matmul(A, B.T)
+    return C
+
+
+def generate_random_inputs(M, device="cuda"):
+    """Generate random inputs for testing GEMM N=3072, K=8192."""
+    N = 3072
+    K = 8192
+
+    A = torch.randn(M, K, dtype=torch.float16, device=device)
+    B = torch.randn(N, K, dtype=torch.float16, device=device)
+
+    return {"A": A, "B": B}
+
+
+def test_correctness(M=128, atol=1e-2, rtol=1e-2):
+    """Test correctness of reference GEMM against torch.nn.functional.linear."""
+    print(f"\n{'='*60}")
+    print(f"Testing GEMM N=3072, K=8192: M={M}")
+    print(f"{'='*60}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return False
+
+    inputs = generate_random_inputs(M, device)
+    A = inputs["A"]
+    B = inputs["B"]
+
+    print(f"A shape: {A.shape}, dtype: {A.dtype}")
+    print(f"B shape: {B.shape}, dtype: {B.dtype}")
+
+    print("\nRunning reference implementation (A @ B.T)...")
+    ref_output = run(A, B)
+
+    print("Running F.linear implementation...")
+    fi_output = F.linear(A, B)
+
+    print("\nComparing outputs...")
+
+    ref_f32 = ref_output.float()
+    fi_f32 = fi_output.float()
+
+    abs_diff = torch.abs(ref_f32 - fi_f32)
+    rel_diff = abs_diff / (torch.abs(fi_f32) + 1e-8)
+
+    max_abs_diff = abs_diff.max().item()
+    max_rel_diff = rel_diff.max().item()
+    mean_abs_diff = abs_diff.mean().item()
+    mean_rel_diff = rel_diff.mean().item()
+
+    print(f"\nOutput tensor comparison:")
+    print(f"  Output shape: {ref_output.shape}")
+    print(f"  Max absolute difference: {max_abs_diff:.6e}")
+    print(f"  Max relative difference: {max_rel_diff:.6e}")
+    print(f"  Mean absolute difference: {mean_abs_diff:.6e}")
+    print(f"  Mean relative difference: {mean_rel_diff:.6e}")
+
+    output_close = torch.allclose(ref_f32, fi_f32, atol=atol, rtol=rtol)
+
+    if output_close:
+        print(f"\n✓ PASSED: Outputs match within tolerance (atol={atol}, rtol={rtol})")
+    else:
+        print(f"\n✗ FAILED: Outputs differ beyond tolerance (atol={atol}, rtol={rtol})")
+
+    return output_close
+
+
+def main():
+    """Run comprehensive tests for GEMM N=3072, K=8192."""
+    print("Testing GEMM N=3072, K=8192 Reference Implementation")
+
+    test_M_values = [1, 4, 16, 64, 128, 256]
+
+    passed = 0
+    total = len(test_M_values)
+
+    for M in test_M_values:
+        try:
+            if test_correctness(M):
+                passed += 1
+        except Exception as e:
+            print(f"✗ Test failed with exception: {str(e)}")
+            import traceback
+
+            traceback.print_exc()
+
+    print(f"\n{'='*60}")
+    print(f"Summary: {passed}/{total} tests passed")
+    print(f"{'='*60}")
+
+    if passed == total:
+        print("✓ All tests passed!")
+    else:
+        print(f"✗ {total - passed} tests failed")
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `gemm_n3072_k8192` definition and reference test.

This GEMM shape (N=3072, K=8192) appears in:
- Llama 3.2 3B `mlp.down_proj` (intermediate=8192 → hidden=3072)
- MiniMax M2 MoE FC2/down proj (same dimensions)

| Field | Value |
|-------|-------|
| Definition | `gemm_n3072_k8192` |
| Op type | gemm |
| Models | Llama 3.2 3B, MiniMax M2 |
| N | 3072 |
| K | 8192 |
| dtype | float16 |

## Reference Test Output

```
Testing GEMM N=3072, K=8192 Reference Implementation
Summary: 6/6 tests passed
✓ All tests passed!
```

## Coverage Update

MiniMax M2: 14/15 → 15/16 definitions present

## PR2 (HuggingFace trace)
_Link to be added after PR2 opens._