### PR TITLE
docs: align skills + CLAUDE.md with HF-only trace dataset layout

### DIFF
--- a/.claude/skills/add-reference-tests/SKILL.md
+++ b/.claude/skills/add-reference-tests/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: add-reference-tests
-description: Add pytest tests to validate reference implementations in flashinfer_trace against FlashInfer or SGLang ground truth. Use when validating kernel definitions, adding tests for new op_types, or verifying reference implementations are correct.
+description: Add pytest tests to validate reference implementations in the flashinfer-trace HuggingFace dataset against FlashInfer or SGLang ground truth. Use when validating kernel definitions, adding tests for new op_types, or verifying reference implementations are correct.
 ---
 
 # Add Reference Tests
 
-Add tests to validate reference implementations in `./flashinfer_trace/`. Ground truth is sourced from FlashInfer repository or SGLang when FlashInfer doesn't have the implementation.
+Add tests to validate reference implementations in the HuggingFace dataset clone at `tmp/flashinfer-trace/`. Ground truth is sourced from FlashInfer repository or SGLang when FlashInfer doesn't have the implementation.
 
 ## Description
 
-This skill creates test cases under `./flashinfer_trace/tests/references/` to validate that reference implementations in Definition JSON files produce correct outputs. The ground truth comes from:
+This skill creates test cases under `tmp/flashinfer-trace/tests/references/` (the HF dataset clone — the in-repo `flashinfer_trace/` directory was removed in the trace-dataset refactor) to validate that reference implementations in Definition JSON files produce correct outputs. The ground truth comes from:
 
 1. **FlashInfer repository** (preferred): Official optimized GPU kernels in `tmp/flashinfer/`
 2. **SGLang repository** (fallback): When FlashInfer doesn't have the kernel, use `tmp/sglang/`
@@ -43,7 +43,7 @@ This skill creates test cases under `./flashinfer_trace/tests/references/` to va
 
 ## Prerequisites
 
-Run `/clone-repos` first to set up the `tmp/` directory with SGLang and FlashInfer (the `flashinfer_trace/` directory is already part of this repository).
+Run `/clone-repos` first to set up the `tmp/` directory with SGLang, FlashInfer, and the HuggingFace trace dataset clone at `tmp/flashinfer-trace/` — that clone is the only home for definitions and reference tests.
 
 ## What This Skill Does
 
@@ -51,11 +51,11 @@ Run `/clone-repos` first to set up the `tmp/` directory with SGLang and FlashInf
 
 1. **Load Target Definitions**:
    - If `definition_name` specified: load single definition
-   - If `op_type` specified: load all definitions matching op_type from `flashinfer_trace/definitions/{op_type}/`
+   - If `op_type` specified: load all definitions matching op_type from `tmp/flashinfer-trace/definitions/{op_type}/`
    - If `all`: scan all definitions
 
 2. **Check Existing Tests**:
-   - Scan `flashinfer_trace/tests/references/` for existing test files
+   - Scan `tmp/flashinfer-trace/tests/references/` for existing test files
    - Skip definitions that already have tests (unless force=true)
 
 3. **Parse Definition Schema**:
