### PR TITLE
Adapt codebase to author-based trace directory layout

### DIFF
--- a/examples/win_at_p.py
+++ b/examples/win_at_p.py
@@ -38,7 +38,7 @@ import sys
 from collections import defaultdict
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 
-import matplotlib
+import matplotlib.pyplot as plt  # lazy import
 
 # ---------- Parsing helpers ----------
 
@@ -349,8 +349,6 @@ def make_win_at_p_plot(
     """
     Render a single Win@p plot. If out_path is provided, saves there; otherwise shows interactively.
     """
-    import matplotlib.pyplot as plt  # lazy import
-
     if not p_grid or not authors_to_plot:
         raise RuntimeError("Nothing to plot: empty p-grid or no authors selected.")
 

--- a/examples/win_at_p.py
+++ b/examples/win_at_p.py
@@ -17,15 +17,15 @@ Outputs:
   (n_total is the number of workload groups where this author had a valid run; n_wins counts those with r>p)
 
 Examples:
-  python win_at_p.py traces/*/*.jsonl -o win_at_p.csv
-  python win_at_p.py traces/*/*.jsonl -o win_at_p.csv --baseline-author torch
-  python win_at_p.py traces/*/*.jsonl -o win_at_p.csv --author-map author_map.json
+  python win_at_p.py traces/*/*/*.jsonl -o win_at_p.csv
+  python win_at_p.py traces/*/*/*.jsonl -o win_at_p.csv --baseline-author torch
+  python win_at_p.py traces/*/*/*.jsonl -o win_at_p.csv --author-map author_map.json
   # author_map.json example:
   # { "rmsnorm_triton_v1": "alice", "my_fast_impl": "bob" }
 
 Notes:
 - If multiple runs exist for the same author within a group, we take the MIN latency for that author in that group.
-- By default, the baseline author ('flashinfer') is EXCLUDED from output curves; use --include-baseline to include it.
+- By default, the baseline author ('baseline') is EXCLUDED from output curves; use --include-baseline to include it.
 """
 
 import argparse
@@ -404,8 +404,8 @@ def main():
     )
     ap.add_argument(
         "--baseline-author",
-        default="flashinfer",
-        help="Baseline author name to prefer when present (default: flashinfer).",
+        default="baseline",
+        help="Baseline author name to prefer when present (default: baseline).",
     )
     ap.add_argument(
         "--include-baseline",

--- a/flashinfer_bench/data/trace_set.py
+++ b/flashinfer_bench/data/trace_set.py
@@ -350,7 +350,7 @@ class TraceSet:
 
     def summary(
         self,
-        baseline_author: str = "flashinfer",
+        baseline_author: str = "baseline",
         op_type: Optional[str] = None,
         definition_name: Optional[str] = None,
     ) -> TraceSetSummary:
@@ -383,7 +383,7 @@ class TraceSet:
         )
 
     def get_solution_score(
-        self, solution_name: str, baseline_author: str = "flashinfer"
+        self, solution_name: str, baseline_author: str = "baseline"
     ) -> Optional[SpeedupMetrics]:
         """Get the score for a single solution against the baseline.
 
@@ -404,7 +404,7 @@ class TraceSet:
         solution_name : str
             Solution name to score.
         baseline_author : str
-            Author name to use as baseline (default: 'flashinfer').
+            Author name to use as baseline (default: 'baseline').
 
         Returns
         -------
@@ -520,7 +520,7 @@ class TraceSet:
     def get_author_score(
         self,
         author: str,
-        baseline_author: str = "flashinfer",
+        baseline_author: str = "baseline",
         op_type: Optional[str] = None,
         definition_name: Optional[str] = None,
     ) -> Optional[SpeedupMetrics]:
@@ -536,7 +536,7 @@ class TraceSet:
         author : str
             Author name to score.
         baseline_author : str
-            Author name to use as baseline (default: 'flashinfer').
+            Author name to use as baseline (default: 'baseline').
         op_type : Optional[str]
             Operation type to score within.
         definition_name : Optional[str]
@@ -596,7 +596,7 @@ class TraceSet:
 
     def rank_authors(
         self,
-        baseline_author: str = "flashinfer",
+        baseline_author: str = "baseline",
         op_type: Optional[str] = None,
         definition_name: Optional[str] = None,
     ) -> List[Tuple[str, SpeedupMetrics]]:
@@ -609,7 +609,7 @@ class TraceSet:
         Parameters
         ----------
         baseline_author : str
-            Author name to use as baseline (default: 'flashinfer').
+            Author name to use as baseline (default: 'baseline').
         op_type : Optional[str]
             Operation type to rank within.
         definition_name : Optional[str]
@@ -702,7 +702,14 @@ class TraceSet:
 
             # Add to disk bucket
             definition = self.definitions[trace.definition]
-            path = self.traces_path / definition.op_type / f"{definition.name}.jsonl"
+            if trace.solution is None:
+                raise ValueError("Cannot add workload-only trace with add_traces")
+            solution = self._solution_by_name.get(trace.solution)
+            if solution is None:
+                raise ValueError(f"Unknown solution: {trace.solution}")
+            path = (
+                self.traces_path / solution.author / definition.op_type / f"{definition.name}.jsonl"
+            )
             buckets[path].append(trace)
 
         # Write to disk

--- a/scripts/collect_workloads.py
+++ b/scripts/collect_workloads.py
@@ -1107,14 +1107,12 @@ def run_baseline_eval(def_files: list[Path], trace_dir: Path) -> None:
     """Run the baseline (reference) solution against collected workloads.
 
     Uses ``flashinfer-bench run`` to evaluate the baseline solution for each
-    definition and saves a per-definition trace JSONL to
-    ``{trace_dir}/traces/<def_name>_baseline.jsonl``.
+    definition and appends the resulting traces to
+    ``{trace_dir}/traces/baseline/<op_type>/<def_name>.jsonl``.
 
     Exits with a non-zero status if any workload evaluation returns a status
     other than PASSED.
     """
-    import datetime
-
     traces_dir = trace_dir / "traces"
     traces_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1128,7 +1126,8 @@ def run_baseline_eval(def_files: list[Path], trace_dir: Path) -> None:
             continue
 
         print(f"\nPhase 5: Baseline evaluation — {def_name}")
-        out_trace = traces_dir / f"{def_name}_baseline.jsonl"
+        op_type = def_file.parent.name
+        out_trace = traces_dir / "baseline" / op_type / f"{def_name}.jsonl"
 
         cmd = [
             sys.executable,
@@ -1151,17 +1150,13 @@ def run_baseline_eval(def_files: list[Path], trace_dir: Path) -> None:
         result = subprocess.run(cmd, capture_output=True, text=True)
         stdout = result.stdout + result.stderr
 
-        # Collect trace lines from the standard trace output location
-        # flashinfer-bench writes traces to {trace_dir}/traces/<def_name>_workloads.jsonl
-        auto_trace = traces_dir / f"{def_name}_workloads.jsonl"
-
         failed = []
         passed = 0
 
-        if auto_trace.exists():
+        if out_trace.exists():
             import json as _json
 
-            lines = [l.strip() for l in auto_trace.read_text().splitlines() if l.strip()]
+            lines = [l.strip() for l in out_trace.read_text().splitlines() if l.strip()]
             for line in lines:
                 try:
                     rec = _json.loads(line)
@@ -1175,10 +1170,6 @@ def run_baseline_eval(def_files: list[Path], trace_dir: Path) -> None:
                 except Exception:
                     pass
 
-            # Copy to per-def baseline trace name
-            import shutil
-
-            shutil.copy(auto_trace, out_trace)
             print(f"  Results: {passed} PASSED, {len(failed)} FAILED")
             if failed:
                 print(f"  FAILED workloads:")
@@ -1189,7 +1180,7 @@ def run_baseline_eval(def_files: list[Path], trace_dir: Path) -> None:
                 print(f"  All {passed} workloads PASSED ✓")
                 print(f"  Trace written to: {out_trace}")
         else:
-            print(f"  WARNING: No trace output found at {auto_trace}")
+            print(f"  WARNING: No trace output found at {out_trace}")
             print(f"  flashinfer-bench stdout:\n{stdout[:2000]}")
             if result.returncode != 0:
                 all_passed = False
@@ -1330,7 +1321,7 @@ def main():
         help=(
             "After collecting workloads, run the baseline solution against them using "
             "'flashinfer-bench run' and write per-workload trace JSONL to "
-            "{trace_dir}/traces/<def_name>_baseline.jsonl. All workloads must PASS. "
+            "{trace_dir}/traces/baseline/<op_type>/<def_name>.jsonl. All workloads must PASS. "
             "Enabled by default; use --no-eval-baseline to skip."
         ),
     )

--- a/scripts/collect_workloads_agent.py
+++ b/scripts/collect_workloads_agent.py
@@ -214,10 +214,12 @@ def tool_check_workloads(flashinfer_trace_dir: str, definition: str) -> str:
     blobs = list(blob_dir.glob("*.safetensors")) if blob_dir.exists() else []
     results["blob_count"] = len(blobs)
 
-    trace_file = trace_dir / "traces" / op_type / f"{definition}.jsonl"
-    results["trace_exists"] = trace_file.exists()
-    if trace_file.exists():
-        records = [json.loads(l) for l in trace_file.read_text().splitlines() if l.strip()]
+    trace_files = list((trace_dir / "traces").glob(f"*/{op_type}/{definition}.jsonl"))
+    results["trace_exists"] = bool(trace_files)
+    if trace_files:
+        records = []
+        for tf in trace_files:
+            records.extend(json.loads(l) for l in tf.read_text().splitlines() if l.strip())
         statuses = [r.get("evaluation", {}).get("status") for r in records]
         results["trace_statuses"] = dict(
             passed=statuses.count("PASSED"), failed=statuses.count("FAILED"), total=len(statuses)

--- a/scripts/onboard_definition_agent.py
+++ b/scripts/onboard_definition_agent.py
@@ -253,9 +253,11 @@ def tool_check_workloads(flashinfer_trace_dir: str, definition: str) -> str:
     results["workload_count"] = len(wf.read_text().splitlines()) if wf.exists() else 0
     blobs = list((trace_dir / "blob" / "workloads" / op_type / definition).glob("*.safetensors"))
     results["blob_count"] = len(blobs)
-    tf = trace_dir / "traces" / op_type / f"{definition}.jsonl"
-    if tf.exists():
-        records = [json.loads(l) for l in tf.read_text().splitlines() if l.strip()]
+    trace_files = list((trace_dir / "traces").glob(f"*/{op_type}/{definition}.jsonl"))
+    if trace_files:
+        records = []
+        for tf in trace_files:
+            records.extend(json.loads(l) for l in tf.read_text().splitlines() if l.strip())
         statuses = [r.get("evaluation", {}).get("status") for r in records]
         results["trace_passed"] = statuses.count("PASSED")
         results["trace_failed"] = statuses.count("FAILED")

--- a/tests/data/test_trace_set.py
+++ b/tests/data/test_trace_set.py
@@ -21,6 +21,7 @@ from flashinfer_bench.data import (
     Trace,
     TraceSet,
     Workload,
+    load_jsonl_file,
     save_json_file,
     save_jsonl_file,
 )
@@ -28,9 +29,12 @@ from flashinfer_bench.data import (
 
 def test_trace_set_from_path_and_queries(tmp_path: Path):
     # Create directory structure
-    (tmp_path / "definitions").mkdir()
-    (tmp_path / "solutions").mkdir()
-    (tmp_path / "traces").mkdir()
+    (tmp_path / "definitions" / "op").mkdir(parents=True)
+    (tmp_path / "solutions" / "a" / "op" / "d1").mkdir(parents=True)
+    (tmp_path / "solutions" / "b" / "op" / "d1").mkdir(parents=True)
+    (tmp_path / "workloads" / "op").mkdir(parents=True)
+    (tmp_path / "traces" / "a" / "op").mkdir(parents=True)
+    (tmp_path / "traces" / "b" / "op").mkdir(parents=True)
 
     # Definition
     ref = "def run(a):\n    return a\n"
@@ -42,7 +46,7 @@ def test_trace_set_from_path_and_queries(tmp_path: Path):
         outputs={"B": TensorSpec(shape=["M", "N"], dtype="float32")},
         reference=ref,
     )
-    save_json_file(definition, tmp_path / "definitions" / "d1.json")
+    save_json_file(definition, tmp_path / "definitions" / "op" / "d1.json")
 
     # Solutions
     solution1 = Solution(
@@ -63,8 +67,8 @@ def test_trace_set_from_path_and_queries(tmp_path: Path):
         ),
         sources=[SourceFile(path="main.py", content="def run():\n    pass\n")],
     )
-    save_json_file(solution1, tmp_path / "solutions" / "s1.json")
-    save_json_file(solution2, tmp_path / "solutions" / "s2.json")
+    save_json_file(solution1, tmp_path / "solutions" / "a" / "op" / "d1" / "s1.json")
+    save_json_file(solution2, tmp_path / "solutions" / "b" / "op" / "d1" / "s2.json")
 
     # Traces JSONL
     trace_pass = Trace(
@@ -94,8 +98,9 @@ def test_trace_set_from_path_and_queries(tmp_path: Path):
     trace_workload = Trace(
         definition="d1", workload=Workload(axes={"M": 3}, inputs={"A": RandomInput()}, uuid="tw3")
     )
-    save_jsonl_file([trace_workload], tmp_path / "workloads" / "d1.jsonl")
-    save_jsonl_file([trace_pass, trace_fail], tmp_path / "traces" / "d1.jsonl")
+    save_jsonl_file([trace_workload], tmp_path / "workloads" / "op" / "d1.jsonl")
+    save_jsonl_file([trace_pass], tmp_path / "traces" / "a" / "op" / "d1.jsonl")
+    save_jsonl_file([trace_fail], tmp_path / "traces" / "b" / "op" / "d1.jsonl")
 
     # Load
     trace_set = TraceSet.from_path(str(tmp_path))
@@ -161,7 +166,7 @@ def test_trace_set_ranking_uses_avg_speedup():
         definitions={"d1": definition},
         solutions={
             "d1": [
-                make_solution("baseline", "flashinfer"),
+                make_solution("baseline", "baseline"),
                 make_solution("alice", "alice"),
                 make_solution("bob", "bob"),
             ]
@@ -258,7 +263,7 @@ def test_trace_set_ranking_counts_missing_pass_as_zero():
         definitions={"d1": definition},
         solutions={
             "d1": [
-                make_solution("baseline", "flashinfer"),
+                make_solution("baseline", "baseline"),
                 make_solution("alice", "alice"),
                 make_solution("bob", "bob"),
             ]
@@ -345,7 +350,7 @@ def test_trace_set_ranking_uses_best_solution_per_author_and_definition():
         definitions={"d1": definition},
         solutions={
             "d1": [
-                make_solution("baseline", "flashinfer"),
+                make_solution("baseline", "baseline"),
                 make_solution("alice_bad", "alice"),
                 make_solution("alice_good", "alice"),
                 make_solution("bob", "bob"),
@@ -475,12 +480,12 @@ def test_multi_definition_scope_and_best_solutions():
         definitions={"d1": make_def("d1", "attn"), "d2": make_def("d2", "norm")},
         solutions={
             "d1": [
-                make_solution("bl_d1", "flashinfer", "d1"),
+                make_solution("bl_d1", "baseline", "d1"),
                 make_solution("alice_d1_slow", "alice", "d1"),
                 make_solution("alice_d1_fast", "alice", "d1"),
             ],
             "d2": [
-                make_solution("bl_d2", "flashinfer", "d2"),
+                make_solution("bl_d2", "baseline", "d2"),
                 make_solution("alice_d2", "alice", "d2"),
             ],
         },
@@ -568,9 +573,7 @@ def test_summary_includes_rankings():
 
     trace_set = TraceSet(
         definitions={"d1": definition},
-        solutions={
-            "d1": [make_solution("baseline", "flashinfer"), make_solution("alice", "alice")]
-        },
+        solutions={"d1": [make_solution("baseline", "baseline"), make_solution("alice", "alice")]},
         traces={"d1": [make_trace("baseline", "w1", 10.0), make_trace("alice", "w1", 5.0)]},
     )
 

--- a/web/apps/web/lib/data-loader.ts
+++ b/web/apps/web/lib/data-loader.ts
@@ -140,35 +140,38 @@ export async function getTracesForDefinition(definitionName: string): Promise<Tr
 
     const traces: Trace[] = []
 
-    // Read all subdirectories (gemm, gqa, mla, etc.)
-    const types = await fs.readdir(tracesDir)
+    // Read all author directories, then op_type subdirectories under each.
+    const authors = await fs.readdir(tracesDir)
 
-    for (const type of types) {
-      if (type === "workload") {
-        continue
-      }
-      const typePath = path.join(tracesDir, type)
-      const stat = await fs.stat(typePath).catch(() => null)
+    for (const author of authors) {
+      const authorPath = path.join(tracesDir, author)
+      const authorStat = await fs.stat(authorPath).catch(() => null)
+      if (!authorStat || !authorStat.isDirectory()) continue
 
-      if (stat && stat.isDirectory()) {
-        // Look for JSONL files in this directory
-        const files = await fs.readdir(typePath)
+      const types = await fs.readdir(authorPath)
 
-        for (const file of files) {
-          // Check if this file matches our definition name
-          if (file === `${definitionName}.jsonl`) {
-            const content = await fs.readFile(path.join(typePath, file), "utf-8")
-            const lines = content.trim().split("\n")
+      for (const type of types) {
+        const typePath = path.join(authorPath, type)
+        const stat = await fs.stat(typePath).catch(() => null)
 
-            for (const line of lines) {
-              if (line) {
-                try {
-                  const trace = JSON.parse(line) as Trace
-                  if (trace.definition === definitionName) {
-                    traces.push(trace)
+        if (stat && stat.isDirectory()) {
+          const files = await fs.readdir(typePath)
+
+          for (const file of files) {
+            if (file === `${definitionName}.jsonl`) {
+              const content = await fs.readFile(path.join(typePath, file), "utf-8")
+              const lines = content.trim().split("\n")
+
+              for (const line of lines) {
+                if (line) {
+                  try {
+                    const trace = JSON.parse(line) as Trace
+                    if (trace.definition === definitionName) {
+                      traces.push(trace)
+                    }
+                  } catch (e) {
+                    console.error(`Failed to parse trace line in ${file}:`, e)
                   }
-                } catch (e) {
-                  console.error(`Failed to parse trace line in ${file}:`, e)
                 }
               }
             }


### PR DESCRIPTION
## Summary
- Update trace read/write paths to use `traces/<author>/<op_type>/<definition>.jsonl` layout (matching the existing `solutions/` hierarchy)
- Change default `baseline_author` from `"flashinfer"` to `"baseline"` across `TraceSet`, scripts, and examples
- Adapt web data-loader, agent scripts, and workload collection to glob the new directory structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured trace data storage to use a hierarchical directory organization by author and operation type.
  * Updated trace loading and validation logic to work with the new trace directory structure.

* **Chores**
  * Updated default baseline author value from "flashinfer" to "baseline" across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->