### PR TITLE
feat: integrate Kimi K2.5 (model coverage + serving configs; partial, MoE blocked)

### DIFF
--- a/docs/model_coverage.mdx
+++ b/docs/model_coverage.mdx
@@ -32,6 +32,7 @@ This document tracks which kernels are supported in FlashInfer-Bench for each mo
 | Qwen3 235B A22B | GQA + MoE | 🟡 Partial |
 | Qwen3 Next 80B A3B | GDN + GQA + MoE | 🟡 Partial |
 | Kimi K2 | MLA + MoE | 🟡 Partial |
+| Kimi K2.5 | MLA + MoE (INT4 experts) + MoonViT | 🟡 Partial |
 | Phi-4 14B | GQA + Dense | 🟡 Partial |
 | Llama 3.1 405B | GQA + Dense | 🟡 Partial |
 | Llama 4 Scout 17B-16E | GQA + MoE | 🟡 Partial |
@@ -494,6 +495,33 @@ Kimi K2 uses DeepSeek V3-style MLA with the same kv_lora_rank=512 and qk_rope_he
 | `top_p_sampling_from_probs_v160000` | sampling | ❌ |
 
 **Coverage**: 6 / 15 definitions present. RMSNorm definitions are shared with DeepSeek V3 (same hidden=7168 and sub-module dims). MoE EP=1 and EP=8 definitions added. All MLA defs require new h=8 variants; MoE EP=4 variant (e=96) and sampling (v=160000) still missing.
+
+---
+
+## Kimi K2.5
+
+**Architecture**: 61 decoder layers, DeepSeek V3-style MLA attention, sparse MoE FFN (384 total experts, top-8 routing). Multimodal (vision + text) via a MoonViT vision tower. Standard serving configuration: **TP=8** (per MoonshotAI deploy guide).
+
+Kimi K2.5's text backbone (`text_config.architectures=["DeepseekV3ForCausalLM"]`) reuses the exact MLA / RMSNorm / RoPE shapes of Kimi K2 (`h=8` at TP=8, `kv_lora_rank=512`, `qk_rope_head_dim=64`, `q_lora_rank=1536`). The vocab size is new (`163840` vs Kimi K2's `160000`) so three new sampling definitions are added. Routed MoE experts are INT4 group-quantized (`compressed-tensors`, `group_size=32`, `num_bits=4`) rather than FP8 block-scale.
+
+| Definition | Op Type | Status |
+|-----------|---------|:------:|
+| `rmsnorm_h7168` | rmsnorm | ✅ |
+| `fused_add_rmsnorm_h7168` | rmsnorm | ✅ |
+| `rmsnorm_h1536` | rmsnorm | ✅ |
+| `rmsnorm_h512` | rmsnorm | ✅ |
+| `mla_paged_prefill_causal_h8_ckv512_kpe64_ps1` | mla_paged TP=8 | 🟡 |
+| `mla_paged_decode_h8_ckv512_kpe64_ps1` | mla_paged TP=8 | 🟡 |
+| `mla_ragged_prefill_causal_h8_qk192_vo128` | mla_ragged | 🟡 |
+| `rope_with_cos_sin_cache_neox_style_d128_rd64` | rope | 🟡 |
+| `moe_int4_pack_quantized_ds_routing_topk8_ng1_kg1_e384_h7168_i2048` | moe EP=1 | ❌ |
+| `moe_int4_pack_quantized_ds_routing_topk8_ng1_kg1_e96_h7168_i2048` | moe EP=4 | ❌ |
+| `moe_int4_pack_quantized_ds_routing_topk8_ng1_kg1_e48_h7168_i2048` | moe EP=8 | ❌ |
+| `top_k_sampling_from_probs_v163840` | sampling | 🟡 |
+| `top_p_sampling_from_probs_v163840` | sampling | 🟡 |
+| `top_k_top_p_sampling_from_probs_v163840` | sampling | 🟡 |
+
+**Coverage**: 11 / 14 definitions present. RMSNorm, MLA, and RoPE definitions are shared with Kimi K2 / DeepSeek V3 (tagged `model:kimi-k2.5`). Three new sampling definitions added for `vocab_size=163840`. MoE kernels are blocked: FlashInfer has no public INT4 group-quantized MoE API (as of 0.6.x, `flashinfer.fused_moe` exposes only FP8 block-scale / FP4 / bf16 paths), and SGLang dispatches INT4 `compressed-tensors` MoE through its own Triton path. The vision tower uses `sglang.srt.layers.attention.vision.VisionAttention`, not FlashInfer, and is out of scope. New sampling defs and MLA-tag updates are published in `flashinfer-ai/flashinfer-trace` PR [#310](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/310).
 
 ---
 

--- a/examples/sglang_bench/model_configs.json
+++ b/examples/sglang_bench/model_configs.json
@@ -178,6 +178,41 @@
                 "--moe-runner-backend", "triton",
                 "--disable-piecewise-cuda-graph"
             ]
