### PR TITLE
fix: handle None expected shape for scalar inputs in load_safetensors

### DIFF
--- a/flashinfer_bench/bench/utils.py
+++ b/flashinfer_bench/bench/utils.py
@@ -240,9 +240,9 @@ def load_safetensors(
         if input_spec.tensor_key not in tensors:
             raise ValueError(f"Missing key '{input_spec.tensor_key}' in '{path}'")
         t = tensors[input_spec.tensor_key]
-        # shape check (expected[name] is None for scalars)
-        expected_shape = expected[name]
-        actual_shape = list(t.shape) if expected_shape is not None else None
+        # shape check (expected[name] is None for scalars → normalize to [])
+        expected_shape = expected[name] if expected[name] is not None else []
+        actual_shape = list(t.shape)
         if actual_shape != expected_shape:
             raise ValueError(f"'{name}' expected {expected_shape}, got {list(t.shape)}")
         # dtype check

--- a/flashinfer_bench/bench/utils.py
+++ b/flashinfer_bench/bench/utils.py
@@ -240,9 +240,11 @@ def load_safetensors(
         if input_spec.tensor_key not in tensors:
             raise ValueError(f"Missing key '{input_spec.tensor_key}' in '{path}'")
         t = tensors[input_spec.tensor_key]
-        # shape check
-        if list(t.shape) != expected[name]:
-            raise ValueError(f"'{name}' expected {expected[name]}, got {list(t.shape)}")
+        # shape check (expected[name] is None for scalars)
+        expected_shape = expected[name]
+        actual_shape = list(t.shape) if expected_shape is not None else None
+        if actual_shape != expected_shape:
+            raise ValueError(f"'{name}' expected {expected_shape}, got {list(t.shape)}")
         # dtype check
         expect_dtype = dtype_str_to_torch_dtype(definition.inputs[name].dtype)
         if t.dtype != expect_dtype:


### PR DESCRIPTION
## Problem

In `load_safetensors`, the shape check:
```python
if list(t.shape) != expected[name]:
```
When a Definition input has `shape=None` (scalar), `expected[name]` is `None`. `list(t.shape)` returns `[]`, and `[] != None` is always `True`, so valid scalar safetensors inputs always raise a false shape mismatch error.

## Fix

Check `expected_shape` for `None` first and only compare shapes when both are non-None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Enhanced tensor shape validation logic to properly handle scalar tensor inputs and detect shape mismatches more accurately. Users now receive clearer, more informative error messages when tensor shapes don't align with expected dimensions, making it easier to diagnose and resolve configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->