### PR TITLE
fix: respect CLI overrides over YAML layers in resolve_eval_config

### DIFF
--- a/flashinfer_bench/bench/config.py
+++ b/flashinfer_bench/bench/config.py
@@ -85,11 +85,13 @@ class BenchmarkConfig(BaseModel):
     """CLI override for absolute tolerance. None means inherit from YAML / defaults."""
     required_matched_ratio: Optional[float] = Field(default=None, gt=0, le=1)
     """CLI override for required matched ratio. None means inherit from YAML / defaults."""
-    # Deprecated: use op_type_config/definition_config extra instead
-    sampling_validation_trials: int = Field(default=100, gt=0)
-    """Deprecated default for Sampling evaluator validation rounds."""
-    sampling_tvd_threshold: float = Field(default=0.2, ge=0, le=1)
-    """Deprecated default for Sampling evaluator TVD threshold."""
+    # Deprecated: use op_type_config/definition_config extra instead. Kept as
+    # top-level CLI-style overrides for the same reason as the other eval fields:
+    # None means "not set at this layer"; non-None wins over YAML layer.extra.
+    sampling_validation_trials: Optional[int] = Field(default=None, gt=0)
+    """Deprecated CLI override for Sampling evaluator validation rounds."""
+    sampling_tvd_threshold: Optional[float] = Field(default=None, ge=0, le=1)
+    """Deprecated CLI override for Sampling evaluator TVD threshold."""
 
     # Per op_type / per definition overrides
     op_type_config: Dict[str, EvalConfig] = Field(default_factory=dict)
