### PR TITLE
fix: add missing model tags for sampling definitions

### DIFF
--- a/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v128256.json
+++ b/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v128256.json
@@ -5,6 +5,10 @@
   "tags": [
     "status:verified",
     "model:llama-3.1-8b",
+    "model:llama-3.1-70b",
+    "model:llama-3.1-405b",
+    "model:llama-3.2-3b",
+    "model:llama-3.3-70b",
     "fi_api:flashinfer.sampling.top_k_sampling_from_probs"
   ],
   "axes": {

--- a/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v151936.json
+++ b/flashinfer_trace/definitions/sampling/top_k_sampling_from_probs_v151936.json
@@ -4,7 +4,11 @@
   "description": "Top-k sampling from probabilities with vocab_size=151936. Keeps only the k highest probability tokens, renormalizes, then samples from the filtered distribution.",
   "tags": [
     "status:verified",
+    "model:qwen3-8b",
+    "model:qwen3-14b",
     "model:qwen3-30b-a3b",
+    "model:qwen3-32b",
+    "model:qwen3-235b-a22b",
     "fi_api:flashinfer.sampling.top_k_sampling_from_probs"
   ],
   "axes": {

--- a/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v128256.json
+++ b/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v128256.json
@@ -5,6 +5,10 @@
   "tags": [
     "status:verified",
     "model:llama-3.1-8b",
+    "model:llama-3.1-70b",
+    "model:llama-3.1-405b",
+    "model:llama-3.2-3b",
+    "model:llama-3.3-70b",
     "fi_api:flashinfer.sampling.top_k_top_p_sampling_from_probs"
   ],
   "axes": {

--- a/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v151936.json
+++ b/flashinfer_trace/definitions/sampling/top_k_top_p_sampling_from_probs_v151936.json
@@ -4,7 +4,11 @@
   "description": "Top-k top-p (nucleus) sampling from probabilities with vocab_size=151936. Filters probabilities using top-k and top-p constraints, then samples from the filtered distribution. Captured from Qwen 3 30B A3B.",
   "tags": [
     "status:verified",
+    "model:qwen3-8b",
+    "model:qwen3-14b",
     "model:qwen3-30b-a3b",
+    "model:qwen3-32b",
+    "model:qwen3-235b-a22b",
     "fi_api:flashinfer.sampling.top_k_top_p_sampling_from_probs"
   ],
   "axes": {

--- a/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v128256.json
+++ b/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v128256.json
@@ -5,6 +5,10 @@
   "tags": [
     "status:verified",
     "model:llama-3.1-8b",
+    "model:llama-3.1-70b",
+    "model:llama-3.1-405b",
+    "model:llama-3.2-3b",
+    "model:llama-3.3-70b",
     "fi_api:flashinfer.sampling.top_p_sampling_from_probs"
   ],
   "axes": {

--- a/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v151936.json
+++ b/flashinfer_trace/definitions/sampling/top_p_sampling_from_probs_v151936.json
@@ -4,7 +4,11 @@
   "description": "Top-p (nucleus) sampling from probabilities with vocab_size=151936. Filters probabilities using cumulative probability threshold, then samples from the filtered distribution. Captured from Qwen 3 30B A3B.",
   "tags": [
     "status:verified",
+    "model:qwen3-8b",
+    "model:qwen3-14b",
     "model:qwen3-30b-a3b",
+    "model:qwen3-32b",
+    "model:qwen3-235b-a22b",
     "fi_api:flashinfer.sampling.top_p_sampling_from_probs"
   ],
   "axes": {


### PR DESCRIPTION
## Summary 
- Add missing model tags for sampling definitions
- Qwen 3 models share same vocabulary size and thus sampling kernels
- Llama 3 models share same vocabulary size and thus sampling kernels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added model compatibility metadata for additional Llama and Qwen3 model variants across sampling operation definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->