### PR TITLE
fix: correct sampling definitions for Qwen 2.5 7B, 72B

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -359,9 +359,9 @@ At tensor parallelism TP=2, attention head counts are halved (48→24 q-heads, 8
 | `gemm_n3584_k3584` | gemm | ❌ |
 | `gemm_n37888_k3584` | gemm | ❌ |
 | `gemm_n3584_k18944` | gemm | ❌ |
-| `top_k_sampling_from_probs_v151936` | sampling | ✅ |
-| `top_k_top_p_sampling_from_probs_v151936` | sampling | ✅ |
-| `top_p_sampling_from_probs_v151936` | sampling | ✅ |
+| `top_k_sampling_from_probs_v152064` | sampling | ✅ |
+| `top_k_top_p_sampling_from_probs_v152064` | sampling | ✅ |
+| `top_p_sampling_from_probs_v152064` | sampling | ✅ |
 
 **Coverage**: 3 / 14 definitions present. Missing: all rmsnorm, GQA, and GEMM definitions for hidden=3584.
 
@@ -384,9 +384,9 @@ At tensor parallelism TP=2, attention head counts are halved (48→24 q-heads, 8
 | `gemm_n8192_k8192` | gemm | ❌ |
 | `gemm_n59392_k8192` | gemm | ❌ |
 | `gemm_n8192_k29696` | gemm | ❌ |
-| `top_k_sampling_from_probs_v151936` | sampling | ✅ |
-| `top_k_top_p_sampling_from_probs_v151936` | sampling | ✅ |
-| `top_p_sampling_from_probs_v151936` | sampling | ✅ |
+| `top_k_sampling_from_probs_v152064` | sampling | ✅ |
+| `top_k_top_p_sampling_from_probs_v152064` | sampling | ✅ |
+| `top_p_sampling_from_probs_v152064` | sampling | ✅ |
 
 **Coverage**: 3 / 14 definitions present. Missing: rmsnorm h8192, all GQA definitions (h8_kv1_d128 at TP=8), all GEMM definitions for hidden=8192.
 
@@ -438,7 +438,7 @@ At tensor parallelism TP=2, attention head counts are halved (48→24 q-heads, 8
 | `top_k_top_p_sampling_from_probs_v151936` | sampling | ✅ |
 | `top_p_sampling_from_probs_v151936` | sampling | ✅ |
 
-**Coverage**: 10 / 14 definitions present. RMSNorm shared with Qwen3 14B (same hidden=5120). GQA kernels shared with Llama 3.1/3.3 70B (same h=16, kv=2, d=128 at TP=4). Sampling shared with other Qwen3 models (same vocab=151936). Missing: all GEMM definitions.
+**Coverage**: 10 / 14 definitions present. RMSNorm shared with Qwen3 14B (same hidden=5120). GQA kernels shared with Llama 3.1/3.3 70B (same h=16, kv=2, d=128 at TP=4). Missing: all GEMM definitions.
 
 ---
 
@@ -738,7 +738,7 @@ Note: `hidden_size=5376` is non-standard; head_dim is explicitly 128 (not 5376/3
 | `top_k_top_p_sampling_from_probs_v151936` | sampling | ✅ |
 | `top_p_sampling_from_probs_v151936` | sampling | ✅ |
 
-**Coverage**: 14 / 14 definitions present. Sampling definitions are shared with Qwen2.5 and other Qwen3 models (same vocab=151936) which already have workloads collected. The rmsnorm_h5120 definition is also shared with Mistral Nemo 12B, Mistral Small 3.1 24B, Phi-4 14B, and Llama 4 Scout/Maverick. Non-sampling workloads not yet collected.
+**Coverage**: 14 / 14 definitions present. The rmsnorm_h5120 definition is also shared with Mistral Nemo 12B, Mistral Small 3.1 24B, Phi-4 14B, and Llama 4 Scout/Maverick. Non-sampling workloads not yet collected.
 
 ---
 

--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -359,9 +359,9 @@ At tensor parallelism TP=2, attention head counts are halved (48→24 q-heads, 8
 | `gemm_n3584_k3584` | gemm | ❌ |
 | `gemm_n37888_k3584` | gemm | ❌ |
 | `gemm_n3584_k18944` | gemm | ❌ |
-| `top_k_sampling_from_probs_v152064` | sampling | ✅ |
-| `top_k_top_p_sampling_from_probs_v152064` | sampling | ✅ |
-| `top_p_sampling_from_probs_v152064` | sampling | ✅ |
+| `top_k_sampling_from_probs_v152064` | sampling | 🟡 |
+| `top_k_top_p_sampling_from_probs_v152064` | sampling | 🟡 |
+| `top_p_sampling_from_probs_v152064` | sampling | 🟡 |
 
 **Coverage**: 3 / 14 definitions present. Missing: all rmsnorm, GQA, and GEMM definitions for hidden=3584.
 
@@ -384,9 +384,9 @@ At tensor parallelism TP=2, attention head counts are halved (48→24 q-heads, 8
 | `gemm_n8192_k8192` | gemm | ❌ |
 | `gemm_n59392_k8192` | gemm | ❌ |
 | `gemm_n8192_k29696` | gemm | ❌ |
-| `top_k_sampling_from_probs_v152064` | sampling | ✅ |
-| `top_k_top_p_sampling_from_probs_v152064` | sampling | ✅ |
-| `top_p_sampling_from_probs_v152064` | sampling | ✅ |
+| `top_k_sampling_from_probs_v152064` | sampling | 🟡 |
+| `top_k_top_p_sampling_from_probs_v152064` | sampling | 🟡 |
+| `top_p_sampling_from_probs_v152064` | sampling | 🟡 |
 
 **Coverage**: 3 / 14 definitions present. Missing: rmsnorm h8192, all GQA definitions (h8_kv1_d128 at TP=8), all GEMM definitions for hidden=8192.
 

--- a/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v152064.json
+++ b/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v152064.json
@@ -1,7 +1,7 @@
 {
   "name": "top_k_sampling_from_probs_v152064",
   "op_type": "sampling",
-  "description": "Top-k sampling from probabilities with vocab_size=152064. Keeps only the k highest probability tokens, renormalizes, then samples from the filtered distribution.",
+  "description": "Top-k sampling from probabilities with vocab_size=152064. Keeps only the k highest probability tokens, renormalizes, then samples from the filtered distribution. Captured from Qwen2.5 7B.",
   "tags": [
     "status:unverified",
     "model:qwen2.5-7b",

--- a/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v152064.json
+++ b/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v152064.json
@@ -1,0 +1,49 @@
+{
+  "name": "top_k_sampling_from_probs_v152064",
+  "op_type": "sampling",
+  "description": "Top-k sampling from probabilities with vocab_size=152064. Keeps only the k highest probability tokens, renormalizes, then samples from the filtered distribution.",
+  "tags": [
+    "status:unverified",
+    "model:qwen2.5-7b",
+    "model:qwen2.5-72b",
+    "fi_api:flashinfer.sampling.top_k_sampling_from_probs"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of sequences to sample from"
+    },
+    "vocab_size": {
+      "type": "const",
+      "value": 152064,
+      "description": "Size of the vocabulary for Qwen2.5"
+    }
+  },
+  "inputs": {
+    "probs": {
+      "shape": [
+        "batch_size",
+        "vocab_size"
+      ],
+      "dtype": "float32",
+      "description": "Probability distributions (after softmax)"
+    },
+    "top_k": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Number of top tokens to consider for sampling per sequence"
+    }
+  },
+  "outputs": {
+    "samples": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int64",
+      "description": "Sampled token indices"
+    }
+  },
+  "reference": "import torch\n\n@torch.no_grad()\ndef run(probs, top_k):\n    batch_size, vocab_size = probs.shape\n    device = probs.device\n\n    # Check constants\n    assert vocab_size == 152064\n\n    probs = probs.to(torch.float32)\n    samples = torch.empty(batch_size, dtype=torch.int64, device=device)\n\n    for i in range(batch_size):\n        row = probs[i]\n        k = int(top_k[i].item())\n\n        # No filtering on invalid k\n        if 0 < k < vocab_size:\n            idx_sorted = torch.argsort(row, descending=True)\n            keep_idx = idx_sorted[:k]\n\n            filtered = torch.zeros_like(row)\n            filtered[keep_idx] = row[keep_idx]\n\n            row = filtered / filtered.sum()\n\n        samples[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)\n\n    return samples\n"
+}

--- a/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v152064.json
+++ b/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v152064.json
@@ -1,0 +1,56 @@
+{
+  "name": "top_k_top_p_sampling_from_probs_v152064",
+  "op_type": "sampling",
+  "description": "Top-k top-p (nucleus) sampling from probabilities with vocab_size=152064. Filters probabilities using top-k and top-p constraints, then samples from the filtered distribution.",
+  "tags": [
+    "status:unverified",
+    "model:qwen2.5-7b",
+    "model:qwen2.5-72b",
+    "fi_api:flashinfer.sampling.top_k_top_p_sampling_from_probs"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of sequences to sample from"
+    },
+    "vocab_size": {
+      "type": "const",
+      "value": 152064,
+      "description": "Size of the vocabulary for Qwen2.5"
+    }
+  },
+  "inputs": {
+    "probs": {
+      "shape": [
+        "batch_size",
+        "vocab_size"
+      ],
+      "dtype": "float32",
+      "description": "Probability distributions (after softmax)"
+    },
+    "top_k": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int32",
+      "description": "Number of top tokens to consider for sampling per sequence"
+    },
+    "top_p": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "float32",
+      "description": "Cumulative probability threshold for nucleus sampling per sequence"
+    }
+  },
+  "outputs": {
+    "samples": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int64",
+      "description": "Sampled token indices"
+    }
+  },
+  "reference": "import torch\n\n@torch.no_grad()\ndef run(probs, top_k, top_p):\n    batch_size, vocab_size = probs.shape\n    device = probs.device\n\n    # Check constants\n    assert vocab_size == 152064\n\n    probs = probs.to(torch.float32)\n    samples = torch.empty(batch_size, dtype=torch.int64, device=device)\n\n    for i in range(batch_size):\n        row = probs[i]\n        k = int(top_k[i].item())\n        p = float(top_p[i].item())\n\n        # Apply top-k filtering\n        if 0 < k < vocab_size:\n            idx_sorted = torch.argsort(row, descending=True)\n            keep_idx_k = idx_sorted[:k]\n            filtered_k = torch.zeros_like(row)\n            filtered_k[keep_idx_k] = row[keep_idx_k]\n            row = filtered_k / filtered_k.sum()\n\n        # Then apply top-p filtering\n        if p <= 0.0:\n            samples[i] = torch.argmax(row).to(torch.int64)\n            continue\n\n        if p < 1.0:\n            vals, idx = torch.sort(row, descending=True)\n            cdf = torch.cumsum(vals, dim=0)\n\n            to_remove = cdf > p\n            if vocab_size > 1:\n                to_remove[1:] = to_remove[:-1].clone()\n                to_remove[0] = False\n\n            keep_idx_p = idx[~to_remove]\n            filtered_p = torch.zeros_like(row)\n            filtered_p[keep_idx_p] = row[keep_idx_p]\n            row = filtered_p / filtered_p.sum()\n\n        # sample\n        samples[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)\n\n    return samples\n"
+}

--- a/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v152064.json
+++ b/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v152064.json
@@ -1,7 +1,7 @@
 {
   "name": "top_k_top_p_sampling_from_probs_v152064",
   "op_type": "sampling",
-  "description": "Top-k top-p (nucleus) sampling from probabilities with vocab_size=152064. Filters probabilities using top-k and top-p constraints, then samples from the filtered distribution.",
+  "description": "Top-k top-p (nucleus) sampling from probabilities with vocab_size=152064. Filters probabilities using top-k and top-p constraints, then samples from the filtered distribution. Captured from Qwen2.5 7B.",
   "tags": [
     "status:unverified",
     "model:qwen2.5-7b",

--- a/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v152064.json
+++ b/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v152064.json
@@ -1,7 +1,7 @@
 {
   "name": "top_p_sampling_from_probs_v152064",
   "op_type": "sampling",
-  "description": "Top-p (nucleus) sampling from probabilities with vocab_size=152064. Filters probabilities using cumulative probability threshold, then samples from the filtered distribution.",
+  "description": "Top-p (nucleus) sampling from probabilities with vocab_size=152064. Filters probabilities using cumulative probability threshold, then samples from the filtered distribution. Captured from Qwen2.5 7B.",
   "tags": [
     "status:unverified",
     "model:qwen2.5-7b",

--- a/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v152064.json
+++ b/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v152064.json
@@ -1,0 +1,49 @@
+{
+  "name": "top_p_sampling_from_probs_v152064",
+  "op_type": "sampling",
+  "description": "Top-p (nucleus) sampling from probabilities with vocab_size=152064. Filters probabilities using cumulative probability threshold, then samples from the filtered distribution.",
+  "tags": [
+    "status:unverified",
+    "model:qwen2.5-7b",
+    "model:qwen2.5-72b",
+    "fi_api:flashinfer.sampling.top_p_sampling_from_probs"
+  ],
+  "axes": {
+    "batch_size": {
+      "type": "var",
+      "description": "Number of sequences to sample from"
+    },
+    "vocab_size": {
+      "type": "const",
+      "value": 152064,
+      "description": "Size of the vocabulary for Qwen2.5"
+    }
+  },
+  "inputs": {
+    "probs": {
+      "shape": [
+        "batch_size",
+        "vocab_size"
+      ],
+      "dtype": "float32",
+      "description": "Probability distributions (after softmax)"
+    },
+    "top_p": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "float32",
+      "description": "Cumulative probability threshold for nucleus sampling per sequence"
+    }
+  },
+  "outputs": {
+    "samples": {
+      "shape": [
+        "batch_size"
+      ],
+      "dtype": "int64",
+      "description": "Sampled token indices"
+    }
+  },
+  "reference": "import torch\n\n@torch.no_grad()\ndef run(probs, top_p):\n    batch_size, vocab_size = probs.shape\n    device = probs.device\n\n    # Check constants\n    assert vocab_size == 152064\n\n    probs = probs.to(torch.float32)\n    out = torch.empty(batch_size, dtype=torch.int64, device=device)\n\n    for i in range(batch_size):\n        row = probs[i]\n        p = float(top_p[i].item())\n        \n        if p <= 0.0:\n            # Degenerate to argmax\n            out[i] = torch.argmax(row).to(torch.int64)\n            continue\n\n        if p < 1.0:\n            vals, idx = torch.sort(row, descending=True)\n            cdf = torch.cumsum(vals, dim=0)\n\n            # Shift mask to keep the first token that crosses p\n            to_remove = cdf > p\n            to_remove[1:] = to_remove[:-1].clone()\n            to_remove[0] = False\n            keep = ~to_remove\n            keep_idx = idx[keep]\n\n            # Build filtered distribution in original index space\n            filtered = torch.zeros_like(row)\n            filtered[keep_idx] = row[keep_idx]\n            row = filtered / filtered.sum()\n\n        out[i] = torch.multinomial(row, 1, replacement=True).squeeze(0)\n\n    return out"
+}


### PR DESCRIPTION
## Summary
- Fix incorrect sampling definitions for Qwen 2.5 models (7B, 72B)
  - Previous definitions assumed the same vocab size as Qwen 3 (151936)
  - Qwen 2.5 models use vocab size = 152064 as described in [config.json](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/config.json) 
- Add sampling definitions for Qwen 2.5 (7B, 72B)
  - `top_k_sampling_from_probs_v152064`
  - `top_k_top_p_sampling_from_probs_v152064`
  - `top_p_sampling_from_probs_v152064`
- Update `model_coverage.mdx`: mark new sampling definitions as 🟡


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Qwen2.5 and Qwen3 coverage docs: adjusted sampling-definition references and workload collection statuses; removed statements that certain Qwen3 models shared already-collected sampling definitions while keeping other coverage notes.

* **New Features**
  * Added three sampling operators (top-k, top-p, top-k+top-p) that accept per-sequence k/p inputs and support a 152064-token vocabulary for improved sampling workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->