### PR TITLE
feat: add Llama 4 Maverick 17B-128E model entry; update coverage doc

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -575,28 +575,26 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 
 ## Llama 4 Maverick 17B-128E
 
-**Architecture**: Same base architecture as Llama 4 Scout but with 128 total experts (vs 16). Standard serving configuration: **TP=8** (from sgl-cookbook).
-
-> **Note**: Exact config.json values are pending verification from HuggingFace.
+**Architecture**: Same base architecture as Llama 4 Scout but with 128 total experts (vs 16). Standard serving configuration: **TP=8** (from sgl-cookbook). hidden_size=5120, 40 q-heads, 8 kv-heads, head_dim=128, intermediate_size=8192.
 
 | Definition | Op Type | Status |
 |-----------|---------|:------:|
 | `rmsnorm_h5120` | rmsnorm | 🟡 |
 | `fused_add_rmsnorm_h5120` | rmsnorm | 🟡 |
 | `gqa_paged_prefill_causal_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
-| `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_prefill_causal_h5_kv1_d128_ps64` | gqa_paged TP=8 | 🟡 |
 | `gqa_paged_decode_h5_kv1_d128_ps1` | gqa_paged TP=8 | 🟡 |
-| `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | ❌ |
+| `gqa_paged_decode_h5_kv1_d128_ps64` | gqa_paged TP=8 | 🟡 |
 | `gqa_ragged_prefill_causal_h5_kv1_d128` | gqa_ragged TP=8 | 🟡 |
 | MoE experts (top-1, 128 experts, standard routing) | moe | — |
 | `trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192` | moe (TRT-LLM FP4, Llama4 routing) | 🟡 |
 | `trtllm_fp4_block_scale_routed_moe_topk1_e128_h5120_i8192` | moe (TRT-LLM FP4 routed, Llama4 routing) | 🟡 |
 | `trtllm_fp8_per_tensor_scale_moe_topk1_e128_h5120_i8192` | moe (TRT-LLM FP8) | 🟡 |
-| `top_k_sampling_from_probs_v202048` | sampling | ❌ |
-| `top_k_top_p_sampling_from_probs_v202048` | sampling | ❌ |
-| `top_p_sampling_from_probs_v202048` | sampling | ❌ |
+| `top_k_sampling_from_probs_v202048` | sampling | 🟡 |
+| `top_k_top_p_sampling_from_probs_v202048` | sampling | 🟡 |
+| `top_p_sampling_from_probs_v202048` | sampling | 🟡 |
 
-**Coverage**: 4 / 10 referenced definitions present. rmsnorm h5120 shared with Qwen3 14B. TRT-LLM FP4 + FP8 MoE kernels added (top-1, 128 experts, Llama4 routing). Same base dimensions as Llama 4 Scout; MoE expert count differs. Missing: all GQA defs (h=5 per device), sampling v202048.
+**Coverage**: 10 / 10 definitions present. Same base dimensions as Llama 4 Scout; all GQA and sampling definitions shared. MoE expert count differs (128 vs 16). Workload collection pending.
 
 ---
 

--- a/web/apps/web/data/models.ts
+++ b/web/apps/web/data/models.ts
@@ -1134,6 +1134,176 @@ const models: Model[] = [
       },
     },
   },