+        },
+        "kimi-k2.5": {
+            "_comment": "Kimi K2.5 (moonshotai/Kimi-K2.5). Multimodal DeepSeek V3-style backbone + MoonViT. INT4 compressed-tensors MoE experts are dispatched by SGLang to its Triton MoE path, not FlashInfer; attention (MLA) uses FlashInfer. Standard serving config from MoonshotAI deploy_guidance: --tp 8 --trust-remote-code.",
+            "server_flags": [
+                "--trust-remote-code",
+                "--attention-backend", "flashinfer",
+                "--tp-size", "8",
+                "--moe-runner-backend", "triton",
+                "--tool-call-parser", "kimi_k2",
+                "--reasoning-parser", "kimi_k2"
+            ]
+        },
+        "kimi-k2.5-ps64": {
+            "_comment": "Kimi K2.5 with page_size=64 variant for paged workload collection.",
+            "server_flags": [
+                "--trust-remote-code",
+                "--attention-backend", "flashinfer",
+                "--tp-size", "8",
+                "--moe-runner-backend", "triton",
+                "--tool-call-parser", "kimi_k2",
+                "--reasoning-parser", "kimi_k2",
+                "--page-size", "64"
+            ]
+        },
+        "kimi-k2.5-ragged": {
+            "_comment": "Kimi K2.5 ragged-prefill variant: disable piecewise cuda graph so total prefill traces are collectable.",
+            "server_flags": [
+                "--trust-remote-code",
+                "--attention-backend", "flashinfer",
+                "--tp-size", "8",
+                "--moe-runner-backend", "triton",
+                "--tool-call-parser", "kimi_k2",
+                "--reasoning-parser", "kimi_k2",
+                "--disable-piecewise-cuda-graph"
+            ]
         }
     },
     "h200": {
@@ -230,6 +265,17 @@
                 "--trust-remote-code",
                 "--attention-backend", "flashinfer",
                 "--tp-size", "8"
+            ]
+        },
+        "kimi-k2.5": {
+            "_comment": "Kimi K2.5 on H200 (single-node TP=8 recommended by MoonshotAI deploy_guidance).",
+            "server_flags": [
+                "--trust-remote-code",
+                "--attention-backend", "flashinfer",
+                "--tp-size", "8",
+                "--moe-runner-backend", "triton",
+                "--tool-call-parser", "kimi_k2",
+                "--reasoning-parser", "kimi_k2"
             ]
         }
     },


### PR DESCRIPTION
Adds Kimi K2.5 (`moonshotai/Kimi-K2.5`) to the FlashInfer-Bench coverage matrix.

## GitHub side (this PR)
- `docs/model_coverage.mdx`: add Kimi K2.5 section + summary row, mark 11/14 definitions present
- `examples/sglang_bench/model_configs.json`: add `kimi-k2.5`, `kimi-k2.5-ps64`, `kimi-k2.5-ragged` for B200 + `kimi-k2.5` for H200 (TP=8, triton MoE backend)

## Hugging Face side (companion PR)
Dataset artifacts live in [`flashinfer-ai/flashinfer-trace#310`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/310):

- 3 new sampling definitions (`top_{k,p,k_top_p}_sampling_from_probs_v163840`) for Kimi K2.5's new vocab size (163840 vs Kimi K2's 160000)
- 3 matching reference tests at `tests/references/`
- 3 existing MLA defs tagged with `model:kimi-k2.5`:
  - `mla_paged_decode_h8_ckv512_kpe64_ps1`
  - `mla_paged_prefill_causal_h8_ckv512_kpe64_ps1`
  - `mla_ragged_prefill_causal_h8_qk192_vo128`

The text backbone (`DeepseekV3ForCausalLM`) reuses Kimi K2's MLA / RMSNorm / RoPE shapes at TP=8 (`h=8`, `kv_lora_rank=512`, `qk_rope_head_dim=64`), so MLA defs are tagged rather than duplicated. RMSNorm and RoPE defs are also reused from Kimi K2 / DeepSeek V3.

## Smoke check
- All 3 new sampling reference tests pass against the HF PR snapshot on RTX 5090 (3/3 each)
- All 3 patched MLA reference tests still pass after the tag/description update on PR 310

## Out of scope 
- **INT4 group-quantized MoE experts** (`compressed-tensors`, `group_size=32`, `num_bits=4`): FlashInfer 0.6.x has no public INT4 group-quantized MoE API; SGLang dispatches these through its own Triton path
- **MoonViT vision tower**: uses `sglang.srt.layers.attention.vision.VisionAttention`, outside FlashInfer's scope


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kimi K2.5 model support with multiple benchmark configurations for B200 and H200 GPUs, including variants optimized for different deployment scenarios.

* **Documentation**
  * Expanded model coverage documentation to include Kimi K2.5, detailing supported components, implementation status, and overall feature coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->