### PR TITLE
fix: remove extra def_name subdirectory in workload blob path

### DIFF
--- a/flashinfer_bench/data/trace_set.py
+++ b/flashinfer_bench/data/trace_set.py
@@ -751,7 +751,6 @@ class TraceSet:
         file_path = (
             self.blob_workloads_path
             / op_type
-            / def_name
             / f"{def_name}_{workload_uuid}.safetensors"
         )
         file_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #201

## Problem

`add_workload_blob_tensor` was writing workload blobs to:
```
blob/workloads/{op_type}/{def_name}/{def_name}_{uuid}.safetensors
```

But workload JSONL files reference the flat format:
```
blob/workloads/{op_type}/{def_name}_{uuid}.safetensors
```

This mismatch caused `FileNotFoundError` when loading workloads (and downstream `No healthy persistent workers available` errors).

## Fix

Removed the extra `/ def_name` subdirectory layer in `add_workload_blob_tensor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the directory structure for workload tensor storage by consolidating the file organization to reduce nesting levels. Workload tensor files are now organized more efficiently for better file management and access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->