@@ -131,13 +133,7 @@ class BenchmarkConfig(BaseModel):
         ``--required-matched-ratio 0.9`` is never silently shadowed by a value
         coming from the packaged ``eval_config.yaml``.
         """
-        merged: Dict[str, Any] = {
-            "profile_baseline": self.profile_baseline,
-            "extra": {
-                "sampling_validation_trials": self.sampling_validation_trials,
-                "sampling_tvd_threshold": self.sampling_tvd_threshold,
-            },
-        }
+        merged: Dict[str, Any] = {"profile_baseline": self.profile_baseline, "extra": {}}
 
         layers = [
             self.op_type_config.get(definition.op_type),
@@ -162,5 +158,11 @@ class BenchmarkConfig(BaseModel):
             "required_matched_ratio": self.required_matched_ratio,
         }
         merged.update({k: v for k, v in top_level.items() if v is not None})
+
+        extra_overrides = {
+            "sampling_validation_trials": self.sampling_validation_trials,
+            "sampling_tvd_threshold": self.sampling_tvd_threshold,
+        }
+        merged["extra"].update({k: v for k, v in extra_overrides.items() if v is not None})
 
         return ResolvedEvalConfig(**merged)

--- a/flashinfer_bench/bench/config.py
+++ b/flashinfer_bench/bench/config.py
@@ -70,19 +70,21 @@ class BenchmarkConfig(BaseModel):
     log_dir: Optional[str] = None
     """Deprecated. Logs are embedded in trace evaluations."""
 
-    # Per-definition defaults
-    warmup_runs: int = Field(default=10, ge=0)
-    """Default warmup iterations before timing for all definitions."""
-    iterations: int = Field(default=50, gt=0)
-    """Default timed iterations per trial for all definitions."""
-    num_trials: int = Field(default=3, gt=0)
-    """Default number of benchmark trials for all definitions."""
-    rtol: float = Field(default=1e-2, gt=0)
-    """Default relative tolerance for numerical checks."""
-    atol: float = Field(default=1e-2, gt=0)
-    """Default absolute tolerance for numerical checks."""
+    # Top-level / CLI overrides. None means "not set at this layer" — falls through
+    # to YAML layers and the hardcoded defaults in ResolvedEvalConfig. When non-None,
+    # these win over op_type_config and definition_config (CLI has highest priority).
+    warmup_runs: Optional[int] = Field(default=None, ge=0)
+    """CLI override for warmup iterations. None means inherit from YAML / defaults."""
+    iterations: Optional[int] = Field(default=None, gt=0)
+    """CLI override for timed iterations per trial. None means inherit from YAML / defaults."""
+    num_trials: Optional[int] = Field(default=None, gt=0)
+    """CLI override for number of benchmark trials. None means inherit from YAML / defaults."""
+    rtol: Optional[float] = Field(default=None, gt=0)
+    """CLI override for relative tolerance. None means inherit from YAML / defaults."""
+    atol: Optional[float] = Field(default=None, gt=0)
+    """CLI override for absolute tolerance. None means inherit from YAML / defaults."""
     required_matched_ratio: Optional[float] = Field(default=None, gt=0, le=1)
-    """Default minimum fraction of elements that must be within tolerance."""
+    """CLI override for required matched ratio. None means inherit from YAML / defaults."""
     # Deprecated: use op_type_config/definition_config extra instead
     sampling_validation_trials: int = Field(default=100, gt=0)
     """Deprecated default for Sampling evaluator validation rounds."""
@@ -122,14 +124,14 @@ class BenchmarkConfig(BaseModel):
         return cls(**overrides)
 
     def resolve_eval_config(self, definition: Any) -> ResolvedEvalConfig:
-        """Merge: per-def defaults -> op_type_config -> definition_config."""
-        merged = {
-            "warmup_runs": self.warmup_runs,
-            "iterations": self.iterations,
-            "num_trials": self.num_trials,
-            "rtol": self.rtol,
-            "atol": self.atol,
-            "required_matched_ratio": self.required_matched_ratio,
+        """Merge priority (lowest -> highest): ResolvedEvalConfig defaults ->
+        op_type_config -> definition_config -> top-level / CLI overrides.
+
+        Top-level fields win when non-None, so a CLI flag such as
+        ``--required-matched-ratio 0.9`` is never silently shadowed by a value
+        coming from the packaged ``eval_config.yaml``.
+        """
+        merged: Dict[str, Any] = {
             "profile_baseline": self.profile_baseline,
             "extra": {
                 "sampling_validation_trials": self.sampling_validation_trials,
@@ -141,7 +143,6 @@ class BenchmarkConfig(BaseModel):
             self.op_type_config.get(definition.op_type),
             self.definition_config.get(definition.name),
         ]
-
         for layer in layers:
             if layer is None:
                 continue
@@ -151,5 +152,15 @@ class BenchmarkConfig(BaseModel):
             merged.update(updates)
             if layer.extra:
                 merged["extra"].update(layer.extra)
+
+        top_level = {
+            "warmup_runs": self.warmup_runs,
+            "iterations": self.iterations,
+            "num_trials": self.num_trials,
+            "rtol": self.rtol,
+            "atol": self.atol,
+            "required_matched_ratio": self.required_matched_ratio,
+        }
+        merged.update({k: v for k, v in top_level.items() if v is not None})
 
         return ResolvedEvalConfig(**merged)

--- a/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps64.py
+++ b/flashinfer_trace/tests/references/test_gqa_paged_prefill_causal_h5_kv1_d128_ps64.py
@@ -106,9 +106,7 @@ def test_correctness(batch_size=2, max_seq_len=256, atol=1e-2, rtol=5e-2):
         kv_data_type=torch.bfloat16,
         sm_scale=inputs["sm_scale"].item(),
     )
-    fi_o, fi_lse = wrapper.run(
-        inputs["q"], (inputs["k_cache"], inputs["v_cache"]), return_lse=True
-    )
+    fi_o, fi_lse = wrapper.run(inputs["q"], (inputs["k_cache"], inputs["v_cache"]), return_lse=True)
 
     out_ok = torch.allclose(ref_o.float(), fi_o.float(), atol=atol, rtol=rtol)
     lse_ok = torch.allclose(ref_lse, fi_lse, atol=atol, rtol=rtol)

--- a/scripts/collect_stream.py
+++ b/scripts/collect_stream.py
@@ -64,6 +64,7 @@ HF_BATCH_SIZE = 500  # max operations per HF commit
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def log(msg: str) -> None:
     ts = time.strftime("%Y-%m-%d %H:%M:%S")
     print(f"[collect_stream {ts}] {msg}", flush=True)
@@ -72,9 +73,7 @@ def log(msg: str) -> None:
 def get_definition(trace_dir: Path, def_name: str) -> dict:
     matches = list((trace_dir / "definitions").glob(f"**/{def_name}.json"))
     if not matches:
-        raise FileNotFoundError(
-            f"Definition '{def_name}' not found under {trace_dir}/definitions/"
-        )
+        raise FileNotFoundError(f"Definition '{def_name}' not found under {trace_dir}/definitions/")
     with open(matches[0]) as f:
         return json.load(f)
 
@@ -85,8 +84,19 @@ def get_op_type(defn: dict) -> str:
         return op
     # Fallback: first component of name (e.g. "gqa_paged_decode_..." → "gqa_paged")
     name = defn["name"]
-    for known in ("gqa_paged", "gqa_ragged", "mla_paged", "dsa_paged", "gdn", "moe",
-                  "rope", "rmsnorm", "gemm", "sampling", "mamba_ssu"):
+    for known in (
+        "gqa_paged",
+        "gqa_ragged",
+        "mla_paged",
+        "dsa_paged",
+        "gdn",
+        "moe",
+        "rope",
+        "rmsnorm",
+        "gemm",
+        "sampling",
+        "mamba_ssu",
+    ):
         if name.startswith(known):
             return known
     return name.split("_")[0]
@@ -96,7 +106,7 @@ def get_include_pattern(defn: dict) -> str:
     """Derive FLASHINFER_DUMP_INCLUDE glob from the fi_api tag."""
     for tag in defn.get("tags", []):
         if tag.startswith("fi_api:"):
-            api = tag[len("fi_api:"):]
+            api = tag[len("fi_api:") :]
             parts = api.split(".")
             # Use the class name with a wildcard (matches .run, .plan, etc.)
             cls = next((p for p in parts if p[0].isupper()), None)
@@ -119,6 +129,7 @@ def snapshot_blobs(blob_dir: Path) -> set:
 # ---------------------------------------------------------------------------
 # Step 1: run inference
 # ---------------------------------------------------------------------------
+
 
 def run_inference(
     def_name: str,
@@ -158,12 +169,18 @@ def run_inference(
     }
 
     cmd = [
-        sys.executable, str(_BENCH_SCRIPT),
-        "--model", model_key,
-        "--model-path", model_path,
-        "--batch-sizes", str(batch_size),
-        "--num-batches", str(num_batches),
-        "--base-url", base_url,
+        sys.executable,
+        str(_BENCH_SCRIPT),
+        "--model",
+        model_key,
+        "--model-path",
+        model_path,
+        "--batch-sizes",
+        str(batch_size),
+        "--num-batches",
+        str(num_batches),
+        "--base-url",
+        base_url,
     ] + extra_server_flags
 
     if peer_node_addr:
@@ -191,19 +208,21 @@ def run_inference(
 # Step 2: sanitize
 # ---------------------------------------------------------------------------
 
+
 def run_sanitize(
-    dump_dir: Path,
-    def_name: str,
-    trace_dir: Path,
-    max_new_workloads: int,
-    replace: bool = False,
+    dump_dir: Path, def_name: str, trace_dir: Path, max_new_workloads: int, replace: bool = False
 ) -> None:
     cmd = [
-        sys.executable, str(_SANITIZE_SCRIPT),
-        "--dump-dir", str(dump_dir),
-        "--definitions", def_name,
-        "--flashinfer-trace-dir", str(trace_dir),
-        "--max-new-workloads", str(max_new_workloads),
+        sys.executable,
+        str(_SANITIZE_SCRIPT),
+        "--dump-dir",
+        str(dump_dir),
+        "--definitions",
+        def_name,
+        "--flashinfer-trace-dir",
+        str(trace_dir),
+        "--max-new-workloads",
+        str(max_new_workloads),
     ]
     if replace:
         cmd.append("--replace")
@@ -218,6 +237,7 @@ def run_sanitize(
 # Step 3: push to HF PR (append-only)
 # ---------------------------------------------------------------------------
 
+
 def push_to_pr(
     pr_num: int,
     def_name: str,
@@ -228,7 +248,7 @@ def push_to_pr(
     batch_size: int,
 ) -> None:
     """Upload updated JSONL + new blobs to the HF PR.  Never deletes existing files."""
-    from huggingface_hub import HfApi, CommitOperationAdd
+    from huggingface_hub import CommitOperationAdd, HfApi
 
     api = HfApi()
 
@@ -246,15 +266,12 @@ def push_to_pr(
     # Always re-upload the full JSONL (it's small) so the HF copy stays current.
     ops = [
         CommitOperationAdd(
-            path_in_repo=f"workloads/{op_type}/{def_name}.jsonl",
-            path_or_fileobj=str(jsonl_path),
+            path_in_repo=f"workloads/{op_type}/{def_name}.jsonl", path_or_fileobj=str(jsonl_path)
         )
     ]
     for blob_abs in sorted(new_blobs):
         blob_rel = Path(blob_abs).relative_to(trace_dir)
-        ops.append(
-            CommitOperationAdd(path_in_repo=str(blob_rel), path_or_fileobj=blob_abs)
-        )
+        ops.append(CommitOperationAdd(path_in_repo=str(blob_rel), path_or_fileobj=blob_abs))
 
     for i in range(0, len(ops), HF_BATCH_SIZE):
         batch = ops[i : i + HF_BATCH_SIZE]
@@ -263,8 +280,7 @@ def push_to_pr(
             repo_type=HF_REPO_TYPE,
             operations=batch,
             commit_message=(
-                f"Add {def_name} workloads (bs={batch_size}, "
-                f"part {i // HF_BATCH_SIZE + 1})"
+                f"Add {def_name} workloads (bs={batch_size}, " f"part {i // HF_BATCH_SIZE + 1})"
             ),
             revision=f"refs/pr/{pr_num}",
             num_threads=8,
@@ -276,14 +292,19 @@ def push_to_pr(
 # Step 5: eval
 # ---------------------------------------------------------------------------
 
+
 def run_eval(def_name: str, trace_dir: Path) -> bool:
     """Run flashinfer-bench baseline evaluation. Returns True if all PASSED."""
     log("Running flashinfer-bench baseline eval ...")
     cmd = [
-        "flashinfer-bench", "run",
-        "--local", str(trace_dir),
-        "--definitions", def_name,
-        "--solutions", "baseline",
+        "flashinfer-bench",
+        "run",
+        "--local",
+        str(trace_dir),
+        "--definitions",
+        def_name,
+        "--solutions",
+        "baseline",
     ]
     result = subprocess.run(cmd)
     if result.returncode != 0:
@@ -296,9 +317,10 @@ def run_eval(def_name: str, trace_dir: Path) -> bool:
 # Step 6: push trace
 # ---------------------------------------------------------------------------
 
+
 def push_trace(pr_num: int, def_name: str, op_type: str, trace_dir: Path) -> None:
     """Push the baseline trace JSONL to the HF PR."""
-    from huggingface_hub import HfApi, CommitOperationAdd
+    from huggingface_hub import CommitOperationAdd, HfApi
 
     api = HfApi()
 
@@ -316,8 +338,7 @@ def push_trace(pr_num: int, def_name: str, op_type: str, trace_dir: Path) -> Non
         repo_type=HF_REPO_TYPE,
         operations=[
             CommitOperationAdd(
-                path_in_repo=f"traces/{op_type}/{def_name}.jsonl",
-                path_or_fileobj=str(trace_path),
+                path_in_repo=f"traces/{op_type}/{def_name}.jsonl", path_or_fileobj=str(trace_path)
             )
         ],
         commit_message=f"Add {def_name} baseline traces",
@@ -331,49 +352,56 @@ def push_trace(pr_num: int, def_name: str, op_type: str, trace_dir: Path) -> Non
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--def-name", required=True,
-        help="Definition name (e.g. gqa_paged_decode_h5_kv1_d128_ps64)",
+        "--def-name", required=True, help="Definition name (e.g. gqa_paged_decode_h5_kv1_d128_ps64)"
     )
     parser.add_argument(
-        "--model-key", required=True,
+        "--model-key",
+        required=True,
         help="Model key for bench_sharegpt.py (e.g. llama-4-scout-ps64)",
     )
+    parser.add_argument("--model-path", required=True, help="Path to model weights directory")
     parser.add_argument(
-        "--model-path", required=True,
-        help="Path to model weights directory",
-    )
-    parser.add_argument(
-        "--batch-sizes", type=int, nargs="+", required=True,
+        "--batch-sizes",
+        type=int,
+        nargs="+",
+        required=True,
         help="Batch sizes to collect (e.g. 64 128)",
     )
     parser.add_argument(
-        "--pr-num", type=int, required=True,
-        help="HuggingFace PR number to push workloads to",
+        "--pr-num", type=int, required=True, help="HuggingFace PR number to push workloads to"
     )
     parser.add_argument(
-        "--trace-dir", default="tmp/flashinfer-trace",
+        "--trace-dir",
+        default="tmp/flashinfer-trace",
         help="flashinfer-trace repo clone dir (default: tmp/flashinfer-trace)",
     )
     parser.add_argument(
-        "--dump-base-dir", default="/tmp/fi_stream_dump",
+        "--dump-base-dir",
+        default="/tmp/fi_stream_dump",
         help="Base dir for per-batch-size dump dirs (default: /tmp/fi_stream_dump)",
     )
     parser.add_argument(
-        "--dump-count", type=int, default=500,
+        "--dump-count",
+        type=int,
+        default=500,
         help="FLASHINFER_DUMP_MAX_COUNT per server session (default: 500)",
     )
     parser.add_argument(
-        "--workloads-per-batch", type=int, default=4,
+        "--workloads-per-batch",
+        type=int,
+        default=4,
         help="Max new workloads to select per batch size (default: 4)",
     )
     parser.add_argument(
-        "--num-batches", type=int, default=2,
+        "--num-batches",
+        type=int,
+        default=2,
         help=(
             "Inference rounds per batch size (default: 2). "
             "The dump budget is typically hit in round 1; "
@@ -381,31 +409,39 @@ def main():
         ),
     )
     parser.add_argument(
-        "--base-url", default="http://127.0.0.1:20000",
+        "--base-url",
+        default="http://127.0.0.1:20000",
         help="SGLang server base URL (default: http://127.0.0.1:20000)",
     )
     parser.add_argument(
-        "--peer-node-addr", nargs="+", default=None, metavar="HOST",
+        "--peer-node-addr",
+        nargs="+",
+        default=None,
+        metavar="HOST",
         help="Peer node hostname(s) for multi-node TP",
     )
     parser.add_argument(
-        "--dist-init-port", type=int, default=20010,
+        "--dist-init-port",
+        type=int,
+        default=20010,
         help="PyTorch distributed rendezvous port (default: 20010)",
     )
     parser.add_argument(
-        "--conda-env", default=None,
-        help="Conda environment name for peer-node SSH workers",
+        "--conda-env", default=None, help="Conda environment name for peer-node SSH workers"
     )
     parser.add_argument(
-        "--include-pattern", default=None,
+        "--include-pattern",
+        default=None,
         help=(
-            "Override FLASHINFER_DUMP_INCLUDE pattern. "
-            "Auto-derived from fi_api tag if omitted."
+            "Override FLASHINFER_DUMP_INCLUDE pattern. " "Auto-derived from fi_api tag if omitted."
         ),
     )
     parser.add_argument(
-        "--extra-server-flag", nargs="*", default=None,
-        dest="extra_server_flags", metavar="FLAG",
+        "--extra-server-flag",
+        nargs="*",
+        default=None,
+        dest="extra_server_flags",
+        metavar="FLAG",
         help=(
             "Extra flags forwarded verbatim to bench_sharegpt.py. "
             "Default: --disable-cuda-graph. "
@@ -413,22 +449,25 @@ def main():
         ),
     )
     parser.add_argument(
-        "--replace-first", action="store_true",
+        "--replace-first",
+        action="store_true",
         help="Replace (not append) existing workloads when processing the first batch size",
     )
     parser.add_argument(
-        "--no-eval", action="store_true",
+        "--no-eval",
+        action="store_true",
         help="Skip flashinfer-bench eval and trace upload (steps 5-6)",
     )
     parser.add_argument(
-        "--no-push", action="store_true",
-        help="Dry-run: collect and sanitize but do not push to HF",
+        "--no-push", action="store_true", help="Dry-run: collect and sanitize but do not push to HF"
     )
     args = parser.parse_args()
 
     trace_dir = Path(args.trace_dir).expanduser().resolve()
     dump_base_dir = Path(args.dump_base_dir)
-    extra_server_flags = args.extra_server_flags if args.extra_server_flags is not None else ["--disable-cuda-graph"]
+    extra_server_flags = (
+        args.extra_server_flags if args.extra_server_flags is not None else ["--disable-cuda-graph"]
+    )
 
     # Load definition to derive op_type and include pattern
     defn = get_definition(trace_dir, args.def_name)
@@ -498,7 +537,9 @@ def main():
         # --- Step 3: push ---
         if not args.no_push:
             log("Step 3: push to HF PR")
-            push_to_pr(args.pr_num, args.def_name, op_type, trace_dir, blob_dir, old_blobs, batch_size)
+            push_to_pr(
+                args.pr_num, args.def_name, op_type, trace_dir, blob_dir, old_blobs, batch_size
+            )
         else:
             log("Step 3: skipped (--no-push)")
 

--- a/tests/bench/test_benchmark_config.py
+++ b/tests/bench/test_benchmark_config.py
@@ -122,5 +122,37 @@ def test_definition_config_beats_op_type_config():
     assert resolved.rtol == 0.1
 
 
+def test_sampling_extra_cli_override_beats_yaml():
+    """Top-level sampling_* fields (deprecated CLI overrides) win over YAML layer.extra,
+    matching the precedence of the other eval fields."""
+    cfg = BenchmarkConfig(
+        sampling_validation_trials=1,
+        op_type_config={"sampling": EvalConfig(extra={"sampling_validation_trials": 100})},
+    )
+    definition = SimpleNamespace(op_type="sampling", name="sampling_def")
+    resolved = cfg.resolve_eval_config(definition)
+    assert resolved.extra["sampling_validation_trials"] == 1
+
+
+def test_sampling_extra_yaml_applies_without_cli_override():
+    """YAML layer.extra still applies when no top-level override is supplied."""
+    cfg = BenchmarkConfig(
+        op_type_config={"sampling": EvalConfig(extra={"sampling_validation_trials": 50})}
+    )
+    definition = SimpleNamespace(op_type="sampling", name="sampling_def")
+    resolved = cfg.resolve_eval_config(definition)
+    assert resolved.extra["sampling_validation_trials"] == 50
+
+
+def test_sampling_extra_empty_when_nothing_set():
+    """When neither CLI nor YAML sets sampling_*, resolved.extra is empty so the
+    evaluator falls back to its own class-level defaults (100 / 0.2)."""
+    cfg = BenchmarkConfig()
+    definition = SimpleNamespace(op_type="sampling", name="sampling_def")
+    resolved = cfg.resolve_eval_config(definition)
+    assert "sampling_validation_trials" not in resolved.extra
+    assert "sampling_tvd_threshold" not in resolved.extra
+
+
 if __name__ == "__main__":
     pytest.main(sys.argv)

--- a/tests/bench/test_benchmark_config.py
+++ b/tests/bench/test_benchmark_config.py
@@ -8,11 +8,19 @@ from flashinfer_bench.bench import BenchmarkConfig, EvalConfig, ResolvedEvalConf
 
 
 def test_benchmark_config_defaults_valid():
+    # Top-level fields are Optional and default to None so they act as CLI
+    # overrides only when explicitly set. Defaults are supplied by ResolvedEvalConfig.
     cfg = BenchmarkConfig()
-    assert cfg.warmup_runs >= 0
-    assert cfg.iterations > 0
-    assert cfg.num_trials > 0
-    assert cfg.rtol > 0 and cfg.atol > 0
+    assert cfg.warmup_runs is None
+    assert cfg.iterations is None
+    assert cfg.num_trials is None
+    assert cfg.rtol is None and cfg.atol is None
+
+    resolved = cfg.resolve_eval_config(SimpleNamespace(op_type="generic", name="anon"))
+    assert resolved.warmup_runs >= 0
+    assert resolved.iterations > 0
+    assert resolved.num_trials > 0
+    assert resolved.rtol > 0 and resolved.atol > 0
 
 
 @pytest.mark.parametrize(
@@ -61,8 +69,10 @@ def test_from_yaml(tmp_path):
 
 
 def test_resolve_merge_priority():
+    # Priority (lowest -> highest): ResolvedEvalConfig defaults ->
+    # op_type_config -> definition_config -> top-level / CLI overrides.
     cfg = BenchmarkConfig(
-        rtol=0.01,
+        rtol=0.01,  # CLI-supplied override — must win over YAML layers below.
         atol=0.01,
         op_type_config={"moe": EvalConfig(rtol=0.05, required_matched_ratio=0.95)},
         definition_config={"moe_fp8_def": EvalConfig(rtol=0.1)},
@@ -72,10 +82,46 @@ def test_resolve_merge_priority():
     resolved = cfg.resolve_eval_config(definition)
 
     assert isinstance(resolved, ResolvedEvalConfig)
-    assert resolved.rtol == 0.1
+    # CLI-supplied rtol beats both op_type_config and definition_config.
+    assert resolved.rtol == 0.01
+    # No CLI value for required_matched_ratio, so op_type_config applies.
     assert resolved.required_matched_ratio == 0.95
     assert resolved.atol == 0.01
+    # No value at any layer -> hardcoded ResolvedEvalConfig default.
     assert resolved.warmup_runs == 10
+
+
+def test_cli_override_beats_yaml_op_type():
+    """Regression test: --required-matched-ratio 0.9 must not be shadowed by
+    eval_config.yaml's op_type_config.moe.required_matched_ratio = 0.95."""
+    cfg = BenchmarkConfig(
+        required_matched_ratio=0.9,  # simulates CLI --required-matched-ratio 0.9
+        op_type_config={"moe": EvalConfig(required_matched_ratio=0.95)},
+    )
+    definition = SimpleNamespace(op_type="moe", name="some_moe_def")
+    resolved = cfg.resolve_eval_config(definition)
+    assert resolved.required_matched_ratio == 0.9
+
+
+def test_yaml_op_type_applies_without_cli_override():
+    """When CLI doesn't supply the field, YAML op_type_config still takes effect."""
+    cfg = BenchmarkConfig(
+        op_type_config={"moe": EvalConfig(required_matched_ratio=0.95)},
+    )
+    definition = SimpleNamespace(op_type="moe", name="some_moe_def")
+    resolved = cfg.resolve_eval_config(definition)
+    assert resolved.required_matched_ratio == 0.95
+
+
+def test_definition_config_beats_op_type_config():
+    """Among YAML layers, more-specific (definition) beats less-specific (op_type)."""
+    cfg = BenchmarkConfig(
+        op_type_config={"moe": EvalConfig(rtol=0.05)},
+        definition_config={"my_def": EvalConfig(rtol=0.1)},
+    )
+    definition = SimpleNamespace(op_type="moe", name="my_def")
+    resolved = cfg.resolve_eval_config(definition)
+    assert resolved.rtol == 0.1
 
 
 if __name__ == "__main__":

