### PR TITLE
feat: add gqa_paged ps64 definitions for Llama 4 Scout/Maverick (TP=8)

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -557,9 +557,9 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `rmsnorm_h5120` | rmsnorm | 🟡 |
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
-| `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | 🟡 |
 | `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
-| `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | 🟡 |
 | `gqa_ragged_prefill_causal_h5_kv1_d128` | gqa_ragged TP=8 | 🟡 |
 | MoE experts (top-1, 16 experts, standard routing) | moe | — |
 | `trtllm_fp4_block_scale_moe_topk1_e16_h5120_i8192` | moe (TRT-LLM FP4, Llama4 routing) | 🟡 |
@@ -584,9 +584,9 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `rmsnorm_h5120` | rmsnorm | 🟡 |
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
-| `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | 🟡 |
 | `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
-| `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | 🟡 |
 | `gqa_ragged_prefill_causal_h5_kv1_d128` | gqa_ragged TP=8 | 🟡 |
 | MoE experts (top-1, 128 experts, standard routing) | moe | — |
 | `trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192` | moe (TRT-LLM FP4, Llama4 routing) | 🟡 |

--- a/flashinfer_trace/definitions/gqa_paged/gqa_paged_decode_h5_kv1_d128_ps64.json
+++ b/flashinfer_trace/definitions/gqa_paged/gqa_paged_decode_h5_kv1_d128_ps64.json
@@ -1,0 +1,124 @@
+{
+  "name": "gqa_paged_decode_h5_kv1_d128_ps64",
+  "description": "Batched Grouped Query Attention decode with a paged KV cache (page_size=64). Captured from Llama 4 Scout/Maverick at TP=8. 5 q-heads, 1 kv-heads, head_dim=128.",
+  "op_type": "gqa_paged",
+  "tags": [
+    "stage:decode",
+    "status:unverified",
+    "model:llama-4-scout",
+    "fi_api:flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper",
+    "tp:8"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Total number of sequences."
+    },
+    "num_qo_heads": {
+      "type": "const",
+      "value": 5,
+      "description": "Number of query heads after tensor parallel split (40/8=5)."
+    },
+    "num_kv_heads": {
+      "type": "const",
+      "value": 1,
+      "description": "Number of KV heads after tensor parallel split (8/8=1)."
+    },
+    "head_dim": {
+      "type": "const",
+      "value": 128
+    },
+    "num_pages": {
+      "type": "var"
+    },
+    "page_size": {
+      "type": "const",
+      "value": 64
+    },
+    "len_indptr": {
+      "type": "var",
+      "description": "Length of kv_indptr array."
+    },
+    "num_kv_indices": {
+      "type": "var",
+      "description": "Total number of KV page indices."
+    }
+  },
+  "constraints": [
+    "len_indptr == batch_size + 1",
+    "num_kv_indices == kv_indptr[-1].item()"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "batch_size",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "k_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "v_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "kv_indptr": {
+      "shape": [
+        "len_indptr"
+      ],
+      "dtype": "int32",
+      "description": "KV page offsets for each sequence."
+    },
+    "kv_indices": {
+      "shape": [
+        "num_kv_indices"
+      ],
+      "dtype": "int32",
+      "description": "Page IDs for KV cache lookups."
+    },
+    "kv_last_page_len": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Number of valid tokens in the last page for each sequence."
+    },
+    "sm_scale": {
+      "shape": null,
+      "dtype": "float32",
+      "description": "Softmax scale. Default is (1/sqrt(head_dim))."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "batch_size",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "lse": {
+      "shape": [
+        "batch_size",
+        "num_qo_heads"
+      ],
+      "dtype": "float32",
+      "description": "The 2-based log-sum-exp of attention logits."
+    }
+  },
+  "reference": "import torch\nimport math\n\n\n@torch.no_grad()\ndef run(q, k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, sm_scale):\n    batch_size, num_qo_heads, head_dim = q.shape\n    _, page_size, num_kv_heads, _ = k_cache.shape\n    len_indptr = kv_indptr.shape[0]\n    num_kv_indices = kv_indices.shape[0]\n\n    # Check constants\n    assert num_qo_heads == 5\n    assert num_kv_heads == 1\n    assert head_dim == 128\n    assert page_size == 64\n\n    # Check constraints\n    assert len_indptr == batch_size + 1\n    assert num_kv_indices == kv_indptr[-1].item()\n\n    device = q.device\n\n    output = torch.zeros(\n        (batch_size, num_qo_heads, head_dim), dtype=torch.bfloat16, device=device\n    )\n    lse = torch.full(\n        (batch_size, num_qo_heads), -float(\"inf\"), dtype=torch.float32, device=device\n    )\n\n    gqa_ratio = num_qo_heads // num_kv_heads\n\n    k_cache_f32 = k_cache.to(torch.float32)\n    v_cache_f32 = v_cache.to(torch.float32)\n\n    for b in range(batch_size):\n        page_start = int(kv_indptr[b].item())\n        page_end = int(kv_indptr[b + 1].item())\n        last_page_len = int(kv_last_page_len[b].item())\n\n        if page_start >= page_end:\n            output[b].zero_()\n            continue\n\n        page_ids = kv_indices[page_start:page_end].to(torch.long)\n        num_pages_for_seq = page_ids.shape[0]\n\n        if num_pages_for_seq == 0:\n            output[b].zero_()\n            continue\n\n        num_full_pages = num_pages_for_seq - 1\n        total_tokens = num_full_pages * page_size + last_page_len\n\n        if total_tokens == 0:\n            output[b].zero_()\n            continue\n\n        k_batch = torch.zeros(\n            (total_tokens, num_kv_heads, head_dim), dtype=torch.float32, device=device\n        )\n        v_batch = torch.zeros(\n            (total_tokens, num_kv_heads, head_dim), dtype=torch.float32, device=device\n        )\n\n        token_idx = 0\n        for p_idx, page_id in enumerate(page_ids):\n            if p_idx < num_full_pages:\n                k_batch[token_idx : token_idx + page_size] = k_cache_f32[page_id]\n                v_batch[token_idx : token_idx + page_size] = v_cache_f32[page_id]\n                token_idx += page_size\n            else:\n                k_batch[token_idx : token_idx + last_page_len] = k_cache_f32[\n                    page_id, :last_page_len\n                ]\n                v_batch[token_idx : token_idx + last_page_len] = v_cache_f32[\n                    page_id, :last_page_len\n                ]\n                token_idx += last_page_len\n\n        q_batch = q[b].to(torch.float32)\n\n        for h in range(num_qo_heads):\n            kv_head = h // gqa_ratio\n\n            q_head = q_batch[h]\n            k_head = k_batch[:, kv_head]\n            v_head = v_batch[:, kv_head]\n\n            logits = torch.matmul(q_head, k_head.T)\n            logits_scaled = logits * sm_scale\n\n            lse[b, h] = torch.logsumexp(logits_scaled, dim=-1) / math.log(2.0)\n\n            attn = torch.softmax(logits_scaled, dim=-1)\n            out_head = torch.matmul(attn, v_head)\n            output[b, h] = out_head.to(torch.bfloat16)\n\n    return output, lse"
+}

