### PR TITLE
feat: add sampling v202048 definitions for Llama 4 Scout/Maverick

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -565,11 +565,11 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `trtllm_fp4_block_scale_moe_topk1_e16_h5120_i8192` | moe (TRT-LLM FP4, Llama4 routing) | 🟡 |
 | `trtllm_fp4_block_scale_routed_moe_topk1_e16_h5120_i8192` | moe (TRT-LLM FP4 routed, Llama4 routing) | 🟡 |
 | `trtllm_fp8_per_tensor_scale_moe_topk1_e16_h5120_i8192` | moe (TRT-LLM FP8) | 🟡 |
-| `top_k_sampling_from_probs_v202048` | sampling | ❌ |
-| `top_k_top_p_sampling_from_probs_v202048` | sampling | ❌ |
-| `top_p_sampling_from_probs_v202048` | sampling | ❌ |
+| `top_k_sampling_from_probs_v202048` | sampling | 🟡 |
+| `top_k_top_p_sampling_from_probs_v202048` | sampling | 🟡 |
+| `top_p_sampling_from_probs_v202048` | sampling | 🟡 |
 
-**Coverage**: 4 / 10 referenced definitions present. rmsnorm h5120 shared with Qwen3 14B. TRT-LLM FP4 + FP8 MoE kernels added (top-1, 16 experts, Llama4 routing). Missing: all GQA defs (h=5 per device), sampling v202048.
+**Coverage**: 7 / 10 definitions present. sampling v202048 (vocab_size=202048, Llama 4 Scout/Maverick) added. Workloads pending. Missing (pending open PRs): gqa_paged ps64 variants.
 
 ---
 