--- a/tests/bench/test_benchmark_config.py
+++ b/tests/bench/test_benchmark_config.py
@@ -105,9 +105,7 @@ def test_cli_override_beats_yaml_op_type():
 
 def test_yaml_op_type_applies_without_cli_override():
     """When CLI doesn't supply the field, YAML op_type_config still takes effect."""
-    cfg = BenchmarkConfig(
-        op_type_config={"moe": EvalConfig(required_matched_ratio=0.95)},
-    )
+    cfg = BenchmarkConfig(op_type_config={"moe": EvalConfig(required_matched_ratio=0.95)})
     definition = SimpleNamespace(op_type="moe", name="some_moe_def")
     resolved = cfg.resolve_eval_config(definition)
     assert resolved.required_matched_ratio == 0.95


### PR DESCRIPTION
  ## Summary

  - `BenchmarkConfig.resolve_eval_config` merged `op_type_config` and    `definition_config` **after** top-level fields, so any CLI flag whose    field also had a YAML entry was silently overridden.

  ## Fix

  - Change top-level eval fields (`warmup_runs`, `iterations`, `num_trials`,  `rtol`, `atol`) to `Optional[...] = None`. `required_matched_ratio` was    already `Optional`.
  - Rewrite `resolve_eval_config` so the merge order is now  `ResolvedEvalConfig` defaults → `op_type_config` → `definition_config`     → top-level / CLI overrides (highest priority).
  - Hardcoded fallbacks (10 / 50 / 3 / 1e-2 / 1e-2) come from `ResolvedEvalConfig` alone; YAML layers still stack by specificity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Evaluation parameters are now treated as optional and resolved using layered precedence: resolved defaults → per-operation-type → per-definition → top-level/CLI overrides.

* **Tests**
  * Strengthened regression tests to validate layered override and deprecated sampling override precedence.

* **Style**
  * Minor formatting and import ordering cleanups; a small test invocation was reformatted for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->