--- a/flashinfer_trace/definitions/gqa_paged/gqa_paged_prefill_causal_h5_kv1_d128_ps64.json
+++ b/flashinfer_trace/definitions/gqa_paged/gqa_paged_prefill_causal_h5_kv1_d128_ps64.json
@@ -1,0 +1,135 @@
+{
+  "name": "gqa_paged_prefill_causal_h5_kv1_d128_ps64",
+  "description": "Batched Grouped Query Attention prefill with a paged KV cache (page_size=64). Causal mask applied. From Llama 4 Scout/Maverick at TP=8. 5 q-heads, 1 kv-heads, head_dim=128.",
+  "op_type": "gqa_paged",
+  "tags": [
+    "stage:prefill",
+    "status:unverified",
+    "model:llama-4-scout",
+    "fi_api:flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper",
+    "tp:8"
+  ],
+  "axes": {
+    "num_qo_heads": {
+      "type": "const",
+      "value": 5,
+      "description": "Number of query heads after tensor parallel split (40/8=5)."
+    },
+    "num_kv_heads": {
+      "type": "const",
+      "value": 1,
+      "description": "Number of KV heads after tensor parallel split (8/8=1)."
+    },
+    "head_dim": {
+      "type": "const",
+      "value": 128
+    },
+    "page_size": {
+      "type": "const",
+      "value": 64
+    },
+    "batch_size": {
+      "type": "var",
+      "description": "Number of sequences in the batch."
+    },
+    "len_indptr": {
+      "type": "var",
+      "description": "Length of indptr arrays."
+    },
+    "total_q": {
+      "type": "var",
+      "description": "Total number of query tokens."
+    },
+    "num_kv_indices": {
+      "type": "var",
+      "description": "Total number of KV page indices."
+    },
+    "num_pages": {
+      "type": "var"
+    }
+  },
+  "constraints": [
+    "total_q == qo_indptr[-1].item()",
+    "num_kv_indices == kv_indptr[-1].item()"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "total_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "k_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "v_cache": {
+      "shape": [
+        "num_pages",
+        "page_size",
+        "num_kv_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "qo_indptr": {
+      "shape": [
+        "len_indptr"
+      ],
+      "dtype": "int32",
+      "description": "Query offsets for each sequence."
+    },
+    "kv_indptr": {
+      "shape": [
+        "len_indptr"
+      ],
+      "dtype": "int32",
+      "description": "KV page offsets for each sequence."
+    },
+    "kv_indices": {
+      "shape": [
+        "num_kv_indices"
+      ],
+      "dtype": "int32",
+      "description": "Page IDs for KV cache lookups."
+    },
+    "kv_last_page_len": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Number of valid tokens in the last page for each sequence."
+    },
+    "sm_scale": {
+      "shape": null,
+      "dtype": "float32",
+      "description": "Softmax scale. Default is (1/sqrt(head_dim))."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "total_q",
+        "num_qo_heads",
+        "head_dim"
+      ],
+      "dtype": "bfloat16"
+    },
+    "lse": {
+      "shape": [
+        "total_q",
+        "num_qo_heads"
+      ],
+      "dtype": "float32",
+      "description": "The 2-based log-sum-exp of attention logits."
+    }
+  },
+  "reference": "import torch\nimport math\n\n\n@torch.no_grad()\ndef run(q, k_cache, v_cache, qo_indptr, kv_indptr, kv_indices, kv_last_page_len, sm_scale):\n    total_q, num_qo_heads, head_dim = q.shape\n    num_pages, page_size, num_kv_heads, _ = k_cache.shape\n    len_indptr = qo_indptr.shape[0]\n    num_kv_indices = kv_indices.shape[0]\n\n    # Check constants\n    assert num_qo_heads == 5\n    assert num_kv_heads == 1\n    assert head_dim == 128\n    assert page_size == 64\n\n    # Check constraints\n    assert total_q == qo_indptr[-1].item()\n\n    device = q.device\n    batch_size = len_indptr - 1\n\n    output = torch.zeros(\n        (total_q, num_qo_heads, head_dim), dtype=torch.bfloat16, device=device\n    )\n    lse = torch.full(\n        (total_q, num_qo_heads), -float(\"inf\"), dtype=torch.float32, device=device\n    )\n\n    gqa_ratio = num_qo_heads // num_kv_heads\n\n    q_f32 = q.to(torch.float32)\n    k_cache_f32 = k_cache.to(torch.float32)\n    v_cache_f32 = v_cache.to(torch.float32)\n\n    for b in range(batch_size):\n        q_start = int(qo_indptr[b].item())\n        q_end = int(qo_indptr[b + 1].item())\n\n        kv_start = int(kv_indptr[b].item())\n        kv_end = int(kv_indptr[b + 1].item())\n        last_page_len = int(kv_last_page_len[b].item())\n\n        if q_start >= q_end or kv_start >= kv_end:\n            continue\n\n        page_ids = kv_indices[kv_start:kv_end].to(torch.long)\n        num_pages_for_seq = page_ids.shape[0]\n\n        num_full_pages = num_pages_for_seq - 1\n        num_kv_tokens = num_full_pages * page_size + last_page_len\n\n        k_batch = torch.zeros(\n            (num_kv_tokens, num_kv_heads, head_dim), dtype=torch.float32, device=device\n        )\n        v_batch = torch.zeros(\n            (num_kv_tokens, num_kv_heads, head_dim), dtype=torch.float32, device=device\n        )\n\n        token_idx = 0\n        for p_idx, page_id in enumerate(page_ids):\n            if p_idx < num_full_pages:\n                k_batch[token_idx:token_idx + page_size] = k_cache_f32[page_id]\n                v_batch[token_idx:token_idx + page_size] = v_cache_f32[page_id]\n                token_idx += page_size\n            else:\n                k_batch[token_idx:token_idx + last_page_len] = k_cache_f32[page_id, :last_page_len]\n                v_batch[token_idx:token_idx + last_page_len] = v_cache_f32[page_id, :last_page_len]\n                token_idx += last_page_len\n\n        q_batch = q_f32[q_start:q_end]\n        num_q_tokens = q_batch.shape[0]\n        delta = num_kv_tokens - num_q_tokens\n\n        for q_idx in range(num_q_tokens):\n            global_q_idx = q_start + q_idx\n            max_kv_idx = min(q_idx + 1 + delta, num_kv_tokens)\n            if max_kv_idx <= 0:\n                continue\n\n            q_pos = q_batch[q_idx]\n\n            for h in range(num_qo_heads):\n                kv_head = h // gqa_ratio\n\n                q_head = q_pos[h]\n                k_head = k_batch[:max_kv_idx, kv_head]\n                v_head = v_batch[:max_kv_idx, kv_head]\n\n                logits = torch.matmul(q_head, k_head.T)\n                logits_scaled = logits * sm_scale\n\n                lse[global_q_idx, h] = torch.logsumexp(logits_scaled, dim=-1) / math.log(2.0)\n\n                attn = torch.softmax(logits_scaled, dim=-1)\n                out_head = torch.matmul(attn, v_head)\n                output[global_q_idx, h] = out_head.to(torch.bfloat16)\n\n    return output, lse"
+}

