### PR TITLE
fix: propagate new baseline handle after persistent worker restart

### DIFF
--- a/flashinfer_bench/bench/runner/persistent_runner.py
+++ b/flashinfer_bench/bench/runner/persistent_runner.py
@@ -538,8 +538,20 @@ class PersistentRunner(Runner):
             raise RuntimeError("No healthy persistent workers available after baseline setup")
 
         def run_solution_with_health_check(
-            worker: PersistentSubprocessWorker, solution: Solution, baseline_handle: BaselineHandle
+            worker: PersistentSubprocessWorker, solution: Solution
         ) -> Evaluation:
+            # NOTE: baseline_handle is no longer a parameter. It used to be
+            # captured at submit time, which made every queued task hold a
+            # stale handle if a peer task triggered a worker restart and the
+            # restart rebuilt the baseline with a new handle. Now we read
+            # fresh from the shared `baselines` dict immediately before each
+            # `run_solution` call, and update the dict when restarting so
+            # subsequent tasks see the new handle.
+            #
+            # Single-GPU evaluations serialize through one pool thread
+            # (max_workers == len(selected) == 1), so no extra locking is
+            # needed. A multi-GPU multi-thread restart still races the dict
+            # update — out of scope for this fix.
             try:
                 if not worker.is_healthy():
                     logger.warning(
@@ -548,8 +560,13 @@ class PersistentRunner(Runner):
                     if worker.restart():
                         try:
                             new_baseline = worker.run_ref(definition, workload, config, root)
-                            worker.release(baseline_handle)
-                            baseline_handle = new_baseline
+                            old_handle = baselines.get(worker)
+                            if old_handle is not None:
+                                try:
+                                    worker.release(old_handle)
+                                except Exception:
+                                    pass  # release may fail if worker already discarded the old handle on restart
+                            baselines[worker] = new_baseline
                             logger.info(f"Rebuilt baseline for worker on device {worker._device}")
                         except Exception as e:
                             logger.error(
@@ -567,6 +584,10 @@ class PersistentRunner(Runner):
                             device=worker._device,
                             extra_msg="Worker restart failed",
                         )
+
+                # Read the current baseline handle fresh — picks up any
+                # restart update from a peer task on the same worker.
+                baseline_handle = baselines[worker]
 
                 # Run the solution
                 eval_start_time = time.perf_counter()
@@ -592,10 +613,8 @@ class PersistentRunner(Runner):
 
                 for i, solution in enumerate(solutions):
                     worker = selected[i % len(selected)]
-                    baseline_handle = baselines[worker]
-
                     sol_futs[solution.name] = pool.submit(
-                        run_solution_with_health_check, worker, solution, baseline_handle
+                        run_solution_with_health_check, worker, solution
                     )
 
                 results: Dict[str, Evaluation] = {

--- a/flashinfer_bench/bench/runner/persistent_runner.py
+++ b/flashinfer_bench/bench/runner/persistent_runner.py
@@ -540,32 +540,17 @@ class PersistentRunner(Runner):
         def run_solution_with_health_check(
             worker: PersistentSubprocessWorker, solution: Solution
         ) -> Evaluation:
-            # NOTE: baseline_handle is no longer a parameter. It used to be
-            # captured at submit time, which made every queued task hold a
-            # stale handle if a peer task triggered a worker restart and the
-            # restart rebuilt the baseline with a new handle. Now we read
-            # fresh from the shared `baselines` dict immediately before each
-            # `run_solution` call, and update the dict when restarting so
-            # subsequent tasks see the new handle.
-            #
-            # Single-GPU evaluations serialize through one pool thread
-            # (max_workers == len(selected) == 1), so no extra locking is
-            # needed. A multi-GPU multi-thread restart still races the dict
-            # update — out of scope for this fix.
             try:
                 if not worker.is_healthy():
                     logger.warning(
                         f"Worker on device {worker._device} is unhealthy, attempting restart"
                     )
                     if worker.restart():
+                        # Evict before rebuild so a failed rebuild doesn't
+                        # leave peer tasks reading a stale handle.
+                        baselines.pop(worker, None)
                         try:
                             new_baseline = worker.run_ref(definition, workload, config, root)
-                            old_handle = baselines.get(worker)
-                            if old_handle is not None:
-                                try:
-                                    worker.release(old_handle)
-                                except Exception:
-                                    pass  # release may fail if worker already discarded the old handle on restart
                             baselines[worker] = new_baseline
                             logger.info(f"Rebuilt baseline for worker on device {worker._device}")
                         except Exception as e:
@@ -585,11 +570,15 @@ class PersistentRunner(Runner):
                             extra_msg="Worker restart failed",
                         )
 
-                # Read the current baseline handle fresh — picks up any
-                # restart update from a peer task on the same worker.
-                baseline_handle = baselines[worker]
+                # Read fresh so we pick up any peer-task restart update.
+                baseline_handle = baselines.get(worker)
+                if baseline_handle is None:
+                    return make_eval(
+                        status=EvaluationStatus.RUNTIME_ERROR,
+                        device=worker._device,
+                        extra_msg="No baseline available for worker (rebuild may have failed)",
+                    )
 
-                # Run the solution
                 eval_start_time = time.perf_counter()
                 result = worker.run_solution(solution, baseline_handle, config)
                 eval_time = time.perf_counter() - eval_start_time


### PR DESCRIPTION
  ## Summary

  Fix a bug in the persistent runner: when a worker is restarted mid-eval (e.g. after a solution timeout), the rebuilt baseline
  handle is only saved in a local variable. Subsequent solution tasks already submitted to the `ThreadPoolExecutor` with the OLD handle captured as a parameter value — fail with`RunnerError("Baseline handle not found")`. The fix here:

- After a successful restart-and-rebuild, update `baselines[worker]` so  the new handle is visible to peer tasks via the shared dict closure.
- Read `baselines[worker]` fresh inside the function immediately before `run_solution`, so any peer-triggered restart update is picked up.
- Tolerate `worker.release(old_handle)` failing — the worker may have already discarded the old handle when it restarted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved baseline state handling during worker restarts to ensure evaluations consistently use the latest baseline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->