### PR TITLE
docs: add skill summaries and cross-references

### DIFF
--- a/.claude/skills/extract-kernel-definitions/SKILL.md
+++ b/.claude/skills/extract-kernel-definitions/SKILL.md
@@ -910,6 +910,9 @@ FlashInfer kernel to be available.
 /add-reference-tests --op-type mla_paged
 /add-reference-tests --op-type moe
 
+# Update model coverage documentation
+/track-models --refresh-status
+
 # Or use the full end-to-end pipeline (recommended for new models)
 /onboard-model --model-name qwen3-235b-a22b
 ```
@@ -931,3 +934,4 @@ Update this file when adding new op_types, changing Definition JSON schema, or m
 - [onboard-model](../onboard-model/SKILL.md)
 - [clone-repos](../clone-repos/SKILL.md)
 - [add-reference-tests](../add-reference-tests/SKILL.md)
+- [track-models](../track-models/SKILL.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,21 @@ reason against the external dataset
 
 ### Agent and skill workflows
 
-Start with `.claude/skills/`. Each subdirectory contains a `SKILL.md` describing a specific
-automated workflow (model onboarding, kernel extraction, workload collection, etc.).
+Start with `.claude/skills/`. Each subdirectory contains a `SKILL.md` with full instructions.
+
+- **onboard-model**: End-to-end pipeline for discovering new LLMs and onboarding them
+  (repo updates, model discovery, definition generation, workload collection, PR submission)
+- **extract-kernel-definitions**: Extract kernel schemas from SGLang model implementations
+  with deduplication, generate Definition JSON files
+- **collect-workloads**: Collect real workloads from SGLang inference runs using FlashInfer
+  logging API, sanitize and submit to flashinfer-trace
+- **collect-workloads-bench**: Collect workloads using `bench_sharegpt.py` with model-specific
+  server configs from `model_configs.json`
+- **add-reference-tests**: Add pytest tests to validate reference implementations against
+  FlashInfer or SGLang ground truth
+- **track-models**: Track open-source LLMs and update `docs/model_coverage.mdx` with kernel
+  support status
+- **clone-repos**: Clone SGLang, FlashInfer, sgl-cookbook, and flashinfer-trace to `tmp/`
 
 ## Common Misunderstandings
 


### PR DESCRIPTION
## Summary

Follow-up to #224. Adds two small improvements:

- List all 7 agent skills with brief descriptions in CLAUDE.md's "Where To Look By Task" section
- Add `track-models` to `extract-kernel-definitions` integration workflow and See Also, so model coverage updates aren't missed after definition extraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill workflow documentation to include additional integration steps and clarified skill directory structure with detailed responsibility definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->