+  {
+    id: "llama-4-maverick-17b-128e",
+    name: "Llama 4 Maverick 17B-128E",
+    description:
+      "Meta Llama 4 Maverick 17B-128E. Same architecture as Scout but with 128 experts (vs 16). 48 decoder layers with interleaved local (RoPE chunked, ×40) and global (NoPE, ×8) attention, MoE FFN (128 experts, top-1). TP=8: 40/8=5 q-heads, 8/8=1 kv-head.",
+    modules: {
+      Llama4MaverickForCausalLM: {
+        count: 1,
+        type: "block",
+        definitions: [],
+      },
+      Llama4MaverickTextModel: {
+        count: 1,
+        parent: "Llama4MaverickForCausalLM",
+        type: "block",
+        definitions: [],
+      },
+      // --- Local attention layers (RoPE chunked): 5 of every 6 layers = 40 total ---
+      Llama4MaverickDecoderLayer_Local: {
+        count: 40,
+        parent: "Llama4MaverickTextModel",
+        type: "block",
+        definitions: [],
+      },
+      input_layernorm_local_mav: {
+        count: 40,
+        parent: "Llama4MaverickDecoderLayer_Local",
+        type: "layer",
+        definitions: ["rmsnorm_h5120", "fused_add_rmsnorm_h5120"],
+      },
+      self_attn_local_mav: {
+        count: 40,
+        parent: "Llama4MaverickDecoderLayer_Local",
+        type: "block",
+        definitions: [],
+      },
+      attn_local_mav: {
+        count: 40,
+        parent: "self_attn_local_mav",
+        type: "layer",
+        definitions: [
+          "gqa_paged_prefill_causal_h5_kv1_d128_ps1",
+          "gqa_paged_prefill_causal_h5_kv1_d128_ps64",
+          "gqa_paged_decode_h5_kv1_d128_ps1",
+          "gqa_paged_decode_h5_kv1_d128_ps64",
+          "gqa_ragged_prefill_causal_h5_kv1_d128",
+        ],
+      },
+      post_attention_layernorm_local_mav: {
+        count: 40,
+        parent: "Llama4MaverickDecoderLayer_Local",
+        type: "layer",
+        definitions: ["fused_add_rmsnorm_h5120"],
+      },
+      feed_forward_local_mav: {
+        count: 40,
+        parent: "Llama4MaverickDecoderLayer_Local",
+        type: "block",
+        definitions: [],
+      },
+      moe_local_mav: {
+        count: 40,
+        parent: "feed_forward_local_mav",
+        type: "block",
+        definitions: [],
+      },
+      moe_gate_local_mav: {
+        count: 40,
+        parent: "moe_local_mav",
+        type: "layer",
+        definitions: [
+          "trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp4_block_scale_routed_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp8_per_tensor_scale_moe_topk1_e128_h5120_i8192",
+        ],
+      },
+      moe_experts_local_mav: {
+        count: 40,
+        parent: "moe_local_mav",
+        type: "layer",
+        definitions: [
+          "trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp4_block_scale_routed_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp8_per_tensor_scale_moe_topk1_e128_h5120_i8192",
+        ],
+      },
+      // --- Global attention layers (NoPE / full context): 1 of every 6 layers = 8 total ---
+      Llama4MaverickDecoderLayer_Global: {
+        count: 8,
+        parent: "Llama4MaverickTextModel",
+        type: "block",
+        definitions: [],
+      },
+      input_layernorm_global_mav: {
+        count: 8,
+        parent: "Llama4MaverickDecoderLayer_Global",
+        type: "layer",
+        definitions: ["rmsnorm_h5120", "fused_add_rmsnorm_h5120"],
+      },
+      self_attn_global_mav: {
+        count: 8,
+        parent: "Llama4MaverickDecoderLayer_Global",
+        type: "block",
+        definitions: [],
+      },
+      attn_global_mav: {
+        count: 8,
+        parent: "self_attn_global_mav",
+        type: "layer",
+        definitions: [
+          "gqa_paged_prefill_causal_h5_kv1_d128_ps1",
+          "gqa_paged_prefill_causal_h5_kv1_d128_ps64",
+          "gqa_paged_decode_h5_kv1_d128_ps1",
+          "gqa_paged_decode_h5_kv1_d128_ps64",
+          "gqa_ragged_prefill_causal_h5_kv1_d128",
+        ],
+      },
+      post_attention_layernorm_global_mav: {
+        count: 8,
+        parent: "Llama4MaverickDecoderLayer_Global",
+        type: "layer",
+        definitions: ["fused_add_rmsnorm_h5120"],
+      },
+      feed_forward_global_mav: {
+        count: 8,
+        parent: "Llama4MaverickDecoderLayer_Global",
+        type: "block",
+        definitions: [],
+      },
+      moe_global_mav: {
+        count: 8,
+        parent: "feed_forward_global_mav",
+        type: "block",
+        definitions: [],
+      },
+      moe_gate_global_mav: {
+        count: 8,
+        parent: "moe_global_mav",
+        type: "layer",
+        definitions: [
+          "trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp4_block_scale_routed_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp8_per_tensor_scale_moe_topk1_e128_h5120_i8192",
+        ],
+      },
+      moe_experts_global_mav: {
+        count: 8,
+        parent: "moe_global_mav",
+        type: "layer",
+        definitions: [
+          "trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp4_block_scale_routed_moe_topk1_e128_h5120_i8192",
+          "trtllm_fp8_per_tensor_scale_moe_topk1_e128_h5120_i8192",
+        ],
+      },
+      // --- Final norm + head ---
+      norm_mav: {
+        count: 1,
+        parent: "Llama4MaverickTextModel",
+        type: "layer",
+        definitions: ["rmsnorm_h5120", "fused_add_rmsnorm_h5120"],
+      },
+      lm_head_mav: {
+        count: 1,
+        parent: "Llama4MaverickForCausalLM",
+        type: "layer",
+        definitions: [],
+      },
+    },
+  },
 ] satisfies Model[]
 
 export default models


### PR DESCRIPTION
## Summary

Adds the Llama 4 Maverick 17B-128E model entry to `web/apps/web/data/models.ts`. Maverick shares the same base architecture as Llama 4 Scout but uses 128 MoE experts (vs 16). All GQA attention and sampling definitions are shared between Scout and Maverick — only the MoE definitions differ (`e128` vs `e16`).

**Module structure:** mirrors Scout exactly with `_mav` suffixes to avoid module-name collisions:
- 40× local decoder layers (RoPE chunked): `attn_local_mav`, `moe_gate_local_mav`, `moe_experts_local_mav`
- 8× global decoder layers (NoPE): `attn_global_mav`, `moe_gate_global_mav`, `moe_experts_global_mav`

**MoE definitions referenced (128 experts):**
- `trtllm_fp4_block_scale_moe_topk1_e128_h5120_i8192`
- `trtllm_fp4_block_scale_routed_moe_topk1_e128_h5120_i8192`
- `trtllm_fp8_per_tensor_scale_moe_topk1_e128_h5120_i8192`

**Coverage doc updates:**
- Removes "pending verification" note from Maverick section
- Adds confirmed architecture params: `hidden_size=5120, 40 q-heads, 8 kv-heads, head_dim=128, intermediate_size=8192`
- Marks ps64 GQA and sampling rows as 🟡 (definition files added in PRs #380 and #381)
- Updates coverage text to 10/10

## Test plan

- [ ] Verify model entry renders correctly in web UI
- [ ] All referenced definitions (GQA ps1, ps64, ragged; MoE e128; sampling v202048) exist in `flashinfer_trace/definitions/`
- [ ] Note: ps64 defs added in #380, sampling defs added in #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)