@@ -592,11 +592,11 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192` | moe (TRT-LLM FP4, Llama4 routing) | 🟡 |
 | `trtllm_fp4_block_scale_routed_moe_topk1_e128_h5120_i8192` | moe (TRT-LLM FP4 routed, Llama4 routing) | 🟡 |
 | `trtllm_fp8_per_tensor_scale_moe_topk1_e128_h5120_i8192` | moe (TRT-LLM FP8) | 🟡 |
-| `top_k_sampling_from_probs_v202048` | sampling | ❌ |
-| `top_k_top_p_sampling_from_probs_v202048` | sampling | ❌ |
-| `top_p_sampling_from_probs_v202048` | sampling | ❌ |
+| `top_k_sampling_from_probs_v202048` | sampling | 🟡 |
+| `top_k_top_p_sampling_from_probs_v202048` | sampling | 🟡 |
+| `top_p_sampling_from_probs_v202048` | sampling | 🟡 |
 
-**Coverage**: 4 / 10 referenced definitions present. rmsnorm h5120 shared with Qwen3 14B. TRT-LLM FP4 + FP8 MoE kernels added (top-1, 128 experts, Llama4 routing). Same base dimensions as Llama 4 Scout; MoE expert count differs. Missing: all GQA defs (h=5 per device), sampling v202048.
+**Coverage**: 7 / 10 definitions present. sampling v202048 (vocab_size=202048, shared with Llama 4 Scout) added. Workloads pending. Missing (pending open PRs): gqa_paged ps64 variants.
 
 ---
 

--- a/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v202048.json
+++ b/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v202048.json
@@ -1,0 +1,48 @@
+{
+  "name": "top_k_sampling_from_probs_v202048",
+  "op_type": "sampling",
+  "description": "Top-k sampling from probabilities with vocab_size=202048. Keeps only the k highest probability tokens, renormalizes, then samples from the filtered distribution. Captured from Llama 4 Scout/Maverick.",
+  "tags": [
+    "status:unverified",
+    "model:llama-4-scout",
+    "fi_api:flashinfer.sampling.top_k_sampling_from_probs"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of sequences to sample from"
+    },
+    "vocab_size": {
+      "type": "const",
+      "value": 202048,
+      "description": "Size of the vocabulary for Llama 4 Scout/Maverick"
+    }
+  },
+  "inputs": {
+    "probs": {
+      "shape": [
+        "batch_size",
+        "vocab_size"
+      ],
+      "dtype": "float32",
+      "description": "Probability distributions (after softmax)"
+    },
+    "top_k": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Number of top tokens to consider for sampling per sequence"
+    }
+  },
+  "outputs": {
+    "samples": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int64",
+      "description": "Sampled token indices"
+    }
+  },
+  "reference": "import torch\n\n@torch.no_grad()\ndef run(probs, top_k):\n    batch_size, vocab_size = probs.shape\n    device = probs.device\n\n    # Check constants\n    assert vocab_size == 202048\n\n    probs = probs.to(torch.float32)\n    samples = torch.empty(batch_size, dtype=torch.int64, device=device)\n\n    for i in range(batch_size):\n        row = probs[i]\n        k = int(top_k[i].item())\n\n        # No filtering on invalid k\n        if 0 < k < vocab_size:\n            idx_sorted = torch.argsort(row, descending=True)\n            keep_idx = idx_sorted[:k]\n\n            filtered = torch.zeros_like(row)\n            filtered[keep_idx] = row[keep_idx]\n\n            row = filtered / filtered.sum()\n\n        samples[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)\n\n    return samples\n"
+}

--- a/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v202048.json
+++ b/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v202048.json
@@ -1,0 +1,55 @@
+{
+  "name": "top_k_top_p_sampling_from_probs_v202048",
+  "op_type": "sampling",
+  "description": "Top-k top-p (nucleus) sampling from probabilities with vocab_size=202048. Filters probabilities using top-k and top-p constraints, then samples from the filtered distribution. Captured from Llama 4 Scout/Maverick.",
+  "tags": [
+    "status:unverified",
+    "model:llama-4-scout",
+    "fi_api:flashinfer.sampling.top_k_top_p_sampling_from_probs"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of sequences to sample from"
+    },
+    "vocab_size": {
+      "type": "const",
+      "value": 202048,
+      "description": "Size of the vocabulary for Llama 4 Scout/Maverick"
+    }
+  },
+  "inputs": {
+    "probs": {
+      "shape": [
+        "batch_size",
+        "vocab_size"
+      ],
+      "dtype": "float32",
+      "description": "Probability distributions (after softmax)"
+    },
+    "top_k": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Number of top tokens to consider for sampling per sequence"
+    },
+    "top_p": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "float32",
+      "description": "Cumulative probability threshold for nucleus sampling per sequence"
+    }
+  },
+  "outputs": {
+    "samples": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int64",
+      "description": "Sampled token indices"
+    }
+  },
+  "reference": "import torch\n\n@torch.no_grad()\ndef run(probs, top_k, top_p):\n    batch_size, vocab_size = probs.shape\n    device = probs.device\n\n    # Check constants\n    assert vocab_size == 202048\n\n    probs = probs.to(torch.float32)\n    samples = torch.empty(batch_size, dtype=torch.int64, device=device)\n\n    for i in range(batch_size):\n        row = probs[i]\n        k = int(top_k[i].item())\n        p = float(top_p[i].item())\n\n        # Apply top-k filtering\n        if 0 < k < vocab_size:\n            idx_sorted = torch.argsort(row, descending=True)\n            keep_idx_k = idx_sorted[:k]\n            filtered_k = torch.zeros_like(row)\n            filtered_k[keep_idx_k] = row[keep_idx_k]\n            row = filtered_k / filtered_k.sum()\n\n        # Then apply top-p filtering\n        if p <= 0.0:\n            samples[i] = torch.argmax(row).to(torch.int64)\n            continue\n\n        if p < 1.0:\n            vals, idx = torch.sort(row, descending=True)\n            cdf = torch.cumsum(vals, dim=0)\n\n            to_remove = cdf > p\n            if vocab_size > 1:\n                to_remove[1:] = to_remove[:-1].clone()\n                to_remove[0] = False\n\n            keep_idx_p = idx[~to_remove]\n            filtered_p = torch.zeros_like(row)\n            filtered_p[keep_idx_p] = row[keep_idx_p]\n            row = filtered_p / filtered_p.sum()\n\n        # sample\n        samples[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)\n\n    return samples\n"
+}

--- a/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v202048.json
+++ b/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v202048.json
@@ -1,0 +1,48 @@
+{
+  "name": "top_p_sampling_from_probs_v202048",
+  "op_type": "sampling",
+  "description": "Top-p (nucleus) sampling from probabilities with vocab_size=202048. Filters probabilities using cumulative probability threshold, then samples from the filtered distribution. Captured from Llama 4 Scout/Maverick.",
+  "tags": [
+    "status:unverified",
+    "model:llama-4-scout",
+    "fi_api:flashinfer.sampling.top_p_sampling_from_probs"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of sequences to sample from"
+    },
+    "vocab_size": {
+      "type": "const",
+      "value": 202048,
+      "description": "Size of the vocabulary for Llama 4 Scout/Maverick"
+    }
+  },
+  "inputs": {
+    "probs": {
+      "shape": [
+        "batch_size",
+        "vocab_size"
+      ],
+      "dtype": "float32",
+      "description": "Probability distributions (after softmax)"
+    },
+    "top_p": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "float32",
+      "description": "Cumulative probability threshold for nucleus sampling per sequence"
+    }
+  },
+  "outputs": {
+    "samples": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int64",
+      "description": "Sampled token indices"
+    }
+  },
+  "reference": "import torch\n\n@torch.no_grad()\ndef run(probs, top_p):\n    batch_size, vocab_size = probs.shape\n    device = probs.device\n\n    # Check constants\n    assert vocab_size == 202048\n\n    probs = probs.to(torch.float32)\n    out = torch.empty(batch_size, dtype=torch.int64, device=device)\n\n    for i in range(batch_size):\n        row = probs[i]\n        p = float(top_p[i].item())\n\n        if p <= 0.0:\n            # Degenerate to argmax\n            out[i] = torch.argmax(row).to(torch.int64)\n            continue\n\n        if p < 1.0:\n            vals, idx = torch.sort(row, descending=True)\n            cdf = torch.cumsum(vals, dim=0)\n\n            # Shift mask to keep the first token that crosses p\n            to_remove = cdf > p\n            to_remove[1:] = to_remove[:-1].clone()\n            to_remove[0] = False\n            keep = ~to_remove\n            keep_idx = idx[keep]\n\n            # Build filtered distribution in original index space\n            filtered = torch.zeros_like(row)\n            filtered[keep_idx] = row[keep_idx]\n            row = filtered / filtered.sum()\n\n        out[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)\n\n    return out\n"
+}

--- a/flashinfer_trace/tests/references/test_top_k_sampling_from_probs_v202048.py
+++ b/flashinfer_trace/tests/references/test_top_k_sampling_from_probs_v202048.py
@@ -1,0 +1,91 @@
+"""Reference test for top_k_sampling_from_probs_v202048 (Llama 4 Scout/Maverick)."""
+
+import math
+from pathlib import Path
+
+import flashinfer
+import torch
+
+from flashinfer_bench.data import Definition, load_json_file
+
+DEFINITIONS_DIR = Path(__file__).parent.parent.parent / "definitions"
+
+VOCAB_SIZE = 202048
+
+
+def load_definition(name: str) -> Definition:
+    for op_dir in DEFINITIONS_DIR.iterdir():
+        if op_dir.is_dir():
+            def_file = op_dir / f"{name}.json"
+            if def_file.exists():
+                return load_json_file(Definition, def_file)
+    raise FileNotFoundError(f"Definition {name} not found in {DEFINITIONS_DIR}")
+
+
+def compile_reference(reference_code: str):
+    namespace = {"torch": torch, "math": math}
+    exec(reference_code, namespace)
+    return namespace["run"]
+
+
+def generate_random_inputs(batch_size, distribution="peaked", device="cuda"):
+    if distribution == "peaked":
+        logits = torch.randn(batch_size, VOCAB_SIZE, device=device) * 0.1
+        peak_indices = torch.randint(0, VOCAB_SIZE, (batch_size,), device=device)
+        for i in range(batch_size):
+            logits[i, peak_indices[i]] += 5.0
+    else:
+        logits = torch.randn(batch_size, VOCAB_SIZE, device=device)
+
+    probs = torch.softmax(logits, dim=-1).to(torch.float32)
+    top_k = torch.randint(
+        10, min(500, VOCAB_SIZE // 2), (batch_size,), dtype=torch.int32, device=device
+    )
+    return probs, top_k
+
+
+def test_correctness(batch_size=4, num_trials=5000):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return False
+
+    definition = load_definition("top_k_sampling_from_probs_v202048")
+    run = compile_reference(definition.reference)
+
+    torch.manual_seed(42)
+    probs, top_k = generate_random_inputs(batch_size, "peaked", device)
+
+    ref_counter = torch.zeros(batch_size, VOCAB_SIZE, dtype=torch.int32, device=device)
+    fi_counter = torch.zeros(batch_size, VOCAB_SIZE, dtype=torch.int32, device=device)
+
+    for _ in range(num_trials):
+        ref_samples = run(probs.clone(), top_k)
+        fi_samples = flashinfer.sampling.top_k_sampling_from_probs(probs, top_k)
+
+        for i in range(batch_size):
+            ref_counter[i, ref_samples[i]] += 1
+            fi_counter[i, fi_samples[i]] += 1
+
+    ref_freq = ref_counter.float() / num_trials
+    fi_freq = fi_counter.float() / num_trials
+
+    nonzero_mask = probs > 1e-6
+    freq_diff = torch.abs(ref_freq[nonzero_mask] - fi_freq[nonzero_mask]).max().item()
+
+    passed = freq_diff < 0.05
+    print(
+        f"batch_size={batch_size}: max_freq_diff={freq_diff:.4f} "
+        f"{'PASSED' if passed else 'FAILED'}"
+    )
+    return passed
+
+
+def main():
+    test_configs = [(1, 5000), (4, 5000), (8, 3000)]
+    passed = sum(1 for b, t in test_configs if test_correctness(b, t))
+    print(f"\nSummary: {passed}/{len(test_configs)} tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_top_k_top_p_sampling_from_probs_v202048.py
+++ b/flashinfer_trace/tests/references/test_top_k_top_p_sampling_from_probs_v202048.py
@@ -1,0 +1,92 @@
+"""Reference test for top_k_top_p_sampling_from_probs_v202048 (Llama 4 Scout/Maverick)."""
+
+import math
+from pathlib import Path
+
+import flashinfer
+import torch
+
+from flashinfer_bench.data import Definition, load_json_file
+
+DEFINITIONS_DIR = Path(__file__).parent.parent.parent / "definitions"
+
+VOCAB_SIZE = 202048
+
+
+def load_definition(name: str) -> Definition:
+    for op_dir in DEFINITIONS_DIR.iterdir():
+        if op_dir.is_dir():
+            def_file = op_dir / f"{name}.json"
+            if def_file.exists():
+                return load_json_file(Definition, def_file)
+    raise FileNotFoundError(f"Definition {name} not found in {DEFINITIONS_DIR}")
+
+
+def compile_reference(reference_code: str):
+    namespace = {"torch": torch, "math": math}
+    exec(reference_code, namespace)
+    return namespace["run"]
+
+
+def generate_random_inputs(batch_size, distribution="peaked", device="cuda"):
+    if distribution == "peaked":
+        logits = torch.randn(batch_size, VOCAB_SIZE, device=device) * 0.1
+        peak_indices = torch.randint(0, VOCAB_SIZE, (batch_size,), device=device)
+        for i in range(batch_size):
+            logits[i, peak_indices[i]] += 5.0
+    else:
+        logits = torch.randn(batch_size, VOCAB_SIZE, device=device)
+
+    probs = torch.softmax(logits, dim=-1).to(torch.float32)
+    top_k = torch.randint(
+        10, min(500, VOCAB_SIZE // 2), (batch_size,), dtype=torch.int32, device=device
+    )
+    top_p = torch.rand(batch_size, device=device) * 0.8 + 0.1  # Range [0.1, 0.9]
+    return probs, top_k, top_p
+
+
+def test_correctness(batch_size=4, num_trials=5000):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return False
+
+    definition = load_definition("top_k_top_p_sampling_from_probs_v202048")
+    run = compile_reference(definition.reference)
+
+    torch.manual_seed(42)
+    probs, top_k, top_p = generate_random_inputs(batch_size, "peaked", device)
+
+    ref_counter = torch.zeros(batch_size, VOCAB_SIZE, dtype=torch.int32, device=device)
+    fi_counter = torch.zeros(batch_size, VOCAB_SIZE, dtype=torch.int32, device=device)
+
+    for _ in range(num_trials):
+        ref_samples = run(probs.clone(), top_k, top_p)
+        fi_samples = flashinfer.sampling.top_k_top_p_sampling_from_probs(probs, top_k, top_p)
+
+        for i in range(batch_size):
+            ref_counter[i, ref_samples[i]] += 1
+            fi_counter[i, fi_samples[i]] += 1
+
+    ref_freq = ref_counter.float() / num_trials
+    fi_freq = fi_counter.float() / num_trials
+
+    nonzero_mask = probs > 1e-6
+    freq_diff = torch.abs(ref_freq[nonzero_mask] - fi_freq[nonzero_mask]).max().item()
+
+    passed = freq_diff < 0.05
+    print(
+        f"batch_size={batch_size}: max_freq_diff={freq_diff:.4f} "
+        f"{'PASSED' if passed else 'FAILED'}"
+    )
+    return passed
+
+
+def main():
+    test_configs = [(1, 5000), (4, 5000), (8, 3000)]
+    passed = sum(1 for b, t in test_configs if test_correctness(b, t))
+    print(f"\nSummary: {passed}/{len(test_configs)} tests passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_trace/tests/references/test_top_p_sampling_from_probs_v202048.py
+++ b/flashinfer_trace/tests/references/test_top_p_sampling_from_probs_v202048.py
@@ -1,0 +1,89 @@
+"""Reference test for top_p_sampling_from_probs_v202048 (Llama 4 Scout/Maverick)."""
+
+import math
+from pathlib import Path
+
+import flashinfer
+import torch
+
+from flashinfer_bench.data import Definition, load_json_file
+
+DEFINITIONS_DIR = Path(__file__).parent.parent.parent / "definitions"
+
+VOCAB_SIZE = 202048
+
+
+def load_definition(name: str) -> Definition:
+    for op_dir in DEFINITIONS_DIR.iterdir():
+        if op_dir.is_dir():
+            def_file = op_dir / f"{name}.json"
+            if def_file.exists():
+                return load_json_file(Definition, def_file)
+    raise FileNotFoundError(f"Definition {name} not found in {DEFINITIONS_DIR}")
+
+
+def compile_reference(reference_code: str):
+    namespace = {"torch": torch, "math": math}
+    exec(reference_code, namespace)
+    return namespace["run"]
+
+
+def generate_random_inputs(batch_size, distribution="peaked", device="cuda"):
+    if distribution == "peaked":
+        logits = torch.randn(batch_size, VOCAB_SIZE, device=device) * 0.1
+        peak_indices = torch.randint(0, VOCAB_SIZE, (batch_size,), device=device)
+        for i in range(batch_size):
+            logits[i, peak_indices[i]] += 5.0
+    else:
+        logits = torch.randn(batch_size, VOCAB_SIZE, device=device)
+
+    probs = torch.softmax(logits, dim=-1).to(torch.float32)
+    top_p = torch.rand(batch_size, device=device) * 0.8 + 0.1  # Range [0.1, 0.9]
+    return probs, top_p
+
+
+def test_correctness(batch_size=4, num_trials=5000):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    if device == "cpu":
+        print("WARNING: CUDA not available, skipping test")
+        return False
+
+    definition = load_definition("top_p_sampling_from_probs_v202048")
+    run = compile_reference(definition.reference)
+
+    torch.manual_seed(42)
+    probs, top_p = generate_random_inputs(batch_size, "peaked", device)
+
+    ref_counter = torch.zeros(batch_size, VOCAB_SIZE, dtype=torch.int32, device=device)
+    fi_counter = torch.zeros(batch_size, VOCAB_SIZE, dtype=torch.int32, device=device)
+
+    for _ in range(num_trials):
+        ref_samples = run(probs.clone(), top_p)
+        fi_samples = flashinfer.sampling.top_p_sampling_from_probs(probs, top_p)
+
+        for i in range(batch_size):
+            ref_counter[i, ref_samples[i]] += 1
+            fi_counter[i, fi_samples[i]] += 1
+
+    ref_freq = ref_counter.float() / num_trials
+    fi_freq = fi_counter.float() / num_trials
+
+    nonzero_mask = probs > 1e-6
+    freq_diff = torch.abs(ref_freq[nonzero_mask] - fi_freq[nonzero_mask]).max().item()
+
+    passed = freq_diff < 0.05
+    print(
+        f"batch_size={batch_size}: max_freq_diff={freq_diff:.4f} "
+        f"{'PASSED' if passed else 'FAILED'}"
+    )
+    return passed
+
+
+def main():
+    test_configs = [(1, 5000), (4, 5000), (8, 3000)]
+    passed = sum(1 for b, t in test_configs if test_correctness(b, t))
+    print(f"\nSummary: {passed}/{len(test_configs)} tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds three sampling kernel definitions for `vocab_size=202048` (Llama 4 Scout/Maverick). Llama 4 uses a distinct vocab size from other models (202048 vs 151936 for Qwen3, 200064 for MiniMax M2), requiring separate definition files.

**New definitions:**
- `top_k_sampling_from_probs_v202048`: top-k filtering + multinomial sample
- `top_p_sampling_from_probs_v202048`: top-p (nucleus) filtering + multinomial sample
- `top_k_top_p_sampling_from_probs_v202048`: combined top-k then top-p filtering + sample

Each definition includes a pure-PyTorch reference `run()` and reference test using frequency-counting correctness validation (5000 trials, max frequency diff < 5%). Shared by both Scout (16 experts) and Maverick (128 experts).

**Also:**
- Updates `docs/model_coverage.mdx`: marks sampling rows as 🟡 for both Scout and Maverick sections

Tags: `status:unverified` (GPU validation pending), `model:llama-4-scout`

## Test plan

- [ ] GPU validation: run all three reference tests in `flashinfer_trace/tests/references/test_*_v202048.py`
- [ ] Verify frequency distributions match FlashInfer sampling API within tolerance
- [ ] Status can be upgraded from `status:unverified` to `status:reference` after GPU tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new sampling operators for Llama 4 models with fixed vocabulary size 202048: top-k sampling, top-k+nucleus (top-p) sampling, and nucleus sampling.

* **Documentation**
  * Updated model coverage documentation for Llama 4 Scout and Maverick models, now reflecting availability of sampling kernel definitions (4/10 → 7/10 coverage).

* **Tests**
  * Added reference validation tests for the three new sampling operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->