### PR TITLE
fix: guard against ZeroDivisionError when computing speedup_factor

### DIFF
--- a/flashinfer_bench/bench/evaluators/default.py
+++ b/flashinfer_bench/bench/evaluators/default.py
@@ -214,10 +214,13 @@ class DefaultEvaluator(Evaluator):
             )
 
         sol_mean_latency_ms = sum(sol_latencies) / float(len(sol_latencies))
+        speedup_factor = (
+            ref_mean_latency_ms / sol_mean_latency_ms if sol_mean_latency_ms > 0.0 else float("inf")
+        )
         performance = Performance(
             latency_ms=sol_mean_latency_ms,
             reference_latency_ms=ref_mean_latency_ms,
-            speedup_factor=(ref_mean_latency_ms / sol_mean_latency_ms),
+            speedup_factor=speedup_factor,
         )
 
         return performance, None


### PR DESCRIPTION
## Problem

In `eval_performance`, if `sol_mean_latency_ms` is `0.0` (sub-microsecond kernel or timing precision limit), the division:
```python
speedup_factor=(ref_mean_latency_ms / sol_mean_latency_ms)
```
raises `ZeroDivisionError` and crashes the benchmark run.

## Fix

Return `inf` when `sol_mean_latency_ms == 0.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a calculation issue in performance evaluation that occurred when solution latency measurements were zero. The benchmarking system now gracefully handles this edge case and properly computes speedup metrics, ensuring stable and reliable performance reporting across all measurement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->