--- a/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps64.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps64.py
@@ -1,0 +1,116 @@
+"""Reference test for gqa_paged_decode_h5_kv1_d128_ps64."""
+
+import math
+from pathlib import Path
+
+import flashinfer
+import torch
+
+from flashinfer_bench.data import Definition, load_json_file
+
+DEFINITIONS_DIR = Path(__file__).parent.parent.parent / "definitions"
+
+NUM_QO_HEADS = 5
+NUM_KV_HEADS = 1
+HEAD_DIM = 128
+PAGE_SIZE = 64
+
+
+def load_definition(name: str) -> Definition:
+    for op_dir in DEFINITIONS_DIR.iterdir():
+        if op_dir.is_dir():
+            def_file = op_dir / f"{name}.json"
+            if def_file.exists():
+                return load_json_file(Definition, def_file)
+    raise FileNotFoundError(f"Definition {name} not found")
+
+
+def compile_reference(reference_code: str):
+    namespace = {"torch": torch, "math": math}
+    exec(reference_code, namespace)
+    return namespace["run"]
+
+
+def generate_random_inputs(batch_size, max_seq_len, device="cuda"):
+    seq_lens = torch.randint(1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device)
+    pages_per_seq = (seq_lens + PAGE_SIZE - 1) // PAGE_SIZE
+    total_pages = pages_per_seq.sum().item()
+
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(pages_per_seq, dim=0)
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = ((seq_lens - 1) % PAGE_SIZE) + 1
+
+    q = torch.randn(batch_size, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    num_cache_pages = total_pages + 100
+    k_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    v_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    sm_scale = torch.tensor(1.0 / math.sqrt(HEAD_DIM), dtype=torch.float32, device=device)
+
+    return {
+        "q": q,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "kv_last_page_len": kv_last_page_len,
+        "sm_scale": sm_scale,
+    }
+
+
+def test_correctness(batch_size=4, max_seq_len=256, atol=1e-2, rtol=5e-2):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        return False
+
+    definition = load_definition("gqa_paged_decode_h5_kv1_d128_ps64")
+    run = compile_reference(definition.reference)
+    inputs = generate_random_inputs(batch_size, max_seq_len, device)
+
+    ref_o, ref_lse = run(
+        inputs["q"],
+        inputs["k_cache"],
+        inputs["v_cache"],
+        inputs["kv_indptr"],
+        inputs["kv_indices"],
+        inputs["kv_last_page_len"],
+        inputs["sm_scale"],
+    )
+
+    # group_size=5 is not a power of 2; expand KV heads to Q heads (group_size=1)
+    k_cache_exp = inputs["k_cache"].repeat_interleave(NUM_QO_HEADS, dim=2)
+    v_cache_exp = inputs["v_cache"].repeat_interleave(NUM_QO_HEADS, dim=2)
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+    wrapper.plan(
+        indptr=inputs["kv_indptr"],
+        indices=inputs["kv_indices"],
+        last_page_len=inputs["kv_last_page_len"],
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_QO_HEADS,  # expanded to match q heads (group_size=1)
+        head_dim=HEAD_DIM,
+        page_size=PAGE_SIZE,
+        pos_encoding_mode="NONE",
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+        sm_scale=inputs["sm_scale"].item(),
+    )
+    fi_o, fi_lse = wrapper.run(inputs["q"], (k_cache_exp, v_cache_exp), return_lse=True)
+
+    out_ok = torch.allclose(ref_o.float(), fi_o.float(), atol=atol, rtol=rtol)
+    lse_ok = torch.allclose(ref_lse, fi_lse, atol=atol, rtol=rtol)
+    return out_ok and lse_ok
+
+
+def main():
+    configs = [(1, 64), (4, 128), (8, 256), (16, 512)]
+    passed = sum(1 for b, s in configs if test_correctness(b, s))
+    print(f"\nSummary: {passed}/{len(configs)} tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps64.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps64.py
@@ -1,0 +1,125 @@
+"""Reference test for gqa_paged_prefill_causal_h5_kv1_d128_ps64."""
+
+import math
+from pathlib import Path
+
+import flashinfer
+import torch
+
+from flashinfer_bench.data import Definition, load_json_file
+
+DEFINITIONS_DIR = Path(__file__).parent.parent.parent / "definitions"
+
+NUM_QO_HEADS = 5
+NUM_KV_HEADS = 1
+HEAD_DIM = 128
+PAGE_SIZE = 64
+
+
+def load_definition(name: str) -> Definition:
+    for op_dir in DEFINITIONS_DIR.iterdir():
+        if op_dir.is_dir():
+            def_file = op_dir / f"{name}.json"
+            if def_file.exists():
+                return load_json_file(Definition, def_file)
+    raise FileNotFoundError(f"Definition {name} not found")
+
+
+def compile_reference(reference_code: str):
+    namespace = {"torch": torch, "math": math}
+    exec(reference_code, namespace)
+    return namespace["run"]
+
+
+def generate_random_inputs(batch_size, max_seq_len, device="cuda"):
+    total_q_per_seq = torch.randint(
+        1, max_seq_len + 1, (batch_size,), dtype=torch.int32, device=device
+    )
+    total_q = total_q_per_seq.sum().item()
+    num_pages_per_seq = (total_q_per_seq + PAGE_SIZE - 1) // PAGE_SIZE
+    total_pages = num_pages_per_seq.sum().item()
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr[1:] = torch.cumsum(num_pages_per_seq, dim=0)
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    kv_last_page_len = (total_q_per_seq - 1) % PAGE_SIZE + 1
+
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    qo_indptr[1:] = torch.cumsum(total_q_per_seq, dim=0)
+
+    q = torch.randn(total_q, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    num_cache_pages = total_pages + 100
+    k_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    v_cache = torch.randn(
+        num_cache_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    sm_scale = torch.tensor(1.0 / math.sqrt(HEAD_DIM), dtype=torch.float32, device=device)
+
+    return {
+        "q": q,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "qo_indptr": qo_indptr,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "kv_last_page_len": kv_last_page_len,
+        "sm_scale": sm_scale,
+    }
+
+
+def test_correctness(batch_size=2, max_seq_len=256, atol=1e-2, rtol=5e-2):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        return False
+
+    definition = load_definition("gqa_paged_prefill_causal_h5_kv1_d128_ps64")
+    run = compile_reference(definition.reference)
+    inputs = generate_random_inputs(batch_size, max_seq_len, device)
+
+    ref_o, ref_lse = run(
+        inputs["q"],
+        inputs["k_cache"],
+        inputs["v_cache"],
+        inputs["qo_indptr"],
+        inputs["kv_indptr"],
+        inputs["kv_indices"],
+        inputs["kv_last_page_len"],
+        inputs["sm_scale"],
+    )
+
+    # group_size=5 is not power of 2; use num_kv_heads=1 directly (FlashInfer supports GQA natively for prefill)
+    workspace = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=device)
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, kv_layout="NHD")
+    wrapper.plan(
+        qo_indptr=inputs["qo_indptr"],
+        paged_kv_indptr=inputs["kv_indptr"],
+        paged_kv_indices=inputs["kv_indices"],
+        paged_kv_last_page_len=inputs["kv_last_page_len"],
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim_qk=HEAD_DIM,
+        head_dim_vo=HEAD_DIM,
+        page_size=PAGE_SIZE,
+        causal=True,
+        q_data_type=torch.bfloat16,
+        kv_data_type=torch.bfloat16,
+        sm_scale=inputs["sm_scale"].item(),
+    )
+    fi_o, fi_lse = wrapper.run(
+        inputs["q"], (inputs["k_cache"], inputs["v_cache"]), return_lse=True
+    )
+
+    out_ok = torch.allclose(ref_o.float(), fi_o.float(), atol=atol, rtol=rtol)
+    lse_ok = torch.allclose(ref_lse, fi_lse, atol=atol, rtol=rtol)
+    return out_ok and lse_ok
+
+
+def main():
+    configs = [(1, 16), (2, 256)]
+    passed = sum(1 for b, s in configs if test_correctness(b, s))
+    print(f"\nSummary: {passed}/{len(configs)} tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/apps/web/data/models.ts
+++ b/web/apps/web/data/models.ts
@@ -1010,7 +1010,9 @@ const models: Model[] = [
         type: "layer",
         definitions: [
           "gqa_paged_prefill_causal_h5_kv1_d128_ps1",
+          "gqa_paged_prefill_causal_h5_kv1_d128_ps64",
           "gqa_paged_decode_h5_kv1_d128_ps1",
+          "gqa_paged_decode_h5_kv1_d128_ps64",
           "gqa_ragged_prefill_causal_h5_kv1_d128",
         ],
       },
@@ -1077,7 +1079,9 @@ const models: Model[] = [
         type: "layer",
         definitions: [
           "gqa_paged_prefill_causal_h5_kv1_d128_ps1",
+          "gqa_paged_prefill_causal_h5_kv1_d128_ps64",
           "gqa_paged_decode_h5_kv1_d128_ps1",
+          "gqa_paged_decode_h5_kv1_d128_ps64",
           "gqa_ragged_prefill_causal_h5_kv1_d128",
         ],
       },


### PR DESCRIPTION
## Summary

Adds `page_size=64` GQA paged attention definitions for Llama 4 Scout and Maverick (TP=8: h=5 q-heads, kv=1 kv-head). These complement the `ps1` variants already merged (#349, #350) and cover real-world SGLang KV cache page sizes.

**New definitions:**
- `gqa_paged_decode_h5_kv1_d128_ps64`: paged decode, page_size=64, handles partial last pages via `kv_last_page_len`. Since FlashInfer decode only supports power-of-2 group sizes, KV heads are expanded 1→5 via `repeat_interleave` (mathematically equivalent to GQA with group_size=5).
- `gqa_paged_prefill_causal_h5_kv1_d128_ps64`: paged prefill, page_size=64, supports GQA natively (no KV expansion needed).

**Also:**
- Updates `web/apps/web/data/models.ts`: adds ps64 variants to Scout's `attn_local` and `attn_global` modules
- Updates `docs/model_coverage.mdx`: marks ps64 rows as 🟡 for both Scout and Maverick

Tags: `status:unverified` (GPU validation pending), `model:llama-4-scout`, `tp:8`

## Test plan

- [ ] GPU validation: run `flashinfer_trace/tests/references/test_gqa_paged_decode_h5_kv1_d128_ps64.py` on CUDA hardware
- [ ] GPU validation: run `flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps64.py` on CUDA hardware
- [ ] Status can be upgraded from `status:unverified` to `status:reference` after GPU tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for new Grouped Query Attention (GQA) paged kernels with optimized page size configurations for improved performance.
  * Integrated new kernels into model definitions for enhanced compatibility.

* **Tests**
  * Added reference correctness tests for newly supported GQA paged operations.

* **Documentation**
  * Updated model coverage status to reflect partial support for new GQA kernel variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->