@@ -449,12 +449,12 @@ MEDIUM_SIZES = {
 
 ### Phase 5: Write Test Files
 
-Output to `flashinfer_trace/tests/references/`
+Output to `tmp/flashinfer-trace/tests/references/` (the HF dataset clone — committed and PR'd against `flashinfer-ai/flashinfer-trace`).
 
 ## Output Structure
 
 ```
-flashinfer_trace/tests/references/
+tmp/flashinfer-trace/tests/references/
 ├── conftest.py                    # Shared fixtures and utilities
 ├── test_rmsnorm.py                # RMSNorm tests
 ├── test_gqa_paged.py              # GQA paged tests
@@ -751,12 +751,12 @@ When executing this skill:
 
 1. **Identify definitions to test**:
    ```bash
-   ls flashinfer_trace/definitions/{op_type}/
+   ls tmp/flashinfer-trace/definitions/{op_type}/
    ```
 
 2. **Check for existing tests**:
    ```bash
-   ls flashinfer_trace/tests/references/
+   ls tmp/flashinfer-trace/tests/references/
    ```
 
 3. **For each definition**:
@@ -768,7 +768,7 @@ When executing this skill:
 4. **Create test file**:
    ```bash
    # Create tests directory if needed
-   mkdir -p flashinfer_trace/tests/references/
+   mkdir -p tmp/flashinfer-trace/tests/references/
    ```
 
 5. **Write test file**:
@@ -779,20 +779,20 @@ When executing this skill:
 
 ## Running Tests
 
-After generating tests, run from the project root:
+After generating tests, run from the HF dataset clone:
 
 ```bash
 # Run all reference tests
-pytest flashinfer_trace/tests/references/ -v
+pytest tmp/flashinfer-trace/tests/references/ -v
 
 # Run specific test file
-pytest flashinfer_trace/tests/references/test_mla_paged.py -v
+pytest tmp/flashinfer-trace/tests/references/test_mla_paged.py -v
 
 # Run with GPU
-pytest flashinfer_trace/tests/references/ -v --device cuda
+pytest tmp/flashinfer-trace/tests/references/ -v --device cuda
 
 # Run with verbose output
-pytest flashinfer_trace/tests/references/ -v -s
+pytest tmp/flashinfer-trace/tests/references/ -v -s
 ```
 
 ## Error Handling
@@ -830,8 +830,8 @@ pytest flashinfer_trace/tests/references/ -v -s
 /add-reference-tests --op-type mla_paged
 /add-reference-tests --op-type moe
 
-# Run tests from project root
-pytest flashinfer_trace/tests/references/ -v
+# Run tests from the HF dataset clone
+pytest tmp/flashinfer-trace/tests/references/ -v
 ```
 
 ## Notes

--- a/.claude/skills/clone-repos/SKILL.md
+++ b/.claude/skills/clone-repos/SKILL.md
@@ -138,17 +138,6 @@ When executing this skill:
 
 ```
 flashinfer-bench/
-├── flashinfer_trace/                 # Local working area (definitions, tests)
-│   ├── definitions/                  # Kernel definitions (write here first)
-│   │   ├── rmsnorm/
-│   │   ├── gemm/
-│   │   ├── gqa_paged/
-│   │   ├── mla_paged/
-│   │   ├── gdn/
-│   │   ├── moe/
-│   │   └── ...
-│   └── tests/
-│       └── references/               # Reference tests
 └── tmp/                              # Cloned repositories (auto-updated)
     ├── sglang/                       # SGLang repository (installed in current env)
     │   └── python/sglang/srt/
@@ -171,24 +160,15 @@ flashinfer-bench/
     │   ├── csrc/                     # CUDA source files
     │   └── include/                  # C++ headers with kernel implementations
     ├── sgl-cookbook/                 # Serving configuration repository (NOT installed)
-    └── flashinfer-trace/             # HuggingFace dataset clone — workloads and blobs go here for PR submission
-        ├── docs/                     # Model deployment documentation (markdown)
-        │   └── autoregressive/
-        │       ├── DeepSeek/
-        │       │   ├── DeepSeek-V3.md
-        │       │   └── DeepSeek-R1.md
-        │       ├── Qwen/
-        │       │   ├── Qwen3-Next.md
-        │       │   └── Qwen3.md
-        │       └── ...
-        ├── data/
-        │   ├── models/               # Model configurations (YAML)
-        │   │   └── generated/v0.5.6/
-        │   │       ├── qwen3next.yaml
-        │   │       ├── deepseek.yaml
-        │   │       └── ...
-        │   └── optimal-configs/      # Optimal serving configurations
-        └── README.md
+    └── flashinfer-trace/             # HuggingFace dataset clone — single source of truth
+        │                             # for definitions, ref tests, baselines, workloads,
+        │                             # blobs, and eval traces. All trace edits commit here.
+        ├── definitions/{op_type}/    # Kernel definition JSONs
+        ├── tests/references/         # Reference tests (pytest)
+        ├── solutions/baseline/       # FlashInfer-wrapper baseline solutions
+        ├── workloads/{op_type}/      # Sanitized workload JSONLs
+        ├── blob/workloads/{op_type}/ # Safetensors blobs referenced by JSONLs
+        └── traces/{op_type}/         # Eval traces (one entry per workload)
 ```
 
 ## Requirements
@@ -211,8 +191,8 @@ flashinfer-bench/
 
 This skill provides the foundation for:
 
-1. **extract-kernel-definitions**: Uses SGLang model files to extract kernels, sgl-cookbook to find serving configurations (TP/EP flags), outputs to `./flashinfer_trace/definitions/` (local working area)
-2. **add-reference-tests**: Uses FlashInfer for ground truth, outputs tests to `./flashinfer_trace/tests/references/`
+1. **extract-kernel-definitions**: Uses SGLang model files to extract kernels, sgl-cookbook to find serving configurations (TP/EP flags), outputs to `tmp/flashinfer-trace/definitions/` (the HuggingFace dataset clone)
+2. **add-reference-tests**: Uses FlashInfer for ground truth, outputs tests to `tmp/flashinfer-trace/tests/references/`
 3. **collect-workloads**: Uses `tmp/flashinfer-trace` (HuggingFace dataset clone) as the target for workload JSONL + safetensors blobs, then submits a PR
 4. **onboard-model**: End-to-end pipeline that calls this skill first (Phase 0) to ensure all repos are current before model discovery, definition generation, and workload collection.
 

--- a/.claude/skills/extract-kernel-definitions/SKILL.md
+++ b/.claude/skills/extract-kernel-definitions/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: extract-kernel-definitions
-description: Extract kernel schemas and definitions from SGLang model implementations with deduplication. Use when adding a new model, extracting GPU kernels (MLA, MoE, GQA, RMSNorm, GEMM), or generating Definition JSON files for flashinfer_trace.
+description: Extract kernel schemas and definitions from SGLang model implementations with deduplication. Use when adding a new model, extracting GPU kernels (MLA, MoE, GQA, RMSNorm, GEMM), or generating Definition JSON files for the flashinfer-trace HuggingFace dataset.
 ---
 
 # Extract Kernel Definitions
 
-Extract kernel schemas and definitions from SGLang model implementations, with deduplication, and add them to `./flashinfer_trace/` with vanilla Python reference implementations. Uses sgl-cookbook serving configurations to generate multiple kernel definitions for different TP/EP settings.
+Extract kernel schemas and definitions from SGLang model implementations, with deduplication, and add them to the HuggingFace dataset clone at `tmp/flashinfer-trace/` with vanilla Python reference implementations. Uses sgl-cookbook serving configurations to generate multiple kernel definitions for different TP/EP settings.
 
 ## Description
 
@@ -41,7 +41,7 @@ This skill analyzes SGLang model implementations to extract the complete set of 
 
 ## Prerequisites
 
-Run `/clone-repos` first to set up the `tmp/` directory with SGLang, FlashInfer, and sgl-cookbook (the `flashinfer_trace/` directory is already part of this repository).
+Run `/clone-repos` first to set up the `tmp/` directory with SGLang, FlashInfer, sgl-cookbook, and the HuggingFace trace dataset clone at `tmp/flashinfer-trace/` (which is the only home for definitions, reference tests, and workloads — the in-repo `flashinfer_trace/` directory was removed in the trace-dataset refactor).
 
 ## What This Skill Does
 
@@ -141,7 +141,7 @@ For each layer component AND each serving configuration (TP/EP setting), extract
 ### Phase 3: Deduplication
 
 1. **Load Existing Definitions**:
-   - Scan `flashinfer_trace/definitions/` for existing JSONs
+   - Scan `tmp/flashinfer-trace/definitions/` (HF dataset clone) for existing JSONs
    - Build index of definition names and signatures
 
 2. **Compare Extracted Kernels**:
@@ -318,7 +318,7 @@ Add constraints for input validation:
 
 ### Phase 5: Save Definitions
 
-Output to `flashinfer_trace/definitions/{op_type}/{definition_name}.json`
+Output to `tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json` (the HF dataset clone — committed and PR'd against `flashinfer-ai/flashinfer-trace`).
 
 ## Output Format
 
@@ -518,86 +518,34 @@ When executing this skill:
    - Look for config class (e.g., `DeepseekV3Config`)
    - Extract: num_hidden_layers, hidden_size, num_attention_heads, num_key_value_heads, intermediate_size, etc.
 
-6. **Check existing definitions**:
+6. **Check existing definitions** (HF dataset clone is the only home for definitions):
    ```bash
-   ls flashinfer_trace/definitions/*/
+   ls tmp/flashinfer-trace/definitions/*/
    ```
 
 7. **Generate definition JSONs for each TP/EP config**:
    - For each unique TP value, calculate split head counts
    - For each unique EP value, calculate local expert counts
-   - Create directory if needed: `mkdir -p flashinfer_trace/definitions/{op_type}/`
-   - Write JSON file with reference implementation
+   - Create directory if needed: `mkdir -p tmp/flashinfer-trace/definitions/{op_type}/`
+   - Write JSON file with reference implementation into the HF dataset clone
    - **Example**: For Qwen3-Next GDN kernel with original q_heads=16, v_heads=32:
      - TP=2: Create `gdn_decode_qk8_v16_d128_k_last.json` (16/2=8, 32/2=16)
      - TP=4: Create `gdn_decode_qk4_v8_d128_k_last.json` (16/4=4, 32/4=8)
 
-8. **Submit one GitHub PR per definition** (PR 1 in the two-PR workflow):
+8. **Hand off to PR submission**:
 
-   Each PR bundles the definition JSON, a reference test, and the model_coverage.mdx update
-   together. Use git worktrees for parallel submission — one worktree and one agent per definition:
+   This skill stops at writing the definition JSON to the local HF dataset clone. PR
+   submission for new definitions follows the canonical two-PR flow defined in the
+   **onboard-model** skill:
+   - **PR 2** (HuggingFace `flashinfer-ai/flashinfer-trace`): definition JSON + reference
+     test + baseline solution + workloads + blobs + eval traces. Open this first.
+   - **PR 1** (GitHub `flashinfer-ai/flashinfer-bench`): `docs/model_coverage.mdx` update
+     only, with a back-link to PR 2.
 
-   ```bash
-   # Create one worktree per definition (do this up front for all definitions)
-   git worktree add \
-     tmp/worktrees/bench-{definition_name} \
-     -b feat/def-{definition_name}
-
-   # Then in each worktree (agents can run in parallel):
-   # 1. Copy definition JSON
-   cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-      tmp/worktrees/bench-{definition_name}/flashinfer_trace/definitions/{op_type}/
-
-   # 2. Add reference test (use /add-reference-tests skill or write manually)
-   # File: tmp/worktrees/bench-{definition_name}/tests/test_{op_type}_{definition_name}.py
-
-   # 3. Update model coverage doc
-   # Edit tmp/worktrees/bench-{definition_name}/docs/model_coverage.mdx
-
-   cd tmp/worktrees/bench-{definition_name}
-   git add flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-           tests/test_{op_type}_{definition_name}.py \
-           docs/model_coverage.mdx
-   git commit -m "feat: add {definition_name}
-
-   - {op_type} kernel definition for {model_display_name}
-   - Reference test for definition validation
-   - Model coverage doc updated
-   Reference implementation sourced from {source}.
-   "
-   # Run reference test and capture output for PR description
-   pytest tests/test_{op_type}_{definition_name}.py -v 2>&1 | tee /tmp/test_{definition_name}.txt
-
-   pre-commit run --all-files
-   git push origin feat/def-{definition_name}
-   gh pr create \
-     --repo flashinfer-ai/flashinfer-bench \
-     --title "feat: add {definition_name}" \
-     --body "$(cat <<'EOF'
-## Summary
-- Adds kernel definition for `{definition_name}` ({op_type})
-- Model: {model_display_name}
-- Reference implementation sourced from: {source}
-{If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
-
-## Reference Test Results
-\`\`\`
-$(cat /tmp/test_{definition_name}.txt)
-\`\`\`
-
-## Files changed
-- `flashinfer_trace/definitions/{op_type}/{definition_name}.json`
-- `tests/test_{op_type}_{definition_name}.py`
-- `docs/model_coverage.mdx`
-EOF
-)"
-
-   # Clean up worktree after PR is open
-   git worktree remove tmp/worktrees/bench-{definition_name}
-   ```
-
-   **One PR per definition.** Do not batch multiple definitions into a single PR.
-   PR 2 (baseline solution + workloads + traces → HuggingFace) is handled by `collect-workloads`.
+   See `onboard-model/SKILL.md` "Phase 4: Submit PRs" for the full flow, including the
+   per-definition worktree layout and PR Review Checklist. Do **not** add a definition
+   JSON to a `flashinfer_trace/...` path inside `flashinfer-bench` — that directory was
+   removed in the trace-dataset refactor.
 
 9. **Report results**:
    - List new definitions created (grouped by TP/EP config)

--- a/.claude/skills/onboard-model/SKILL.md
+++ b/.claude/skills/onboard-model/SKILL.md
@@ -24,8 +24,8 @@ Phase 3: Workload collection (only when FlashInfer has the kernel)
           └─ kernel NOT integrated into SGLang → draft + submit SGLang PR,
                                                   then collect-workloads (sglang mode)
 Phase 4: Submit PRs (per definition, not batched)
-          ├─ PR 1 → flashinfer-bench (GitHub): definition JSON + reference tests + model_coverage.mdx
-          └─ PR 2 → flashinfer-ai/flashinfer-trace (HuggingFace): baseline solution + workloads + traces + def JSON + reference tests
+          ├─ PR 1 → flashinfer-bench (GitHub): docs/model_coverage.mdx update only
+          └─ PR 2 → flashinfer-ai/flashinfer-trace (HuggingFace): definition JSON + reference tests + baseline solution + workloads + traces
 ```
 
 ## Usage
@@ -89,8 +89,8 @@ Report the SHAs in the Phase 0 summary so the user can reproduce the run.
 ## Phase 1: Model Discovery and Kernel Inventory
 
 **Goal**: Identify the target model(s), extract their required kernel set, and classify each
-kernel as *known* (definition already exists in `flashinfer_trace/definitions/`) or *new*
-(no definition file found).
+kernel as *known* (definition already exists in the HuggingFace dataset clone at
+`tmp/flashinfer-trace/definitions/`) or *new* (no definition file found there).
 
 ### 1a: Discover candidate models (when `--discover` is set)
 
@@ -142,10 +142,11 @@ complete per-op-type formulas.
 
 ### 1d: Classify each kernel
 
-For each expected definition name:
+For each expected definition name (search the HuggingFace dataset clone — definitions no
+longer live in this repo):
 
 ```bash
-find flashinfer_trace/definitions/ -name "{definition_name}.json"
+find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
 ```
 
 | Result | Classification |
@@ -239,8 +240,9 @@ gh issue create \
 ### Motivation
 
 This kernel is required for serving **{model_display_name}** with FlashInfer.
-A FlashInfer-Bench definition has been generated at:
-`flashinfer_trace/definitions/{op_type}/{definition_name}.json`
+A FlashInfer-Bench definition has been staged at:
+`tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json`
+(landing in the HuggingFace dataset PR for `flashinfer-ai/flashinfer-trace`)
 
 ### Kernel Parameters
 
@@ -286,10 +288,11 @@ Delegate to `extract-kernel-definitions` for each new definition. This skill han
 /extract-kernel-definitions --model-name {sglang_model_name}
 ```
 
-After generation, verify each expected definition now exists:
+After generation, verify each expected definition now exists in the HuggingFace dataset
+clone (the only home for definitions after the refactor):
 
 ```bash
-find flashinfer_trace/definitions/ -name "{definition_name}.json"
+find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
 ```
 
 ---
@@ -452,29 +455,37 @@ with all definitions processed in parallel using git worktrees.
 
 | # | Target repo | Content | Trigger |
 |---|-------------|---------|---------|
-| 1 | `flashinfer-ai/flashinfer-bench` (GitHub) | definition JSON + reference tests + `docs/model_coverage.mdx` | after Phase 2 |
-| 2 | `flashinfer-ai/flashinfer-trace` (HuggingFace) | baseline solution + workload JSONL + safetensors traces + def JSON + reference tests | after PR 1 is open |
+| 1 | `flashinfer-ai/flashinfer-bench` (GitHub) | `docs/model_coverage.mdx` update only | after PR 2 is open |
+| 2 | `flashinfer-ai/flashinfer-trace` (HuggingFace) | definition JSON + reference test + baseline solution + workload JSONL + safetensors blobs + eval traces | after Phase 3 |
+
+After the trace-dataset refactor the local `flashinfer_trace/` directory no longer exists in
+`flashinfer-bench`. Definitions, reference tests, workloads, blobs, baseline solutions, and
+eval traces now live **only** in the HuggingFace dataset (`flashinfer-ai/flashinfer-trace`),
+so PR 2 is the canonical destination for all of those artifacts. PR 1 in `flashinfer-bench`
+contains nothing but the coverage-doc update and a back-link to PR 2.
 
 Do **not** batch multiple definitions into a single PR. Each definition must be independently
 reviewable and mergeable.
 
 ### 4-setup: Create worktrees before spawning agents
 
-For each new definition, create two worktrees: one in the main repo (for PRs 1) and one
-in the `tmp/flashinfer-trace` clone (for PR 2). All worktrees can be created up front, then
-agents run in parallel. Run `pre-commit` for PR1.
+For each new definition, create two worktrees: one in the main repo (for PR 1 — coverage doc
+only) and one in the `tmp/flashinfer-trace` clone (for PR 2 — all dataset content). All
+worktrees can be created up front, then agents run in parallel. Run `pre-commit` in the bench
+worktree before pushing PR 1.
 
 ```bash
 DATE=$(date +%Y%m%d)
 
 # For each {definition_name} in the new definitions list:
 
-# Worktree 1: flashinfer-bench (this repo) — for definition JSON + coverage update
+# Worktree 1: flashinfer-bench (this repo) — for docs/model_coverage.mdx update
 git worktree add \
   tmp/worktrees/bench-{definition_name} \
   -b feat/def-{definition_name}
 
-# Worktree 2: flashinfer-trace (HuggingFace dataset clone) — for workload files
+# Worktree 2: flashinfer-trace (HuggingFace dataset clone) — for definition JSON,
+# reference test, baseline solution, workloads, blobs, eval traces
 git -C tmp/flashinfer-trace worktree add \
   ../worktrees/trace-{definition_name} \
   -b workloads-${DATE}-{definition_name}
@@ -486,10 +497,10 @@ flashinfer-bench/
 └── tmp/
     ├── flashinfer-trace/          # main clone (do not commit here directly)
     └── worktrees/
-        ├── bench-{def1}/          # isolated branch for def1 definition JSON + coverage
-        ├── bench-{def2}/          # isolated branch for def2
-        ├── trace-{def1}/          # isolated branch for def1 workloads (HF repo)
-        └── trace-{def2}/          # isolated branch for def2 workloads (HF repo)
+        ├── bench-{def1}/          # isolated branch for def1 model_coverage.mdx update
+        ├── bench-{def2}/          # isolated branch for def2 model_coverage.mdx update
+        ├── trace-{def1}/          # isolated branch for def1 dataset content (HF repo)
+        └── trace-{def2}/          # isolated branch for def2 dataset content (HF repo)
 ```
 
 ### 4-spawn: Run one agent per definition in parallel
@@ -508,99 +519,55 @@ Your worktrees:
 - flashinfer-trace worktree: tmp/worktrees/trace-{definition_name}/
   (branch: workloads-{date}-{definition_name})
 
-Definition file already written at:
-  flashinfer_trace/definitions/{op_type}/{definition_name}.json
+Definition file already written at (staging path inside the local clone):
+  tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json
 
 Workload files already collected at:
   tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl
   tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/
 
+NOTE: The local `flashinfer_trace/` directory in flashinfer-bench was removed in the
+trace-dataset refactor. All definitions, reference tests, workloads, blobs, baseline
+solutions, and eval traces live ONLY in the HuggingFace dataset (PR 2). PR 1 in
+flashinfer-bench contains nothing but the model_coverage.mdx update.
+
 Do the following in order:
 
-1. PR 1 — GitHub flashinfer-bench (definition JSON + reference tests + coverage):
-   - Copy flashinfer_trace/definitions/{op_type}/{definition_name}.json
-     into tmp/worktrees/bench-{definition_name}/flashinfer_trace/definitions/{op_type}/
-   - Add or update reference test in tests/ for this definition
-   - Update docs/model_coverage.mdx to reflect definition status
-   - Run `pre-commit` to format the changes
-   - Commit all three changes together and push
-   - Open PR to flashinfer-ai/flashinfer-bench
-   - Record the PR number as pr1_number
-
-2. PR 2 — HuggingFace flashinfer-trace (baseline solution + workloads + traces + def + tests):
+1. PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline
+   solution + workloads + blobs + eval traces). Open this FIRST so PR 1 can link to it.
    - Check whether a baseline solution already exists:
        ls tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/*.json 2>/dev/null
    - If baseline solution ALREADY EXISTS: skip creating a new solution and skip running eval.
      Include the existing solution directory in the PR commit as-is.
-   - If baseline solution does NOT exist: create it (see Phase 4b below) and run
-     flashinfer-bench eval — all workloads must show PASSED before opening PR2.
+   - If baseline solution does NOT exist: create it (see Phase 4a below) and run
+     flashinfer-bench eval — all workloads must show PASSED before opening PR 2.
+   - Copy definition JSON into tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
+   - Write a reference test under tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
+     (use the add-reference-tests skill — pytest validating the definition's `reference` field
+     against FlashInfer/SGLang ground truth)
    - Copy workload JSONL into tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
    - Copy safetensors blobs into tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
-   - Copy definition JSON (from flashinfer-bench) into tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
-   - Copy reference test (from flashinfer-bench) into tmp/worktrees/trace-{definition_name}/tests/{op_type}/
+   - Copy baseline eval traces into tmp/worktrees/trace-{definition_name}/traces/{op_type}/{definition_name}.jsonl
    - Commit all together and push
    - Open HuggingFace PR via huggingface_hub.HfApi().create_pull_request()
-   - Record the PR number as pr2_number
+   - Record the PR number/URL as pr2_url
+
+2. PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx ONLY):
+   - In tmp/worktrees/bench-{definition_name}/, edit docs/model_coverage.mdx to mark
+     {definition_name} as ✅ for this model (update the relevant kernel row + summary table).
+   - Do NOT add definition JSON, reference test, workloads, blobs, or solutions to this PR —
+     those live exclusively in flashinfer-trace (PR 2).
+   - Run `pre-commit run --all-files` to format the change.
+   - Commit and push.
+   - Open PR to flashinfer-ai/flashinfer-bench. PR description MUST link to pr2_url.
+   - Record the PR number as pr1_number.
 
 Report the two PR URLs when done.
 ```
 
-### 4a: PR 1 — GitHub flashinfer-bench (definition JSON + reference tests + coverage)
+### 4a: PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline solution + workloads + blobs + eval traces)
 
-Inside `tmp/worktrees/bench-{definition_name}/`:
-
-```bash
-# 1. Copy definition JSON
-cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-   tmp/worktrees/bench-{definition_name}/flashinfer_trace/definitions/{op_type}/
-
-# 2. Add or update reference test
-# Write tests/test_{op_type}_{definition_name}.py with pytest test calling
-# the reference implementation from the definition JSON
-
-# 3. Update model coverage doc
-# Edit docs/model_coverage.mdx: mark {definition_name} row as "definition added"
-
-cd tmp/worktrees/bench-{definition_name}
-git add flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-        tests/test_{op_type}_{definition_name}.py \
-        docs/model_coverage.mdx
-git commit -m "feat: add {definition_name}
-
-- Definition JSON for {op_type} ({model_display_name})
-- Reference test validating the implementation
-- Model coverage doc updated
-{If fi_missing: FlashInfer issue: flashinfer-ai/flashinfer#{issue_number}}
-"
-# Run reference test and capture output for PR description
-pytest tests/test_{op_type}_{definition_name}.py -v 2>&1 | tee /tmp/test_{definition_name}.txt
-
-pre-commit run --all-files
-git push origin feat/def-{definition_name}
-gh pr create \
-  --repo flashinfer-ai/flashinfer-bench \
-  --title "feat: add {definition_name}" \
-  --body "$(cat <<'EOF'
-## Summary
-- Adds kernel definition for `{definition_name}` ({op_type})
-- Model: {model_display_name}
-- Reference implementation sourced from: {source}
-{If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
-
-## Reference Test Results
-\`\`\`
-$(cat /tmp/test_{definition_name}.txt)
-\`\`\`
-
-## Files changed
-- `flashinfer_trace/definitions/{op_type}/{definition_name}.json`
-- `tests/test_{op_type}_{definition_name}.py`
-- `docs/model_coverage.mdx`
-EOF
-)"
-```
-
-### 4b: PR 2 — HuggingFace flashinfer-trace (baseline solution + workloads + traces + def + tests)
+PR 2 is opened **first** so PR 1 can link to it.
 
 **Check first** — if a baseline solution already exists in `tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/`, skip creating a new one and skip running `flashinfer-bench run`. Include the existing solution files in the PR commit as-is; do not regenerate eval traces.
 
@@ -609,49 +576,97 @@ Only create a new baseline solution and run eval when no solution exists yet.
 Inside `tmp/worktrees/trace-{definition_name}/`:
 
 ```bash
-# 1. Copy baseline solution (extract reference_impl field from definition JSON as standalone script)
-cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-   tmp/worktrees/trace-{definition_name}/solutions/{op_type}/{definition_name}.py
-# (extract the reference_impl field from the definition JSON as a standalone script)
+# 1. Copy kernel definition JSON (canonical home — only lives in flashinfer-trace now)
+cp tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json \
+   tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
 
-# 2. Copy workload JSONL and safetensors blobs
+# 2. Write the reference test (use the add-reference-tests skill)
+# Output: tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
+# It must validate the definition's `reference` field against FlashInfer/SGLang ground truth.
+
+# 3. Baseline solution
+# If solutions/baseline/{op_type}/{definition_name}/*.json already exists in the HF clone,
+# copy it through unchanged. Otherwise create a FlashInfer-API-wrapper baseline (NOT a
+# copy of `reference`) and run `flashinfer-bench run` to generate eval traces.
+
+# 4. Copy workload JSONL and safetensors blobs
 cp -r tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl \
       tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
 cp -r tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/ \
       tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
 
-# 3. Copy kernel definition JSON and reference test from flashinfer-bench (this repo)
-cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-   tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
-cp tests/test_{op_type}_{definition_name}.py \
-   tmp/worktrees/trace-{definition_name}/tests/{op_type}/
+# 5. Copy eval traces (must show all entries PASSED)
+cp tmp/flashinfer-trace/traces/{op_type}/{definition_name}.jsonl \
+   tmp/worktrees/trace-{definition_name}/traces/{op_type}/
 
 cd tmp/worktrees/trace-{definition_name}
-git add solutions/{op_type}/{definition_name}.py \
+git add definitions/{op_type}/{definition_name}.json \
+        tests/references/test_{definition_name}.py \
+        solutions/baseline/{op_type}/{definition_name}/ \
         workloads/{op_type}/{definition_name}.jsonl \
         blob/workloads/{op_type}/{definition_name}/ \
-        definitions/{op_type}/{definition_name}.json \
-        tests/{op_type}/test_{op_type}_{definition_name}.py
-git commit -m "Add {definition_name}: baseline solution + workloads + traces + def + tests
+        traces/{op_type}/{definition_name}.jsonl
+git commit -m "Add {definition_name}: definition + reference test + baseline solution + workloads + traces
 
 Model: {hf_repo_id}
 SGLang: {sglang_commit_sha}
 FlashInfer: {flashinfer_commit_sha}
 Workload entries: {num_workload_entries}
-GitHub PR: flashinfer-ai/flashinfer-bench#{pr1_number}
 "
-pre-commit run --all-files
 git push origin workloads-{date}-{definition_name}
 python -c "
 from huggingface_hub import HfApi
 HfApi().create_pull_request(
     repo_id='flashinfer-ai/flashinfer-trace',
     repo_type='dataset',
-    title='Add {definition_name}: baseline solution + workloads + traces + def + tests',
+    title='Add {definition_name}: definition + reference test + baseline solution + workloads + traces',
     description='...',
     head='workloads-{date}-{definition_name}',
 )
 "
+# Record the resulting PR URL as pr2_url
+```
+
+### 4b: PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx only)
+
+After PR 2 is open and you have its URL, open PR 1 in `flashinfer-bench`. The local
+`flashinfer_trace/` directory was removed in the trace-dataset refactor, so PR 1 contains
+**only** the model-coverage doc update plus a back-link to PR 2.
+
+Inside `tmp/worktrees/bench-{definition_name}/`:
+
+```bash
+# Edit docs/model_coverage.mdx: mark {definition_name} row as ✅ for this model
+# (and update the per-model summary table).
+
+cd tmp/worktrees/bench-{definition_name}
+pre-commit run --all-files
+git add docs/model_coverage.mdx
+git commit -m "docs: mark {definition_name} as covered for {model_display_name}
+
+Tracks the dataset addition at:
+{pr2_url}
+{If fi_missing: FlashInfer issue: flashinfer-ai/flashinfer#{issue_number}}
+"
+git push origin feat/def-{definition_name}
+gh pr create \
+  --repo flashinfer-ai/flashinfer-bench \
+  --title "docs: mark {definition_name} as covered for {model_display_name}" \
+  --body "$(cat <<EOF
+## Summary
+- Marks \`{definition_name}\` ({op_type}) as covered for **{model_display_name}** in
+  \`docs/model_coverage.mdx\`.
+- Definition JSON, reference test, baseline solution, workloads, blobs, and eval traces
+  all live in the HuggingFace dataset — see ${pr2_url}.
+${If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
+
+## Files changed
+- \`docs/model_coverage.mdx\`
+
+## Linked PRs
+- HuggingFace dataset PR: ${pr2_url}
+EOF
+)"
 ```
 
 ### 4-cleanup: Remove worktrees after PRs are open
@@ -672,32 +687,45 @@ Run this checklist after both PRs are open for a definition. **Both PRs must pas
 before the definition is considered complete.** If any item fails, fix and re-push before
 requesting merge.
 
-### PR 1 — GitHub flashinfer-bench
+After the trace-dataset refactor the local `flashinfer_trace/` directory no longer exists in
+`flashinfer-bench`. The HuggingFace dataset (`flashinfer-ai/flashinfer-trace`) is the only
+home for definition JSONs, reference tests, baseline solutions, workloads, blobs, and eval
+traces — so PR 2 owns all of that. PR 1 only updates `docs/model_coverage.mdx`.
 
-1. **Definition JSON**: `flashinfer_trace/definitions/{op_type}/{name}.json` exists in the PR
-2. **Reference test**: `flashinfer_trace/tests/references/test_{name}.py` exists in the PR
-3. **Coverage**: `docs/model_coverage.mdx` updated — row for this definition shows ✅
-4. **Test results**: PR description includes the full stdout of running the reference test
-5. **PR2 link**: PR description includes a link to the HuggingFace PR 2 (workload addition)
-6. **Tags**: definition JSON has `status:verified` (or `status:unverified` if FlashInfer kernel
-   is missing), `fi_api:*`, and `ep:*`/`tp:*` if applicable
+### PR 1 — GitHub flashinfer-bench (coverage doc only)
 
-### PR 2 — HuggingFace flashinfer-trace
+1. **Coverage**: `docs/model_coverage.mdx` updated — row for `{name}` shows ✅ for
+   `{model_display_name}`, and the per-model summary table reflects the new count.
+2. **Single-file change**: the diff touches **only** `docs/model_coverage.mdx`. No
+   `flashinfer_trace/...` paths, no `tests/references/...`, no workload files, no blobs.
+   (If anything else appears in the diff it belongs in PR 2 instead.)
+3. **PR 2 link**: PR description links to the HuggingFace PR 2 by full URL.
+4. **fi_missing note (if applicable)**: if the kernel is `fi_missing`, PR description links
+   the FlashInfer kernel-request issue (`flashinfer-ai/flashinfer#{issue_number}`).
+5. **pre-commit clean**: `pre-commit run --all-files` passes locally before push.
 
-1. **Workloads**: `workloads/{op_type}/{name}.jsonl` exists and is non-empty
-2. **Blobs**: `blob/workloads/{op_type}/{name}/*.safetensors` files exist
-3. **Baseline solution**: `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json`
+### PR 2 — HuggingFace flashinfer-trace (canonical dataset)
+
+1. **Definition JSON**: `definitions/{op_type}/{name}.json` exists in the PR.
+2. **Definition tags**: definition JSON has `status:verified` (or `status:unverified` when
+   the FlashInfer kernel is missing), plus `fi_api:*` and `ep:*`/`tp:*` where applicable.
+3. **Reference test**: `tests/references/test_{name}.py` exists in the PR and pytest runs
+   green against the definition's `reference` field. PR description includes the full
+   pytest stdout.
+4. **Workloads**: `workloads/{op_type}/{name}.jsonl` exists and is non-empty.
+5. **Blobs**: `blob/workloads/{op_type}/{name}/*.safetensors` files exist.
+6. **Baseline solution**: `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json`
    exists — this must be a FlashInfer API wrapper (calls `BatchDecodeWithPagedKVCacheWrapper`
-   or `BatchPrefillWithPagedKVCacheWrapper`), **not** a copy of `reference_impl`
-4. **Eval trace**: `traces/{op_type}/{name}.jsonl` exists and every entry has
-   `evaluation.status == "PASSED"` — no failures allowed
-5. **Definition JSON**: `definitions/{op_type}/{name}.json` copied from PR 1
-6. **Reference test**: `tests/references/test_{name}.py` copied from PR 1
-7. **SGLang log**: PR description contains a `## SGLang Collection Log` section with the
+   or `BatchPrefillWithPagedKVCacheWrapper`), **not** a copy of the definition's `reference`.
+7. **Eval traces**: `traces/{op_type}/{name}.jsonl` exists and every entry has
+   `evaluation.status == "PASSED"` — no failures allowed.
+8. **SGLang log**: PR description contains a `## SGLang Collection Log` section with the
    full stdout from the `collect_workloads.py sglang` run (model loading, workload counts,
    dump dir info). Workloads must be SGLang-collected (not synthetic) — real workloads have
    diverse `(batch_size, kv_length)` pairs drawn from actual inference. A uniform sweep like
    `batch_size=4096` with 1-page contexts is a red flag for synthetic data.
+9. **Provenance**: commit/PR body records `Model`, `SGLang` and `FlashInfer` commit SHAs,
+   and the workload-entry count.
 
 ---
 
@@ -708,25 +736,33 @@ Every TASK.md for definition onboarding must include:
 
 ```markdown
 ## Objective
-Submit 2 PRs for definition {name}:
-- PR 1 (GitHub flashinfer-bench): Definition JSON + reference tests + docs/model_coverage.mdx (✅) + paste reference test stdout in PR description
-- PR 2 (HuggingFace flashinfer-trace): Baseline solution + workloads + blobs + def JSON + ref test + baseline eval trace (all entries PASSED)
+Submit 2 PRs for definition {name}. After the trace-dataset refactor, all dataset content
+lives only at HuggingFace; flashinfer-bench keeps just the coverage doc.
+- PR 2 (HuggingFace flashinfer-trace, OPEN FIRST): definition JSON + reference test +
+  baseline solution + workloads + blobs + eval traces (all entries PASSED) + SGLang
+  collection log in PR body.
+- PR 1 (GitHub flashinfer-bench, OPEN SECOND): docs/model_coverage.mdx updated to ✅
+  for this definition + back-link to PR 2 in PR body.
 
-## PR 1 Contents
-- `flashinfer_trace/definitions/{op_type}/{name}.json`
-- `flashinfer_trace/tests/references/test_{name}.py`
-- `docs/model_coverage.mdx` updated: ❌/🟡 → ✅ for this definition
-- PR description must include the full stdout of running the reference test
-- PR description must include a link to the HuggingFace PR 2 (workload addition)
-
-## PR 2 Contents
-- `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` (FlashInfer API wrapper — NOT the reference_impl from def JSON; must call flashinfer.BatchDecodeWithPagedKVCacheWrapper or flashinfer.BatchPrefillWithPagedKVCacheWrapper)
+## PR 2 Contents (HuggingFace flashinfer-trace)
+- `definitions/{op_type}/{name}.json`
+- `tests/references/test_{name}.py`
+- `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` (FlashInfer API wrapper —
+  NOT a copy of the definition `reference`; must call
+  flashinfer.BatchDecodeWithPagedKVCacheWrapper or flashinfer.BatchPrefillWithPagedKVCacheWrapper)
 - `workloads/{op_type}/{name}.jsonl`
-- `blob/workloads/{op_type}/*.safetensors`
+- `blob/workloads/{op_type}/{name}/*.safetensors`
 - `traces/{op_type}/{name}.jsonl` (all entries must have `evaluation.status == "PASSED"`)
-- `definitions/{op_type}/{name}.json` (copied from PR 1)
-- `tests/references/test_{name}.py` (copied from PR 1)
-- PR description must include the SGLang inference stdout (capture stdout of `collect_workloads.py sglang` and paste in PR body under `## SGLang Collection Log`)
+- PR description must include the full pytest stdout for the reference test
+- PR description must include the SGLang inference stdout under `## SGLang Collection Log`
+  (capture stdout of `collect_workloads.py sglang`)
+
+## PR 1 Contents (GitHub flashinfer-bench)
+- `docs/model_coverage.mdx` updated: ❌/🟡 → ✅ for this definition (and per-model summary
+  table refreshed)
+- The diff MUST touch only `docs/model_coverage.mdx` — no `flashinfer_trace/...`,
+  no `tests/references/...`, no workload/blob files (those all live in PR 2 now).
+- PR description must include a link to the HuggingFace PR 2 by full URL.
 
 ## Progress Reporting
 Write .agent-progress.md after every major step:
@@ -735,8 +771,8 @@ Write .agent-progress.md after every major step:
   Current: <what you're doing now>
   Next: <next step>
   Blockers: <if any>
-  - PR 1 (def JSON + ref tests + coverage → flashinfer-bench GitHub): <URL or pending>
-  - PR 2 (baseline solution + workloads + traces → flashinfer-trace HF): <URL or pending>
+  - PR 2 (def + ref test + baseline + workloads + traces → flashinfer-trace HF): <URL or pending>
+  - PR 1 (model_coverage.mdx → flashinfer-bench GitHub): <URL or pending>
 
 ## GPU Work
 Use tools/gpu-lock before any SGLang workload collection:
@@ -751,7 +787,7 @@ Where N matches the TP value (1 GPU for TP=1, 4 GPUs for TP=4, etc.)
 ```
 For each required kernel definition:
 
-  Already exists in flashinfer_trace/definitions/?
+  Already exists in tmp/flashinfer-trace/definitions/ (HF dataset clone)?
   ├── YES → skip (existing)
   └── NO  → Phase 2: generate definition JSON
               FlashInfer has this kernel?

--- a/.claude/skills/track-models/SKILL.md
+++ b/.claude/skills/track-models/SKILL.md
@@ -34,8 +34,10 @@ Discover popular or newly released open-source LLMs, determine their kernel cove
 ## Prerequisites
 
 - `docs/model_coverage.mdx` must exist (it does — managed by this skill)
-- `flashinfer_trace/definitions/` must exist with current definition JSON files
-- Run `/clone-repos` first if you need SGLang or sgl-cookbook configs for a model that isn't in the existing patterns
+- `tmp/flashinfer-trace/definitions/` must exist with current definition JSON files
+  (this is the HuggingFace dataset clone — populated by `/clone-repos`; the in-repo
+  `flashinfer_trace/` directory was removed in the trace-dataset refactor)
+- Run `/clone-repos` first if you need SGLang or sgl-cookbook configs for a model that isn't in the existing patterns, or to ensure the trace dataset clone is current
 
 ---
 
@@ -203,7 +205,7 @@ If no sgl-cookbook config exists, use TP=1 (single GPU baseline).
 
 ### Phase 3: Map Kernels to Definitions
 
-For each model, compute the full list of expected definition names, then check which ones exist in `flashinfer_trace/definitions/`.
+For each model, compute the full list of expected definition names, then check which ones exist in `tmp/flashinfer-trace/definitions/` (the HF dataset clone — the only location where definition JSONs live).
 
 #### 3a: Compute expected definitions
 
@@ -265,11 +267,11 @@ Where `ckv_dim = kv_lora_rank + qk_rope_head_dim` and `kpe_dim = qk_rope_head_di
 
 For each expected definition name, check:
 ```bash
-find flashinfer_trace/definitions/ -name "{definition_name}.json"
+find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
 ```
 
 Assign status:
-- **✅** — JSON file exists in `flashinfer_trace/definitions/`
+- **✅** — JSON file exists in `tmp/flashinfer-trace/definitions/`
 - **❌** — Name computed from model config, but no JSON file found (missing, needs to be created)
 - **—** — Module exists in the model architecture but definition is not computed/mapped (unmapped)
 
@@ -472,7 +474,7 @@ This skill is also called by `onboard-model` (Phase 1 and Phase 4b) to update
 
 ### Definition file naming ambiguity
 - **Cause**: Computed name doesn't match any definition (off-by-one in dims, different naming convention)
-- **Handling**: Mark as ❌ and list the computed name in the detailed section. Cross-check with actual files in `flashinfer_trace/definitions/` before marking as missing.
+- **Handling**: Mark as ❌ and list the computed name in the detailed section. Cross-check with actual files in `tmp/flashinfer-trace/definitions/` before marking as missing.
 
 ### Model not in SGLang
 - **Cause**: Model isn't implemented in SGLang yet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,6 @@ flashinfer-bench/
 │   ├── integration/            #   FlashInfer integration
 │   ├── tracing/                #   Workload tracing utilities
 │   └── agents/                 #   Agent orchestration tools
-├── flashinfer_trace/           # Internal trace dataset (see below)
-│   ├── definitions/            #   Kernel definition JSON files, by op_type
-│   ├── tests/                  #   Definition tests and reference tests
-│   └── workloads/              #   Workload JSONL files
 ├── tests/                      # Pytest test suite
 ├── scripts/                    # Standalone scripts (workload collection, sanitization)
 ├── tools/                      # Developer tools (GPU locking, etc.)
@@ -44,40 +40,48 @@ flashinfer-bench/
 ├── web/                        # Web UI for visualization
 ├── examples/                   # Example code and benchmarks
 ├── .claude/skills/             # Agent skill definitions (see below)
-└── tmp/                        # Cloned external repos (SGLang, FlashInfer, sgl-cookbook)
+└── tmp/                        # Cloned external repos, including the
+                                #   flashinfer-trace HF dataset clone
+                                #   (SGLang, FlashInfer, sgl-cookbook, flashinfer-trace)
 ```
 
 ## Trace Dataset
 
-### Internal Trace Layer (`flashinfer_trace/`)
+### Single source of truth: HuggingFace
 
-The `flashinfer_trace/` directory is the repo-managed trace layer. Definitions are organized
-by `op_type` subdirectory:
+The canonical (and only) trace dataset lives at
+[`flashinfer-ai/flashinfer-trace`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace)
+on HuggingFace. It contains definitions, reference tests, baseline solutions, workloads,
+blobs, and evaluation traces.
+
+There is **no** in-repo `flashinfer_trace/` directory in `flashinfer-bench`. The earlier
+"internal trace layer" was removed in the trace-dataset refactor (PR #418); definitions,
+reference tests, and workloads no longer live here. Skills that need to read or edit trace
+content do so through a local clone of the HF dataset at `tmp/flashinfer-trace/`:
 
 ```
-flashinfer_trace/
+tmp/flashinfer-trace/                  # local clone of the HuggingFace dataset
 ├── definitions/{op_type}/{definition_name}.json
 ├── tests/references/test_{definition_name}.py
-└── workloads/{op_type}/{definition_name}.jsonl
+├── solutions/baseline/{op_type}/{definition_name}/...
+├── workloads/{op_type}/{definition_name}.jsonl
+├── blob/workloads/{op_type}/{definition_name}/*.safetensors
+└── traces/{op_type}/{definition_name}.jsonl
 ```
 
-Browse `flashinfer_trace/definitions/` to see the current set of supported op_types.
-Each op_type subdirectory contains one JSON file per kernel definition.
-
-### External Dataset
-
-The canonical published dataset lives at
-[`flashinfer-ai/flashinfer-trace`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace)
-on HuggingFace. It contains definitions, baseline solutions, workloads, and evaluation traces.
+Browse `tmp/flashinfer-trace/definitions/` to see the current set of supported op_types
+once `/clone-repos` has been run.
 
 ### Lifecycle
 
-1. Generate or update definitions in the internal `flashinfer_trace/` directory
-2. Open a PR in this repository for review
-3. After merge, manually sync to the external HuggingFace dataset
+1. Run `/clone-repos` to ensure `tmp/flashinfer-trace/` is checked out and up to date.
+2. Generate or update content under `tmp/flashinfer-trace/` and commit on a feature branch.
+3. Open a PR against the HuggingFace dataset repo (PR 2 in the onboard-model flow).
+4. Open a companion PR against `flashinfer-bench` that updates **only** `docs/model_coverage.mdx`
+   to reflect the new coverage (PR 1 in the onboard-model flow).
 
-New definitions should always be generated into the internal trace layer first.
-The external dataset is not the primary edit surface.
+The HuggingFace dataset is the primary edit surface — flashinfer-bench owns code, docs,
+and the coverage doc, not the trace data itself.
 
 ### Definition JSON Structure
 
@@ -107,7 +111,7 @@ Key conventions:
   local expert counts). Other kernel types (normalization, GEMM, RoPE, sampling) are
   parallelism-agnostic. See the `extract-kernel-definitions` skill for the full rules.
 
-Refer to `flashinfer_trace/definition.md` for the complete schema documentation.
+Refer to `docs/flashinfer-trace/definition.mdx` for the complete schema documentation.
 
 ## Documentation Structure (`docs/`)
 
@@ -176,13 +180,6 @@ Start with `.claude/skills/`. Each subdirectory contains a `SKILL.md` with full 
 
 ## Common Misunderstandings
 
-### `flashinfer_trace/` is the complete dataset
-
-Not necessarily. `flashinfer_trace/` is the internal repo-managed trace layer. The canonical
-published dataset lives at
-[`flashinfer-ai/flashinfer-trace`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace)
-on HuggingFace and may contain additional content (baseline solutions, evaluation traces).
-
 ### Tracing and apply are unrelated entry points
 
 They are different runtimes, but the `apply(...)` call path is a shared entry point for both
@@ -203,13 +200,14 @@ workloads.
 
 To add a new op_type beyond what currently exists:
 
-1. Create operation documentation in `docs/op_type_schema/`
-2. Create Definition JSON files under `flashinfer_trace/definitions/{new_op_type}/`
+1. Create operation documentation in `docs/op-types/`
+2. Create Definition JSON files under `tmp/flashinfer-trace/definitions/{new_op_type}/`
+   (the HuggingFace dataset clone — submit via a PR to `flashinfer-ai/flashinfer-trace`)
 3. Provide a Python reference implementation in the definition's `reference` field
 4. Create Solution implementations (Triton/CUDA optimized)
 5. Optionally create a FlashInfer adapter in `flashinfer_bench/integration/`
 
-The existing op_type directories under `flashinfer_trace/definitions/` serve as templates.
+The existing op_type directories under `tmp/flashinfer-trace/definitions/` serve as templates.
 
 ## Maintenance Notes
 
@@ -229,5 +227,5 @@ op_type-specific details belong in their respective skill files.
 - [FlashInfer Documentation](https://docs.flashinfer.ai)
 - [SGLang GitHub](https://github.com/sgl-project/sglang)
 - [HuggingFace Hub](https://huggingface.co/models)
-- [Definition Schema Documentation](flashinfer_trace/definition.md)
-- [Operation Type Schema](docs/op_type_schema/)
+- [Definition Schema Documentation](docs/flashinfer-trace/definition.mdx)
+- [Operation Type Schema](docs/op-types/)


### PR DESCRIPTION
## Summary

Bring `CLAUDE.md` and the agent skill files in line with the post-refactor
trace-dataset layout. After #418 and #398 the in-repo `flashinfer_trace/`
directory is gone and the HuggingFace dataset
[`flashinfer-ai/flashinfer-trace`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace)
is the single source of truth for definitions, reference tests, baseline
solutions, workloads, blobs, and eval traces. Several skills still pointed
at the dead `flashinfer_trace/...` paths, which would have caused agents
to misclassify every kernel as "new", write files into a non-existent
directory, and stage the wrong content into PR 1.

## What changed

- **`CLAUDE.md`** — replaced the "Internal Trace Layer" section with
  "Single source of truth: HuggingFace"; updated repo tree, lifecycle,
  "Common Misunderstandings", "Contributing New Op Types", and the schema
  doc link (`docs/flashinfer-trace/definition.mdx`, `docs/op-types/`).
- **`.claude/skills/onboard-model/SKILL.md`** — Phase 4 PR table, agent
  prompt template, Phase 4a/4b, **PR Review Checklist**, and TASK.md
  template now reflect the new split:
  - **PR 2 → HF flashinfer-trace** (opened first): definition JSON +
    reference test + baseline solution + workloads + blobs + eval traces.
  - **PR 1 → flashinfer-bench**: `docs/model_coverage.mdx` update only,
    with a back-link to PR 2.
  Phase 1d/2b "is this definition known?" lookups now hit
  `tmp/flashinfer-trace/definitions/` instead of the deleted local path.
- **`.claude/skills/extract-kernel-definitions/SKILL.md`** — outputs to
  `tmp/flashinfer-trace/definitions/`; replaced the inline outdated
  per-skill PR-submission block with a hand-off pointer to onboard-model's
  two-PR flow.
- **`.claude/skills/add-reference-tests/SKILL.md`** — outputs and pytest
  commands now target `tmp/flashinfer-trace/tests/references/`.
- **`.claude/skills/track-models/SKILL.md`** — coverage lookups now use
  `tmp/flashinfer-trace/definitions/`.
- **`.claude/skills/clone-repos/SKILL.md`** — directory tree no longer
  shows a local `flashinfer_trace/`; expands `tmp/flashinfer-trace/` to
  show the canonical layout (definitions / tests / solutions / workloads
  / blob / traces).

## Test plan

- [ ] Skim diff for any remaining stale `flashinfer_trace/...` paths
      (only intentional explanatory mentions should remain).
- [ ] Sanity-check the PR Review Checklist in `onboard-model/SKILL.md`
      against the latest merged onboarding PRs.
- [ ] Confirm `docs/flashinfer-trace/definition.mdx` and `docs/op-types/`
      are the correct link targets for the updated CLAUDE.md references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to reflect new canonical data storage location in the HuggingFace dataset clone
  * Clarified the two-PR submission process: HuggingFace dataset changes first, then flashinfer-bench coverage documentation only
  * Revised all process guides for consistency with the new architecture and data organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->