### PR TITLE
docs(skills): split onboard-model into per-phase skills + PR checklist fix-ups

### DIFF
--- a/.claude/skills/add-reference-tests/SKILL.md
+++ b/.claude/skills/add-reference-tests/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: add-reference-tests
-description: Add pytest tests to validate reference implementations in flashinfer_trace against FlashInfer or SGLang ground truth. Use when validating kernel definitions, adding tests for new op_types, or verifying reference implementations are correct.
+description: Add pytest tests to validate reference implementations in the flashinfer-trace HuggingFace dataset against FlashInfer or SGLang ground truth. Use when validating kernel definitions, adding tests for new op_types, or verifying reference implementations are correct.
 ---
 
 # Add Reference Tests
 
-Add tests to validate reference implementations in `./flashinfer_trace/`. Ground truth is sourced from FlashInfer repository or SGLang when FlashInfer doesn't have the implementation.
+Add tests to validate reference implementations in the HuggingFace dataset clone at `tmp/flashinfer-trace/`. Ground truth is sourced from FlashInfer repository or SGLang when FlashInfer doesn't have the implementation.
 
 ## Description
 
-This skill creates test cases under `./flashinfer_trace/tests/references/` to validate that reference implementations in Definition JSON files produce correct outputs. The ground truth comes from:
+This skill creates test cases under `tmp/flashinfer-trace/tests/references/` (the HF dataset clone — the in-repo `flashinfer_trace/` directory was removed in the trace-dataset refactor) to validate that reference implementations in Definition JSON files produce correct outputs. The ground truth comes from:
 
 1. **FlashInfer repository** (preferred): Official optimized GPU kernels in `tmp/flashinfer/`
 2. **SGLang repository** (fallback): When FlashInfer doesn't have the kernel, use `tmp/sglang/`
@@ -43,7 +43,7 @@ This skill creates test cases under `./flashinfer_trace/tests/references/` to va
 
 ## Prerequisites
 
-Run `/clone-repos` first to set up the `tmp/` directory with SGLang and FlashInfer (the `flashinfer_trace/` directory is already part of this repository).
+Run `/clone-repos` first to set up the `tmp/` directory with SGLang, FlashInfer, and the HuggingFace trace dataset clone at `tmp/flashinfer-trace/` — that clone is the only home for definitions and reference tests.
 
 ## What This Skill Does
 
@@ -51,11 +51,11 @@ Run `/clone-repos` first to set up the `tmp/` directory with SGLang and FlashInf
 
 1. **Load Target Definitions**:
    - If `definition_name` specified: load single definition
-   - If `op_type` specified: load all definitions matching op_type from `flashinfer_trace/definitions/{op_type}/`
+   - If `op_type` specified: load all definitions matching op_type from `tmp/flashinfer-trace/definitions/{op_type}/`
    - If `all`: scan all definitions
 
 2. **Check Existing Tests**:
-   - Scan `flashinfer_trace/tests/references/` for existing test files
+   - Scan `tmp/flashinfer-trace/tests/references/` for existing test files
    - Skip definitions that already have tests (unless force=true)
 
 3. **Parse Definition Schema**:
@@ -449,12 +449,12 @@ MEDIUM_SIZES = {
 
 ### Phase 5: Write Test Files
 
-Output to `flashinfer_trace/tests/references/`
+Output to `tmp/flashinfer-trace/tests/references/` (the HF dataset clone — committed and PR'd against `flashinfer-ai/flashinfer-trace`).
 
 ## Output Structure
 
 ```
-flashinfer_trace/tests/references/
+tmp/flashinfer-trace/tests/references/
 ├── conftest.py                    # Shared fixtures and utilities
 ├── test_rmsnorm.py                # RMSNorm tests
 ├── test_gqa_paged.py              # GQA paged tests
@@ -751,12 +751,12 @@ When executing this skill:
 
 1. **Identify definitions to test**:
    ```bash
-   ls flashinfer_trace/definitions/{op_type}/
+   ls tmp/flashinfer-trace/definitions/{op_type}/
    ```
 
 2. **Check for existing tests**:
    ```bash
-   ls flashinfer_trace/tests/references/
+   ls tmp/flashinfer-trace/tests/references/
    ```
 
 3. **For each definition**:
@@ -768,7 +768,7 @@ When executing this skill:
 4. **Create test file**:
    ```bash
    # Create tests directory if needed
-   mkdir -p flashinfer_trace/tests/references/
+   mkdir -p tmp/flashinfer-trace/tests/references/
    ```
 
 5. **Write test file**:
@@ -779,20 +779,20 @@ When executing this skill:
 
 ## Running Tests
 
-After generating tests, run from the project root:
+After generating tests, run from the HF dataset clone:
 
 ```bash
 # Run all reference tests
-pytest flashinfer_trace/tests/references/ -v
+pytest tmp/flashinfer-trace/tests/references/ -v
 
 # Run specific test file
-pytest flashinfer_trace/tests/references/test_mla_paged.py -v
+pytest tmp/flashinfer-trace/tests/references/test_mla_paged.py -v
 
 # Run with GPU
-pytest flashinfer_trace/tests/references/ -v --device cuda
+pytest tmp/flashinfer-trace/tests/references/ -v --device cuda
 
 # Run with verbose output
-pytest flashinfer_trace/tests/references/ -v -s
+pytest tmp/flashinfer-trace/tests/references/ -v -s
 ```
 
 ## Error Handling
@@ -830,8 +830,8 @@ pytest flashinfer_trace/tests/references/ -v -s
 /add-reference-tests --op-type mla_paged
 /add-reference-tests --op-type moe
 
-# Run tests from project root
-pytest flashinfer_trace/tests/references/ -v
+# Run tests from the HF dataset clone
+pytest tmp/flashinfer-trace/tests/references/ -v
 ```
 
 ## Notes

--- a/.claude/skills/clone-repos/SKILL.md
+++ b/.claude/skills/clone-repos/SKILL.md
@@ -138,17 +138,6 @@ When executing this skill:
 
 ```
 flashinfer-bench/
-├── flashinfer_trace/                 # Local working area (definitions, tests)
-│   ├── definitions/                  # Kernel definitions (write here first)
-│   │   ├── rmsnorm/
-│   │   ├── gemm/
-│   │   ├── gqa_paged/
-│   │   ├── mla_paged/
-│   │   ├── gdn/
-│   │   ├── moe/
-│   │   └── ...
-│   └── tests/
-│       └── references/               # Reference tests
 └── tmp/                              # Cloned repositories (auto-updated)
     ├── sglang/                       # SGLang repository (installed in current env)
     │   └── python/sglang/srt/
@@ -171,24 +160,15 @@ flashinfer-bench/
     │   ├── csrc/                     # CUDA source files
     │   └── include/                  # C++ headers with kernel implementations
     ├── sgl-cookbook/                 # Serving configuration repository (NOT installed)
-    └── flashinfer-trace/             # HuggingFace dataset clone — workloads and blobs go here for PR submission
-        ├── docs/                     # Model deployment documentation (markdown)
-        │   └── autoregressive/
-        │       ├── DeepSeek/
-        │       │   ├── DeepSeek-V3.md
-        │       │   └── DeepSeek-R1.md
-        │       ├── Qwen/
-        │       │   ├── Qwen3-Next.md
-        │       │   └── Qwen3.md
-        │       └── ...
-        ├── data/
-        │   ├── models/               # Model configurations (YAML)
-        │   │   └── generated/v0.5.6/
-        │   │       ├── qwen3next.yaml
-        │   │       ├── deepseek.yaml
-        │   │       └── ...
-        │   └── optimal-configs/      # Optimal serving configurations
-        └── README.md
+    └── flashinfer-trace/             # HuggingFace dataset clone — single source of truth
+        │                             # for definitions, ref tests, baselines, workloads,
+        │                             # blobs, and eval traces. All trace edits commit here.
+        ├── definitions/{op_type}/    # Kernel definition JSONs
+        ├── tests/references/         # Reference tests (pytest)
+        ├── solutions/baseline/       # FlashInfer-wrapper baseline solutions
+        ├── workloads/{op_type}/      # Sanitized workload JSONLs
+        ├── blob/workloads/{op_type}/ # Safetensors blobs referenced by JSONLs
+        └── traces/{op_type}/         # Eval traces (one entry per workload)
 ```
 
 ## Requirements
@@ -211,8 +191,8 @@ flashinfer-bench/
 
 This skill provides the foundation for:
 
-1. **extract-kernel-definitions**: Uses SGLang model files to extract kernels, sgl-cookbook to find serving configurations (TP/EP flags), outputs to `./flashinfer_trace/definitions/` (local working area)
-2. **add-reference-tests**: Uses FlashInfer for ground truth, outputs tests to `./flashinfer_trace/tests/references/`
+1. **extract-kernel-definitions**: Uses SGLang model files to extract kernels, sgl-cookbook to find serving configurations (TP/EP flags), outputs to `tmp/flashinfer-trace/definitions/` (the HuggingFace dataset clone)
+2. **add-reference-tests**: Uses FlashInfer for ground truth, outputs tests to `tmp/flashinfer-trace/tests/references/`
 3. **collect-workloads**: Uses `tmp/flashinfer-trace` (HuggingFace dataset clone) as the target for workload JSONL + safetensors blobs, then submits a PR
 4. **onboard-model**: End-to-end pipeline that calls this skill first (Phase 0) to ensure all repos are current before model discovery, definition generation, and workload collection.
 

--- a/.claude/skills/discover-models/SKILL.md
+++ b/.claude/skills/discover-models/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: discover-models
+description: Discover candidate LLMs and produce a kernel inventory — required definitions, classified as existing/new and fi_supported/fi_missing — for onboarding. Use as Phase 1 of /onboard-model, or standalone to plan onboarding work.
+---
+
+# Discover Models
+
+Identify target models and produce a per-kernel inventory:
+- which definitions are needed,
+- which already live in the HuggingFace dataset (`tmp/flashinfer-trace/definitions/`),
+- which are new and supported by FlashInfer,
+- which are new and missing from FlashInfer (so a kernel-request issue is needed).
+
+Produces the `kernels` block of the onboard-model run manifest.
+
+## Usage
+
+```bash
+# Auto-discover candidate models added to SGLang in the last 30 days
+/discover-models --discover
+
+# Plan a specific model
+/discover-models --model-name qwen3-235b-a22b --hf-repo-id Qwen/Qwen3-235B-A22B
+
+# Write the inventory to a manifest file (consumed by /onboard-model)
+/discover-models --model-name kimi-k2 --manifest tmp/onboard_kimi-k2_20260427.json
+```
+
+## Parameters
+
+- `--discover` (optional): Auto-discover candidates from SGLang day-0 additions and sgl-cookbook YAMLs.
+- `--model-name` (optional): Specific model slug to plan (e.g. `qwen3-235b-a22b`).
+- `--hf-repo-id` (optional): HuggingFace repo override (e.g. `Qwen/Qwen3-235B-A22B`). Inferred from `--model-name` if omitted.
+- `--manifest` (optional): Path to an onboard-model run manifest. The skill writes the `model_slug`, `hf_repo_id`, `repo_shas`, and `kernels` array. If the file already exists, fields are merged; existing per-kernel statuses are preserved unless `--refresh` is set.
+- `--refresh` (optional): Re-classify all kernels even if entries already exist in the manifest.
+
+## Prerequisites
+
+- `/clone-repos` has been run, so `tmp/sglang/`, `tmp/flashinfer/`, `tmp/sgl-cookbook/`, and `tmp/flashinfer-trace/` are present and current.
+- `huggingface_hub` is installed and (for gated models) authenticated.
+
+---
+
+## Phase 1a: Discover candidate models
+
+Run only when `--discover` is set.
+
+**Day-0 SGLang additions** (highest priority — production-ready):
+
+```bash
+git -C tmp/sglang log --since="30 days ago" --name-status --diff-filter=A \
+    -- "python/sglang/srt/models/*.py" | grep "^A" | awk '{print $2}'
+```
+
+Models with a brand-new `.py` under `python/sglang/srt/models/` in the last 30 days are
+day-0 candidates. Parse the model class to derive a slug.
+
+**sgl-cookbook new entries**:
+
+```bash
+git -C tmp/sgl-cookbook log --since="30 days ago" --name-status --diff-filter=A \
+    -- "data/models/generated/v0.5.6/*.yaml" | grep "^A" | awk '{print $2}'
+```
+
+A new YAML signals a model with a recommended serving config.
+
+**Filter already-tracked models**: read `docs/model_coverage.mdx` Summary table and skip any
+candidate already listed.
+
+## Phase 1b: Fetch model config from HuggingFace
+
+For each candidate (or the specified `--model-name`):
+
+```python
+from huggingface_hub import hf_hub_download
+import json
+
+config_path = hf_hub_download(repo_id=hf_repo_id, filename="config.json")
+with open(config_path) as f:
+    config = json.load(f)
+```
+
+Key fields to extract: see `track-models` SKILL.md for the full `config.json → kernel param`
+mapping table.
+
+## Phase 1c: Determine required kernel definitions
+
+Use the per-op-type formulas in `track-models` Phase 3a to compute the expected definition
+names from the model config and the sgl-cookbook TP/EP values. Each formula yields a fully
+qualified definition name like `gqa_paged_decode_h40_kv8_d128_ps1`.
+
+## Phase 1d: Classify existing vs new
+
+For each expected definition name, search the HuggingFace dataset clone (definitions live
+only there after the trace-dataset refactor):
+
+```bash
+find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
+```
+
+| Result | Classification |
+|--------|---------------|
+| File found | **existing** — no new definition needed |
+| Not found | **new** — proceed to FlashInfer-availability classification |
+
+## Phase 1e: Check FlashInfer kernel availability for new definitions
+
+For each *new* definition, determine whether FlashInfer already implements the underlying
+kernel.
+
+| op_type | Check path in `tmp/flashinfer/` |
+|---------|--------------------------------|
+| `rmsnorm` | `flashinfer/norm.py` — grep for `rmsnorm` |
+| `gqa_paged` | `flashinfer/decode.py`, `flashinfer/prefill.py` |
+| `gqa_ragged` | `flashinfer/prefill.py` |
+| `mla_paged` | `flashinfer/mla.py` |
+| `dsa_paged` | `flashinfer/sparse.py` |
+| `gdn` | `flashinfer/gdn.py` or `flashinfer/gdn/` |
+| `moe` | `flashinfer/fused_moe/` — check the specific variant |
+| `gemm` | always available via PyTorch |
+| `sampling` | `flashinfer/sampling.py` |
+| `mamba_ssu` | `flashinfer/mamba.py` — grep for `selective_state_update` |
+| `rope` | `flashinfer/rope.py` — grep for `apply_rope_with_cos_sin_cache` |
+
+Also check `tmp/flashinfer/tests/` for a corresponding test file — its presence is a strong
+signal the kernel is implemented and tested.
+
+Classify each new definition:
+
+- **fi_supported**: FlashInfer has the kernel → onboard-model Phase 2b (extract from FlashInfer).
+- **fi_missing**: FlashInfer does not have the kernel → onboard-model Phase 2a (extract from SGLang + file kernel-request issue).
+
+## Phase 1f: Check SGLang integration for fi_supported definitions
+
+For each `fi_supported` definition, determine whether SGLang already routes through the
+FlashInfer kernel. The result drives Phase 3 (workload collection).
+
+```bash
+# Use the fi_api tag from the definition (or the expected wrapper name) to grep:
+grep -r "{flashinfer_api_name}" tmp/sglang/python/sglang/srt/ 2>/dev/null | grep -v __pycache__
+```
+
+Common mapping:
+
+| fi_api | SGLang integration file | Search term |
+|--------|------------------------|-------------|
+| `flashinfer.mla.BatchMLAPagedAttentionWrapper` | `layers/attention/flashinfer_backend.py` | `BatchMLAPagedAttentionWrapper` |
+| `flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper` | `layers/attention/flashinfer_backend.py` | `BatchDecodeWithPagedKVCacheWrapper` |
+| `flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper` | `layers/attention/flashinfer_backend.py` | `BatchPrefillWithPagedKVCacheWrapper` |
+| `flashinfer.norm.rmsnorm` | `layers/layernorm.py` | `flashinfer.norm` |
+| `flashinfer.fused_moe.trtllm_fp8_block_scale_moe` | `layers/moe/fused_moe.py` | `trtllm_fp8_block_scale_moe` |
+| `flashinfer.gdn.gated_delta_rule_decode` | `layers/attention/gdn_backend.py` | `gated_delta_rule_decode` |
+| `flashinfer.mamba.selective_state_update` | `layers/mamba/mamba_mixer.py` | `selective_state_update` |
+
+Classify:
+
+- **sgl_integrated**: SGLang already calls this FlashInfer API → Phase 3 collects workloads directly.
+- **sgl_missing**: SGLang does not yet wire this API → Phase 3 must submit an SGLang PR first.
+
+For `fi_missing` definitions, SGLang integration is moot (no FlashInfer kernel to call) — set `sgl_status` to `n/a`.
+
+## Phase 1g: Report
+
+Print a classification table:
+
+```
+Model: Qwen3-235B-A22B
+HF repo: Qwen/Qwen3-235B-A22B
+Architecture: 94 layers, GQA + MoE
+
+Kernel inventory:
+  EXISTING (skip):
+    ✅ rmsnorm_h7168
+    ✅ moe_fp8_block_scale_ds_routing_topk8_ng8_kg4_e32_h7168_i2048
+  NEW — FlashInfer supported, SGLang integrated → ready for workload collection:
+    🆕 gqa_paged_decode_h40_kv8_d128_ps1
+    🆕 gqa_paged_decode_h40_kv8_d128_ps64
+  NEW — FlashInfer supported, SGLang missing → submit SGLang PR first:
+    🆕 dsa_topk_indexer_fp8_h64_d128_topk2048_ps64
+  NEW — FlashInfer MISSING → file kernel-request issue, skip workload collection:
+    ❓ <new_op_type>_<params>
+```
+
+## Output: run-manifest contract
+
+When `--manifest <path>` is set, write/update a JSON file with this shape (the same manifest
+consumed by `/onboard-model` and `/submit-onboarding-prs`):
+
+```json
+{
+  "model_slug": "qwen3-235b-a22b",
+  "hf_repo_id": "Qwen/Qwen3-235B-A22B",
+  "date": "2026-04-27",
+  "repo_shas": {
+    "sglang": "abc1234",
+    "flashinfer": "def5678",
+    "sgl_cookbook": "ghi9012",
+    "flashinfer_trace": "jkl3456"
+  },
+  "kernels": [
+    {
+      "definition_name": "gqa_paged_decode_h40_kv8_d128_ps1",
+      "op_type": "gqa_paged",
+      "phase1_status": "new",
+      "fi_status": "fi_supported",
+      "sgl_status": "sgl_integrated"
+    },
+    {
+      "definition_name": "rmsnorm_h7168",
+      "op_type": "rmsnorm",
+      "phase1_status": "existing"
+    },
+    {
+      "definition_name": "new_op_h512",
+      "op_type": "new_op",
+      "phase1_status": "new",
+      "fi_status": "fi_missing",
+      "sgl_status": "n/a"
+    }
+  ]
+}
+```
+
+Existing entries written by later phases (`phase2_status`, `phase3_status`, `workload_entries`,
+`fi_issue_url`, `phase4`) are preserved on update.
+
+## See Also
+
+- [onboard-model](../onboard-model/SKILL.md) — full pipeline that consumes this skill's output
+- [track-models](../track-models/SKILL.md) — config-field and per-op-type formula reference
+- [clone-repos](../clone-repos/SKILL.md) — must run first
+- [submit-onboarding-prs](../submit-onboarding-prs/SKILL.md) — Phase 4 counterpart

--- a/.claude/skills/extract-kernel-definitions/SKILL.md
+++ b/.claude/skills/extract-kernel-definitions/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: extract-kernel-definitions
-description: Extract kernel schemas and definitions from SGLang model implementations with deduplication. Use when adding a new model, extracting GPU kernels (MLA, MoE, GQA, RMSNorm, GEMM), or generating Definition JSON files for flashinfer_trace.
+description: Extract kernel schemas and definitions from SGLang model implementations with deduplication. Use when adding a new model, extracting GPU kernels (MLA, MoE, GQA, RMSNorm, GEMM), or generating Definition JSON files for the flashinfer-trace HuggingFace dataset.
 ---
 
 # Extract Kernel Definitions
 
-Extract kernel schemas and definitions from SGLang model implementations, with deduplication, and add them to `./flashinfer_trace/` with vanilla Python reference implementations. Uses sgl-cookbook serving configurations to generate multiple kernel definitions for different TP/EP settings.
+Extract kernel schemas and definitions from SGLang model implementations, with deduplication, and add them to the HuggingFace dataset clone at `tmp/flashinfer-trace/` with vanilla Python reference implementations. Uses sgl-cookbook serving configurations to generate multiple kernel definitions for different TP/EP settings.
 
 ## Description
 
@@ -41,7 +41,7 @@ This skill analyzes SGLang model implementations to extract the complete set of 
 
 ## Prerequisites
 
-Run `/clone-repos` first to set up the `tmp/` directory with SGLang, FlashInfer, and sgl-cookbook (the `flashinfer_trace/` directory is already part of this repository).
+Run `/clone-repos` first to set up the `tmp/` directory with SGLang, FlashInfer, sgl-cookbook, and the HuggingFace trace dataset clone at `tmp/flashinfer-trace/` (which is the only home for definitions, reference tests, and workloads — the in-repo `flashinfer_trace/` directory was removed in the trace-dataset refactor).
 
 ## What This Skill Does
 
@@ -141,7 +141,7 @@ For each layer component AND each serving configuration (TP/EP setting), extract
 ### Phase 3: Deduplication
 
 1. **Load Existing Definitions**:
-   - Scan `flashinfer_trace/definitions/` for existing JSONs
+   - Scan `tmp/flashinfer-trace/definitions/` (HF dataset clone) for existing JSONs
    - Build index of definition names and signatures
 
 2. **Compare Extracted Kernels**:
@@ -318,7 +318,7 @@ Add constraints for input validation:
 
 ### Phase 5: Save Definitions
 
-Output to `flashinfer_trace/definitions/{op_type}/{definition_name}.json`
+Output to `tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json` (the HF dataset clone — committed and PR'd against `flashinfer-ai/flashinfer-trace`).
 
 ## Output Format
 
@@ -518,86 +518,34 @@ When executing this skill:
    - Look for config class (e.g., `DeepseekV3Config`)
    - Extract: num_hidden_layers, hidden_size, num_attention_heads, num_key_value_heads, intermediate_size, etc.
 
-6. **Check existing definitions**:
+6. **Check existing definitions** (HF dataset clone is the only home for definitions):
    ```bash
-   ls flashinfer_trace/definitions/*/
+   ls tmp/flashinfer-trace/definitions/*/
    ```
 
 7. **Generate definition JSONs for each TP/EP config**:
    - For each unique TP value, calculate split head counts
    - For each unique EP value, calculate local expert counts
-   - Create directory if needed: `mkdir -p flashinfer_trace/definitions/{op_type}/`
-   - Write JSON file with reference implementation
+   - Create directory if needed: `mkdir -p tmp/flashinfer-trace/definitions/{op_type}/`
+   - Write JSON file with reference implementation into the HF dataset clone
    - **Example**: For Qwen3-Next GDN kernel with original q_heads=16, v_heads=32:
      - TP=2: Create `gdn_decode_qk8_v16_d128_k_last.json` (16/2=8, 32/2=16)
      - TP=4: Create `gdn_decode_qk4_v8_d128_k_last.json` (16/4=4, 32/4=8)
 
-8. **Submit one GitHub PR per definition** (PR 1 in the two-PR workflow):
+8. **Hand off to PR submission**:
 
-   Each PR bundles the definition JSON, a reference test, and the model_coverage.mdx update
-   together. Use git worktrees for parallel submission — one worktree and one agent per definition:
+   This skill stops at writing the definition JSON to the local HF dataset clone. PR
+   submission for new definitions follows the canonical two-PR flow defined in the
+   **onboard-model** skill:
+   - **PR 2** (HuggingFace `flashinfer-ai/flashinfer-trace`): definition JSON + reference
+     test + baseline solution + workloads + blobs + eval traces. Open this first.
+   - **PR 1** (GitHub `flashinfer-ai/flashinfer-bench`): `docs/model_coverage.mdx` update
+     only, with a back-link to PR 2.
 
-   ```bash
-   # Create one worktree per definition (do this up front for all definitions)
-   git worktree add \
-     tmp/worktrees/bench-{definition_name} \
-     -b feat/def-{definition_name}
-
-   # Then in each worktree (agents can run in parallel):
-   # 1. Copy definition JSON
-   cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-      tmp/worktrees/bench-{definition_name}/flashinfer_trace/definitions/{op_type}/
-
-   # 2. Add reference test (use /add-reference-tests skill or write manually)
-   # File: tmp/worktrees/bench-{definition_name}/tests/test_{op_type}_{definition_name}.py
-
-   # 3. Update model coverage doc
-   # Edit tmp/worktrees/bench-{definition_name}/docs/model_coverage.mdx
-
-   cd tmp/worktrees/bench-{definition_name}
-   git add flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-           tests/test_{op_type}_{definition_name}.py \
-           docs/model_coverage.mdx
-   git commit -m "feat: add {definition_name}
-
-   - {op_type} kernel definition for {model_display_name}
-   - Reference test for definition validation
-   - Model coverage doc updated
-   Reference implementation sourced from {source}.
-   "
-   # Run reference test and capture output for PR description
-   pytest tests/test_{op_type}_{definition_name}.py -v 2>&1 | tee /tmp/test_{definition_name}.txt
-
-   pre-commit run --all-files
-   git push origin feat/def-{definition_name}
-   gh pr create \
-     --repo flashinfer-ai/flashinfer-bench \
-     --title "feat: add {definition_name}" \
-     --body "$(cat <<'EOF'
-## Summary
-- Adds kernel definition for `{definition_name}` ({op_type})
-- Model: {model_display_name}
-- Reference implementation sourced from: {source}
-{If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
-
-## Reference Test Results
-\`\`\`
-$(cat /tmp/test_{definition_name}.txt)
-\`\`\`
-
-## Files changed
-- `flashinfer_trace/definitions/{op_type}/{definition_name}.json`
-- `tests/test_{op_type}_{definition_name}.py`
-- `docs/model_coverage.mdx`
-EOF
-)"
-
-   # Clean up worktree after PR is open
-   git worktree remove tmp/worktrees/bench-{definition_name}
-   ```
-
-   **One PR per definition.** Do not batch multiple definitions into a single PR.
-   PR 2 (baseline solution + workloads + traces → HuggingFace) is handled by `collect-workloads`.
+   See `onboard-model/SKILL.md` "Phase 4: Submit PRs" for the full flow, including the
+   per-definition worktree layout and PR Review Checklist. Do **not** add a definition
+   JSON to a `flashinfer_trace/...` path inside `flashinfer-bench` — that directory was
+   removed in the trace-dataset refactor.
 
 9. **Report results**:
    - List new definitions created (grouped by TP/EP config)

--- a/.claude/skills/onboard-model/SKILL.md
+++ b/.claude/skills/onboard-model/SKILL.md
@@ -5,28 +5,22 @@ description: End-to-end pipeline for discovering new LLMs with novel kernels and
 
 # Onboard Model
 
-Full end-to-end pipeline for discovering new LLMs with novel kernels and onboarding them into
-FlashInfer-Bench. This skill orchestrates all sub-skills in the correct order and handles
-branching logic depending on whether FlashInfer already supports the required kernels and whether
-SGLang already integrates them.
+Thin orchestrator that runs the five-phase pipeline for adding a new LLM to
+FlashInfer-Bench. Each phase delegates to a focused skill — this file is the contract that
+chains them together via a shared run manifest.
 
-## Overview of Phases
+## Overview of phases
 
-```
-Phase 0: Update local repos (clone-repos)
-Phase 1: Discover model + identify required kernels (track-models + HF)
-Phase 2: Kernel definition generation
-          ├─ kernel present in FlashInfer → generate def from FlashInfer ground truth
-          └─ kernel absent from FlashInfer → generate def from HF config + SGLang,
-                                              file GitHub issue in flashinfer-ai/flashinfer
-Phase 3: Workload collection (only when FlashInfer has the kernel)
-          ├─ kernel integrated into SGLang → collect-workloads (sglang mode)
-          └─ kernel NOT integrated into SGLang → draft + submit SGLang PR,
-                                                  then collect-workloads (sglang mode)
-Phase 4: Submit PRs (per definition, not batched)
-          ├─ PR 1 → flashinfer-bench (GitHub): docs/model_coverage.mdx update only
-          └─ PR 2 → flashinfer-ai/flashinfer-trace (HuggingFace): definition JSON + reference tests + baseline solution + workloads + traces
-```
+| Phase | Skill | Output |
+|-------|-------|--------|
+| 0 | [`/clone-repos`](../clone-repos/SKILL.md) | `tmp/sglang/`, `tmp/flashinfer/`, `tmp/sgl-cookbook/`, `tmp/flashinfer-trace/` cloned and current |
+| 1 | [`/discover-models`](../discover-models/SKILL.md) | manifest `kernels[]` populated with `phase1_status`, `fi_status`, `sgl_status` |
+| 2 | [`/extract-kernel-definitions`](../extract-kernel-definitions/SKILL.md) (+ inline `gh issue create` for `fi_missing`) | definition JSONs in `tmp/flashinfer-trace/definitions/`; manifest `phase2_status=done` (and `fi_issue_url` for fi_missing) |
+| 3 | [`/collect-workloads`](../collect-workloads/SKILL.md) (+ inline SGLang PR for `sgl_missing`) | workloads + blobs in `tmp/flashinfer-trace/`; manifest `phase3_status=done` |
+| 4 | [`/submit-onboarding-prs`](../submit-onboarding-prs/SKILL.md) | one HF PR + one bench PR per definition; manifest `phase4` populated |
+
+The state contract between skills is the run manifest at
+`tmp/onboard_{model_slug}_{date}.json` — see "Run manifest" below.
 
 ## Usage
 
@@ -47,33 +41,25 @@ Phase 4: Submit PRs (per definition, not batched)
 ## Parameters
 
 - `--discover` (optional): Auto-discover new models from SGLang day-0 additions and sgl-cookbook.
-  Mutually compatible with `--model-name`.
+  Compatible with `--model-name`.
 - `--model-name` (optional): Specific model slug to onboard (e.g. `qwen3-235b-a22b`).
-- `--hf-repo-id` (optional): HuggingFace repo ID override (e.g. `Qwen/Qwen3-235B-A22B`).
-  Inferred from model name if omitted.
+- `--hf-repo-id` (optional): HuggingFace repo override. Inferred from `--model-name` if omitted.
 - `--phases` (optional): Comma-separated list of phases to run (default: `0,1,2,3,4`).
 - `--dry-run` (optional): Print what would be done without writing files or submitting PRs.
-- `--skip-workload` (optional): Skip Phase 3 (workload collection). Useful when no GPU is
-  available or kernel support is incomplete.
-- `--submit-prs` (optional): Submit PRs at the end of Phase 4 (default: true).
+- `--skip-workload` (optional): Skip Phase 3 (e.g. when no GPU is available).
+- `--submit-prs` (optional): Submit Phase 4 PRs (default: true).
 
 ---
 
-## Phase 0: Update All Local Repos
+## Phase 0: Update local repos
 
-**Goal**: Ensure all cloned repos under `tmp/` are current before any analysis.
-
-### Implementation
-
-Delegate to the `clone-repos` skill. This covers SGLang, FlashInfer, sgl-cookbook, and
-flashinfer-trace.
+Delegate to the [`clone-repos`](../clone-repos/SKILL.md) skill.
 
 ```bash
-# If repos already exist they will be pulled; otherwise cloned
 /clone-repos
 ```
 
-After the pull, verify the current commit SHAs:
+After the pull, capture the current SHAs and write them to the manifest's `repo_shas`:
 
 ```bash
 git -C tmp/sglang rev-parse --short HEAD
@@ -86,144 +72,54 @@ Report the SHAs in the Phase 0 summary so the user can reproduce the run.
 
 ---
 
-## Phase 1: Model Discovery and Kernel Inventory
+## Phase 1: Discover model + classify kernels
 
-**Goal**: Identify the target model(s), extract their required kernel set, and classify each
-kernel as *known* (definition already exists in the HuggingFace dataset clone at
-`tmp/flashinfer-trace/definitions/`) or *new* (no definition file found there).
-
-### 1a: Discover candidate models (when `--discover` is set)
-
-**Day-0 SGLang additions** (highest priority — these are production-ready models):
+Delegate to the [`discover-models`](../discover-models/SKILL.md) skill, which produces the
+manifest's `kernels[]` array — each entry tagged with `phase1_status` (existing/new),
+`fi_status` (fi_supported/fi_missing/n-a), and `sgl_status` (sgl_integrated/sgl_missing/n-a).
 
 ```bash
-# List files added to SGLang models directory since last 30 days
-git -C tmp/sglang log --since="30 days ago" --name-status --diff-filter=A \
-    -- "python/sglang/srt/models/*.py" | grep "^A" | awk '{print $2}'
+# In auto-discover mode
+/discover-models --discover --manifest tmp/onboard_{model_slug}_{date}.json
+
+# In single-model mode
+/discover-models --model-name {model_slug} --hf-repo-id {hf_repo_id} \
+                 --manifest tmp/onboard_{model_slug}_{date}.json
 ```
 
-Models with a new `.py` file in `python/sglang/srt/models/` within the last 30 days are
-day-0 candidates. Parse the model class name to derive a human-readable model slug.
+Subsequent phases iterate over `kernels` and act based on the per-entry classification.
 
-**sgl-cookbook new entries**:
+---
+
+## Phase 2: Generate kernel definitions
+
+For each kernel with `phase1_status=new`, generate a Definition JSON and write it into
+`tmp/flashinfer-trace/definitions/{op_type}/`.
+
+### 2b: fi_supported → extract from FlashInfer
+
+Delegate to [`extract-kernel-definitions`](../extract-kernel-definitions/SKILL.md). It
+handles sgl-cookbook TP/EP lookup, FlashInfer-test-derived `reference` implementation, and
+deduplication.
 
 ```bash
-git -C tmp/sgl-cookbook log --since="30 days ago" --name-status --diff-filter=A \
-    -- "data/models/generated/v0.5.6/*.yaml" | grep "^A" | awk '{print $2}'
+/extract-kernel-definitions --model-name {sglang_model_name}
 ```
 
-New YAML files in sgl-cookbook indicate models with recommended serving configs.
-
-**Filter already-tracked models**:
-
-Read `docs/model_coverage.mdx` and extract model names from the `## Summary` table. Skip any
-candidate already listed.
-
-### 1b: Fetch model config from HuggingFace
-
-For each candidate model (or the specified `--model-name`), fetch `config.json`:
-
-```python
-from huggingface_hub import hf_hub_download
-import json
-
-config_path = hf_hub_download(repo_id=hf_repo_id, filename="config.json")
-with open(config_path) as f:
-    config = json.load(f)
-```
-
-Key fields to extract (see `track-models` SKILL.md for the full table).
-
-### 1c: Determine required kernel definitions
-
-Use the same rules as `track-models` Phase 3a to compute the expected set of definition names
-from the model config and sgl-cookbook TP/EP values. See `track-models` SKILL.md for the
-complete per-op-type formulas.
-
-### 1d: Classify each kernel
-
-For each expected definition name (search the HuggingFace dataset clone — definitions no
-longer live in this repo):
+Verify each new definition now exists:
 
 ```bash
 find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
 ```
 
-| Result | Classification |
-|--------|---------------|
-| File found | **existing** — skip definition generation |
-| Not found | **new** — proceed to Phase 2 |
+Update each kernel's `phase2_status=done` in the manifest.
 
-### 1e: Check FlashInfer kernel availability for new definitions
+### 2a: fi_missing → SGLang-sourced reference + file kernel-request issue
 
-For each *new* definition, determine whether FlashInfer already implements the underlying
-kernel (even if no definition JSON exists yet).
-
-**op_type → FlashInfer package path mapping**:
-
-| op_type | Check path in `tmp/flashinfer/` |
-|---------|--------------------------------|
-| `rmsnorm` | `flashinfer/norm.py` — grep for `rmsnorm` |
-| `gqa_paged` | `flashinfer/decode.py`, `flashinfer/prefill.py` |
-| `gqa_ragged` | `flashinfer/prefill.py` |
-| `mla_paged` | `flashinfer/mla.py` |
-| `dsa_paged` | `flashinfer/sparse.py` |
-| `gdn` | `flashinfer/gdn.py` or `flashinfer/gdn/` |
-| `moe` | `flashinfer/fused_moe/` — check for specific variant |
-| `gemm` | Always available via PyTorch |
-| `sampling` | `flashinfer/sampling.py` |
-| `mamba_ssu` | `flashinfer/mamba.py` — grep for `selective_state_update` |
-| `rope` | `flashinfer/rope.py` — grep for `apply_rope_with_cos_sin_cache` |
-
-Additionally check `tmp/flashinfer/tests/` for a corresponding test file — its presence is a
-strong signal that the kernel is implemented and tested.
-
-Classify each new definition as:
-
-- **fi_supported**: FlashInfer has the kernel → Phase 2b (generate def from FlashInfer)
-- **fi_missing**: FlashInfer does not have the kernel → Phase 2a (generate def + file issue)
-
-### 1f: Phase 1 report
-
-Print a table:
-
-```
-Model: Qwen3-235B-A22B
-HF repo: Qwen/Qwen3-235B-A22B
-Architecture: 94 layers, GQA + MoE
-
-Kernel inventory:
-  EXISTING (skip):
-    ✅ rmsnorm_h7168
-    ✅ moe_fp8_block_scale_ds_routing_topk8_ng8_kg4_e32_h7168_i2048
-  NEW — FlashInfer supported:
-    🆕 gqa_paged_decode_h40_kv8_d128_ps1
-    🆕 gqa_paged_decode_h40_kv8_d128_ps64
-  NEW — FlashInfer MISSING (will file issue):
-    ❓ <new_op_type>_<params>
-```
-
----
-
-## Phase 2: Kernel Definition Generation
-
-**Goal**: Create definition JSON files for all *new* kernels.
-
-### 2a: FlashInfer missing → generate definition + file issue
-
-When FlashInfer does not yet implement the kernel:
-
-**2a-i: Generate definition JSON from HF config + SGLang**
-
-Follow the same steps as `extract-kernel-definitions` Phase 4, but using SGLang's vanilla
-implementation as the reference `run()` instead of FlashInfer tests. See
-`extract-kernel-definitions` SKILL.md for the full JSON structure and naming conventions.
-
-Mark the definition with `"status:unverified"` tag (no FlashInfer ground truth yet).
-
-**2a-ii: File a GitHub issue in `flashinfer-ai/flashinfer`**
-
-After writing the definition JSON, file a GitHub issue requesting the kernel implementation.
+When FlashInfer does not yet implement the kernel, generate the definition with SGLang's
+vanilla forward as the reference (`extract-kernel-definitions` supports this mode), then
+file an issue against `flashinfer-ai/flashinfer`. Mark the definition with the
+`status:unverified` tag.
 
 ```bash
 gh issue create \
@@ -262,102 +158,42 @@ The SGLang implementation is at:
 
 ### Links
 
-- FlashInfer-Bench definition: (link to PR in this repo once merged)
+- HuggingFace dataset PR: (link once PR 2 is open)
 - SGLang model: `tmp/sglang/python/sglang/srt/models/{model_file}`
 - HuggingFace model: https://huggingface.co/{hf_repo_id}
 EOF
 )"
 ```
 
-Record the issue URL. Add it as a comment to the definition JSON `description` field:
+Record the issue URL in the manifest as `fi_issue_url` for that kernel and add it to the
+definition's `description`:
+
 ```
 "description": "... See flashinfer-ai/flashinfer#<issue_number> for kernel implementation request."
 ```
 
-**Do not proceed to Phase 3** for fi_missing kernels — workload collection requires the
+**Do not proceed to Phase 3 for fi_missing kernels** — workload collection requires the
 FlashInfer kernel to exist.
-
-### 2b: FlashInfer present → generate definition from FlashInfer
-
-Delegate to `extract-kernel-definitions` for each new definition. This skill handles:
-- Looking up TP/EP configs from sgl-cookbook
-- Writing definition JSON with FlashInfer test as reference `run()`
-- Deduplication against existing files
-
-```bash
-/extract-kernel-definitions --model-name {sglang_model_name}
-```
-
-After generation, verify each expected definition now exists in the HuggingFace dataset
-clone (the only home for definitions after the refactor):
-
-```bash
-find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
-```
 
 ---
 
-## Phase 3: Workload Collection
+## Phase 3: Workload collection
 
-**Goal**: Collect real workload tensors for all *fi_supported* definitions that do not yet
-have workloads in `tmp/flashinfer-trace/workloads/`.
+Skip entirely for `fi_missing` kernels.
 
-Skip this phase entirely for *fi_missing* kernels.
-
-### 3a: Check workload existence
+### 3a: Skip if workloads already exist
 
 ```bash
 ls tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl 2>/dev/null
 ```
 
-If the JSONL already exists and is non-empty, skip collection for that definition.
+If the JSONL exists and is non-empty, mark `phase3_status=done` and skip.
 
-### 3b: Check SGLang integration
+### 3b: sgl_missing → submit SGLang integration PR first
 
-Determine whether SGLang already routes the kernel through the FlashInfer backend.
-
-**How to check:**
-
-```bash
-# Check if SGLang's FlashInfer attention backend calls the relevant FlashInfer API
-grep -r "flashinfer.{relevant_module}" \
-    tmp/sglang/python/sglang/srt/layers/attention/flashinfer_backend.py \
-    tmp/sglang/python/sglang/srt/layers/attention/ 2>/dev/null
-
-# Check for the specific wrapper or function name
-grep -r "{flashinfer_api_name}" \
-    tmp/sglang/python/sglang/srt/ 2>/dev/null | grep -v __pycache__
-```
-
-Use the `fi_api` tag from the definition JSON to know which API name to search for.
-
-The fi_api → SGLang integration mapping for common op_types:
-
-| fi_api | SGLang integration file | Search term |
-|--------|------------------------|-------------|
-| `flashinfer.mla.BatchMLAPagedAttentionWrapper` | `layers/attention/flashinfer_backend.py` | `BatchMLAPagedAttentionWrapper` |
-| `flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper` | `layers/attention/flashinfer_backend.py` | `BatchDecodeWithPagedKVCacheWrapper` |
-| `flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper` | `layers/attention/flashinfer_backend.py` | `BatchPrefillWithPagedKVCacheWrapper` |
-| `flashinfer.norm.rmsnorm` | `layers/layernorm.py` | `flashinfer.norm` |
-| `flashinfer.fused_moe.trtllm_fp8_block_scale_moe` | `layers/moe/fused_moe.py` | `trtllm_fp8_block_scale_moe` |
-| `flashinfer.gdn.gated_delta_rule_decode` | `layers/attention/gdn_backend.py` | `gated_delta_rule_decode` |
-| `flashinfer.mamba.selective_state_update` | `layers/mamba/mamba_mixer.py` | `selective_state_update` |
-
-Classify each definition's SGLang integration status:
-
-- **sgl_integrated**: SGLang already calls this FlashInfer API
-- **sgl_missing**: SGLang does not yet call this FlashInfer API
-
-### 3c: SGLang missing → draft + submit SGLang PR
-
-When the FlashInfer kernel exists but SGLang has not wired it in:
-
-**3c-i: Implement the integration**
-
-Locate the appropriate SGLang layer file and add the FlashInfer call. The changes are
-typically small (import + conditional dispatch). Follow existing patterns in the same file.
-
-Common integration patterns:
+For kernels classified `sgl_missing`, wire `{fi_api}` into the appropriate SGLang layer file
+and open a PR against `sgl-project/sglang`. The change is typically small (import +
+conditional dispatch).
 
 ```python
 # In layers/attention/flashinfer_backend.py or equivalent
@@ -374,17 +210,10 @@ def forward(...):
         return vanilla_forward(...)
 ```
 
-**3c-ii: Submit PR to SGLang**
-
 ```bash
 cd tmp/sglang
-
-# Create branch
 git checkout -b feat/flashinfer-{op_type}-integration-{model_slug}
-
-# Stage the integration changes
 git add python/sglang/srt/layers/...
-
 git commit -m "feat: integrate FlashInfer {op_type} for {model_name}
 
 Wire {fi_api} into SGLang's FlashInfer backend to enable
@@ -393,10 +222,8 @@ optimized {op_type} for {model_display_name}.
 Needed for: flashinfer-ai/flashinfer-bench (workload collection)
 FlashInfer API: {fi_api}
 "
-
 pre-commit run --all-files
 git push origin HEAD
-
 gh pr create \
   --repo sgl-project/sglang \
   --title "feat: integrate FlashInfer {op_type} for {model_name}" \
@@ -420,398 +247,57 @@ EOF
 )"
 ```
 
-Record the SGLang PR URL. Wait for it to be merged before running workload collection.
+Record the SGLang PR URL on the kernel entry. Pause Phase 3 for that kernel until the PR
+merges; resume the run with `--phases 3,4` once it lands.
 
-**3c-iii: Wait for SGLang PR**
+### 3c: sgl_integrated → run workload collection
 
-Pause Phase 3 and note that it must resume after the SGLang PR merges.
-
-### 3d: Run workload collection
-
-For each definition with `sgl_integrated` status (or after SGLang PR merges):
+Delegate to [`collect-workloads`](../collect-workloads/SKILL.md):
 
 ```bash
 /collect-workloads \
   --definition-names {definition_name} \
   --model-name {model_name} \
-  --submit-pr false   # PR is submitted in Phase 4
+  --submit-pr false   # PRs are submitted in Phase 4
 ```
 
-Verify output files were created:
+Verify outputs and update the manifest:
 
 ```bash
 ls tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl
 ls tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/
 ```
 
+Mark `phase3_status=done` and record `workload_entries`.
+
 ---
 
 ## Phase 4: Submit PRs
 
-**Goal**: Publish collected workloads and kernel definitions, one PR per definition,
-with all definitions processed in parallel using git worktrees.
-
-**Rule: one definition = two atomic PRs (opened in sequence per definition):**
-
-| # | Target repo | Content | Trigger |
-|---|-------------|---------|---------|
-| 1 | `flashinfer-ai/flashinfer-bench` (GitHub) | `docs/model_coverage.mdx` update only | after PR 2 is open |
-| 2 | `flashinfer-ai/flashinfer-trace` (HuggingFace) | definition JSON + reference test + baseline solution + workload JSONL + safetensors blobs + eval traces | after Phase 3 |
-
-After the trace-dataset refactor the local `flashinfer_trace/` directory no longer exists in
-`flashinfer-bench`. Definitions, reference tests, workloads, blobs, baseline solutions, and
-eval traces now live **only** in the HuggingFace dataset (`flashinfer-ai/flashinfer-trace`),
-so PR 2 is the canonical destination for all of those artifacts. PR 1 in `flashinfer-bench`
-contains nothing but the coverage-doc update and a back-link to PR 2.
-
-Do **not** batch multiple definitions into a single PR. Each definition must be independently
-reviewable and mergeable.
-
-### 4-setup: Create worktrees before spawning agents
-
-For each new definition, create two worktrees: one in the main repo (for PR 1 — coverage doc
-only) and one in the `tmp/flashinfer-trace` clone (for PR 2 — all dataset content). All
-worktrees can be created up front, then agents run in parallel. Run `pre-commit` in the bench
-worktree before pushing PR 1.
+Delegate to [`submit-onboarding-prs`](../submit-onboarding-prs/SKILL.md). It creates the
+per-definition worktrees, spawns one agent per definition, and opens PR 2 (HuggingFace
+dataset) followed by PR 1 (flashinfer-bench coverage doc) for each.
 
 ```bash
-DATE=$(date +%Y%m%d)
-
-# For each {definition_name} in the new definitions list:
-
-# Worktree 1: flashinfer-bench (this repo) — for docs/model_coverage.mdx update
-git worktree add \
-  tmp/worktrees/bench-{definition_name} \
-  -b feat/def-{definition_name}
-
-# Worktree 2: flashinfer-trace (HuggingFace dataset clone) — for definition JSON,
-# reference test, baseline solution, workloads, blobs, eval traces
-git -C tmp/flashinfer-trace worktree add \
-  ../worktrees/trace-{definition_name} \
-  -b workloads-${DATE}-{definition_name}
+/submit-onboarding-prs --manifest tmp/onboard_{model_slug}_{date}.json
 ```
 
-Worktree layout after setup:
-```
-flashinfer-bench/
-└── tmp/
-    ├── flashinfer-trace/          # main clone (do not commit here directly)
-    └── worktrees/
-        ├── bench-{def1}/          # isolated branch for def1 model_coverage.mdx update
-        ├── bench-{def2}/          # isolated branch for def2 model_coverage.mdx update
-        ├── trace-{def1}/          # isolated branch for def1 dataset content (HF repo)
-        └── trace-{def2}/          # isolated branch for def2 dataset content (HF repo)
-```
+The skill writes back to the manifest's `phase4` block with the resulting PR URLs.
 
-### 4-spawn: Run one agent per definition in parallel
-
-Spawn all definition agents simultaneously. Each agent receives its worktree paths and
-handles all three PRs for its definition independently.
-
-**Agent prompt template (repeat for each definition):**
-
-```
-You are handling PR submission for kernel definition: {definition_name}
-
-Your worktrees:
-- flashinfer-bench worktree: tmp/worktrees/bench-{definition_name}/
-  (branch: feat/def-{definition_name})
-- flashinfer-trace worktree: tmp/worktrees/trace-{definition_name}/
-  (branch: workloads-{date}-{definition_name})
-
-Definition file already written at (staging path inside the local clone):
-  tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json
-
-Workload files already collected at:
-  tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl
-  tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/
-
-NOTE: The local `flashinfer_trace/` directory in flashinfer-bench was removed in the
-trace-dataset refactor. All definitions, reference tests, workloads, blobs, baseline
-solutions, and eval traces live ONLY in the HuggingFace dataset (PR 2). PR 1 in
-flashinfer-bench contains nothing but the model_coverage.mdx update.
-
-Do the following in order:
-
-1. PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline
-   solution + workloads + blobs + eval traces). Open this FIRST so PR 1 can link to it.
-   - Check whether a baseline solution already exists:
-       ls tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/*.json 2>/dev/null
-   - If baseline solution ALREADY EXISTS: skip creating a new solution and skip running eval.
-     Include the existing solution directory in the PR commit as-is.
-   - If baseline solution does NOT exist: create it (see Phase 4a below) and run
-     flashinfer-bench eval — all workloads must show PASSED before opening PR 2.
-   - Copy definition JSON into tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
-   - Write a reference test under tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
-     (use the add-reference-tests skill — pytest validating the definition's `reference` field
-     against FlashInfer/SGLang ground truth)
-   - Copy workload JSONL into tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
-   - Copy safetensors blobs into tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
-   - Copy baseline eval traces into tmp/worktrees/trace-{definition_name}/traces/{op_type}/{definition_name}.jsonl
-   - Commit all together and push
-   - Open HuggingFace PR via huggingface_hub.HfApi().create_pull_request()
-   - Record the PR number/URL as pr2_url
-
-2. PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx ONLY):
-   - In tmp/worktrees/bench-{definition_name}/, edit docs/model_coverage.mdx to mark
-     {definition_name} as ✅ for this model (update the relevant kernel row + summary table).
-   - Do NOT add definition JSON, reference test, workloads, blobs, or solutions to this PR —
-     those live exclusively in flashinfer-trace (PR 2).
-   - Run `pre-commit run --all-files` to format the change.
-   - Commit and push.
-   - Open PR to flashinfer-ai/flashinfer-bench. PR description MUST link to pr2_url.
-   - Record the PR number as pr1_number.
-
-Report the two PR URLs when done.
-```
-
-### 4a: PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline solution + workloads + blobs + eval traces)
-
-PR 2 is opened **first** so PR 1 can link to it.
-
-**Check first** — if a baseline solution already exists in `tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/`, skip creating a new one and skip running `flashinfer-bench run`. Include the existing solution files in the PR commit as-is; do not regenerate eval traces.
-
-Only create a new baseline solution and run eval when no solution exists yet.
-
-Inside `tmp/worktrees/trace-{definition_name}/`:
-
-```bash
-# 1. Copy kernel definition JSON (canonical home — only lives in flashinfer-trace now)
-cp tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json \
-   tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
-
-# 2. Write the reference test (use the add-reference-tests skill)
-# Output: tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
-# It must validate the definition's `reference` field against FlashInfer/SGLang ground truth.
-
-# 3. Baseline solution
-# If solutions/baseline/{op_type}/{definition_name}/*.json already exists in the HF clone,
-# copy it through unchanged. Otherwise create a FlashInfer-API-wrapper baseline (NOT a
-# copy of `reference`) and run `flashinfer-bench run` to generate eval traces.
-
-# 4. Copy workload JSONL and safetensors blobs
-cp -r tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl \
-      tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
-cp -r tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/ \
-      tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
-
-# 5. Copy eval traces (must show all entries PASSED)
-cp tmp/flashinfer-trace/traces/{op_type}/{definition_name}.jsonl \
-   tmp/worktrees/trace-{definition_name}/traces/{op_type}/
-
-cd tmp/worktrees/trace-{definition_name}
-git add definitions/{op_type}/{definition_name}.json \
-        tests/references/test_{definition_name}.py \
-        solutions/baseline/{op_type}/{definition_name}/ \
-        workloads/{op_type}/{definition_name}.jsonl \
-        blob/workloads/{op_type}/{definition_name}/ \
-        traces/{op_type}/{definition_name}.jsonl
-git commit -m "Add {definition_name}: definition + reference test + baseline solution + workloads + traces
-
-Model: {hf_repo_id}
-SGLang: {sglang_commit_sha}
-FlashInfer: {flashinfer_commit_sha}
-Workload entries: {num_workload_entries}
-"
-git push origin workloads-{date}-{definition_name}
-python -c "
-from huggingface_hub import HfApi
-HfApi().create_pull_request(
-    repo_id='flashinfer-ai/flashinfer-trace',
-    repo_type='dataset',
-    title='Add {definition_name}: definition + reference test + baseline solution + workloads + traces',
-    description='...',
-    head='workloads-{date}-{definition_name}',
-)
-"
-# Record the resulting PR URL as pr2_url
-```
-
-### 4b: PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx only)
-
-After PR 2 is open and you have its URL, open PR 1 in `flashinfer-bench`. The local
-`flashinfer_trace/` directory was removed in the trace-dataset refactor, so PR 1 contains
-**only** the model-coverage doc update plus a back-link to PR 2.
-
-Inside `tmp/worktrees/bench-{definition_name}/`:
-
-```bash
-# Edit docs/model_coverage.mdx: mark {definition_name} row as ✅ for this model
-# (and update the per-model summary table).
-
-cd tmp/worktrees/bench-{definition_name}
-pre-commit run --all-files
-git add docs/model_coverage.mdx
-git commit -m "docs: mark {definition_name} as covered for {model_display_name}
-
-Tracks the dataset addition at:
-{pr2_url}
-{If fi_missing: FlashInfer issue: flashinfer-ai/flashinfer#{issue_number}}
-"
-git push origin feat/def-{definition_name}
-gh pr create \
-  --repo flashinfer-ai/flashinfer-bench \
-  --title "docs: mark {definition_name} as covered for {model_display_name}" \
-  --body "$(cat <<EOF
-## Summary
-- Marks \`{definition_name}\` ({op_type}) as covered for **{model_display_name}** in
-  \`docs/model_coverage.mdx\`.
-- Definition JSON, reference test, baseline solution, workloads, blobs, and eval traces
-  all live in the HuggingFace dataset — see ${pr2_url}.
-${If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
-
-## Files changed
-- \`docs/model_coverage.mdx\`
-
-## Linked PRs
-- HuggingFace dataset PR: ${pr2_url}
-EOF
-)"
-```
-
-### 4-cleanup: Remove worktrees after PRs are open
-
-```bash
-# After all agents have reported their PR URLs:
-for def in {definition_names}; do
-  git worktree remove tmp/worktrees/bench-${def}
-  git -C tmp/flashinfer-trace worktree remove ../worktrees/trace-${def}
-done
-```
+The PR Review Checklist and Agent TASK.md template both live inside that skill — refer to
+`submit-onboarding-prs/SKILL.md` rather than duplicating them here.
 
 ---
 
-## PR Review Checklist
+## Run manifest
 
-Run this checklist after both PRs are open for a definition. **Both PRs must pass all items
-before the definition is considered complete.** If any item fails, fix and re-push before
-requesting merge.
-
-After the trace-dataset refactor the local `flashinfer_trace/` directory no longer exists in
-`flashinfer-bench`. The HuggingFace dataset (`flashinfer-ai/flashinfer-trace`) is the only
-home for definition JSONs, reference tests, baseline solutions, workloads, blobs, and eval
-traces — so PR 2 owns all of that. PR 1 only updates `docs/model_coverage.mdx`.
-
-### PR 1 — GitHub flashinfer-bench (coverage doc only)
-
-1. **Coverage**: `docs/model_coverage.mdx` updated — row for `{name}` shows ✅ for
-   `{model_display_name}`, and the per-model summary table reflects the new count.
-2. **Single-file change**: the diff touches **only** `docs/model_coverage.mdx`. No
-   `flashinfer_trace/...` paths, no `tests/references/...`, no workload files, no blobs.
-   (If anything else appears in the diff it belongs in PR 2 instead.)
-3. **PR 2 link**: PR description links to the HuggingFace PR 2 by full URL.
-4. **fi_missing note (if applicable)**: if the kernel is `fi_missing`, PR description links
-   the FlashInfer kernel-request issue (`flashinfer-ai/flashinfer#{issue_number}`).
-5. **pre-commit clean**: `pre-commit run --all-files` passes locally before push.
-
-### PR 2 — HuggingFace flashinfer-trace (canonical dataset)
-
-1. **Definition JSON**: `definitions/{op_type}/{name}.json` exists in the PR.
-2. **Definition tags**: definition JSON has `status:verified` (or `status:unverified` when
-   the FlashInfer kernel is missing), plus `fi_api:*` and `ep:*`/`tp:*` where applicable.
-3. **Reference test**: `tests/references/test_{name}.py` exists in the PR and pytest runs
-   green against the definition's `reference` field. PR description includes the full
-   pytest stdout.
-4. **Workloads**: `workloads/{op_type}/{name}.jsonl` exists and is non-empty.
-5. **Blobs**: `blob/workloads/{op_type}/{name}/*.safetensors` files exist.
-6. **Baseline solution**: `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json`
-   exists — this must be a FlashInfer API wrapper (calls `BatchDecodeWithPagedKVCacheWrapper`
-   or `BatchPrefillWithPagedKVCacheWrapper`), **not** a copy of the definition's `reference`.
-7. **Eval traces**: `traces/{op_type}/{name}.jsonl` exists and every entry has
-   `evaluation.status == "PASSED"` — no failures allowed.
-8. **SGLang log**: PR description contains a `## SGLang Collection Log` section with the
-   full stdout from the `collect_workloads.py sglang` run (model loading, workload counts,
-   dump dir info). Workloads must be SGLang-collected (not synthetic) — real workloads have
-   diverse `(batch_size, kv_length)` pairs drawn from actual inference. A uniform sweep like
-   `batch_size=4096` with 1-page contexts is a red flag for synthetic data.
-9. **Provenance**: commit/PR body records `Model`, `SGLang` and `FlashInfer` commit SHAs,
-   and the workload-entry count.
-
----
-
-## Agent TASK.md Template
-
-When spawning an agent for a definition, write `.claude/TASK.md` in its bench worktree.
-Every TASK.md for definition onboarding must include:
-
-```markdown
-## Objective
-Submit 2 PRs for definition {name}. After the trace-dataset refactor, all dataset content
-lives only at HuggingFace; flashinfer-bench keeps just the coverage doc.
-- PR 2 (HuggingFace flashinfer-trace, OPEN FIRST): definition JSON + reference test +
-  baseline solution + workloads + blobs + eval traces (all entries PASSED) + SGLang
-  collection log in PR body.
-- PR 1 (GitHub flashinfer-bench, OPEN SECOND): docs/model_coverage.mdx updated to ✅
-  for this definition + back-link to PR 2 in PR body.
-
-## PR 2 Contents (HuggingFace flashinfer-trace)
-- `definitions/{op_type}/{name}.json`
-- `tests/references/test_{name}.py`
-- `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` (FlashInfer API wrapper —
-  NOT a copy of the definition `reference`; must call
-  flashinfer.BatchDecodeWithPagedKVCacheWrapper or flashinfer.BatchPrefillWithPagedKVCacheWrapper)
-- `workloads/{op_type}/{name}.jsonl`
-- `blob/workloads/{op_type}/{name}/*.safetensors`
-- `traces/{op_type}/{name}.jsonl` (all entries must have `evaluation.status == "PASSED"`)
-- PR description must include the full pytest stdout for the reference test
-- PR description must include the SGLang inference stdout under `## SGLang Collection Log`
-  (capture stdout of `collect_workloads.py sglang`)
-
-## PR 1 Contents (GitHub flashinfer-bench)
-- `docs/model_coverage.mdx` updated: ❌/🟡 → ✅ for this definition (and per-model summary
-  table refreshed)
-- The diff MUST touch only `docs/model_coverage.mdx` — no `flashinfer_trace/...`,
-  no `tests/references/...`, no workload/blob files (those all live in PR 2 now).
-- PR description must include a link to the HuggingFace PR 2 by full URL.
-
-## Progress Reporting
-Write .agent-progress.md after every major step:
-  Status: in_progress | completed | blocked
-  Done: <what's done>
-  Current: <what you're doing now>
-  Next: <next step>
-  Blockers: <if any>
-  - PR 2 (def + ref test + baseline + workloads + traces → flashinfer-trace HF): <URL or pending>
-  - PR 1 (model_coverage.mdx → flashinfer-bench GitHub): <URL or pending>
-
-## GPU Work
-Use tools/gpu-lock before any SGLang workload collection:
-  tools/gpu-lock --gpus <N> --exec-timeout 1800 -- python collect_workloads.py ...
-Where N matches the TP value (1 GPU for TP=1, 4 GPUs for TP=4, etc.)
-```
-
----
-
-## Decision Tree Summary
-
-```
-For each required kernel definition:
-
-  Already exists in tmp/flashinfer-trace/definitions/ (HF dataset clone)?
-  ├── YES → skip (existing)
-  └── NO  → Phase 2: generate definition JSON
-              FlashInfer has this kernel?
-              ├── YES → generate def from FlashInfer tests (status:verified)
-              │          SGLang integrates this FlashInfer API?
-              │          ├── YES → collect workloads (sglang mode)
-              │          └── NO  → submit SGLang PR, wait for merge, then collect workloads
-              └── NO  → generate def from HF config + SGLang (status:unverified)
-                         file GitHub issue in flashinfer-ai/flashinfer
-                         ⛔ skip workload collection (no FlashInfer kernel yet)
-```
-
----
-
-## State Tracking
-
-This skill produces a run manifest file at `tmp/onboard_{model_slug}_{date}.json` that
-records state for resumability:
+The contract between skills. Stored at `tmp/onboard_{model_slug}_{date}.json`:
 
 ```json
 {
   "model_slug": "qwen3-235b-a22b",
   "hf_repo_id": "Qwen/Qwen3-235B-A22B",
-  "date": "2026-03-29",
+  "date": "2026-04-27",
   "repo_shas": {
     "sglang": "abc1234",
     "flashinfer": "def5678",
@@ -834,34 +320,60 @@ records state for resumability:
       "op_type": "new_op",
       "phase1_status": "new",
       "fi_status": "fi_missing",
+      "sgl_status": "n/a",
       "fi_issue_url": "https://github.com/flashinfer-ai/flashinfer/issues/999",
       "phase2_status": "done",
       "phase3_status": "skipped (fi_missing)"
     }
   ],
   "phase4": {
-    "flashinfer_trace_pr": "https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/42",
-    "flashinfer_bench_pr": "https://github.com/flashinfer-ai/flashinfer-bench/pull/57"
+    "gqa_paged_decode_h40_kv8_d128_ps1": {
+      "flashinfer_trace_pr": "https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/42",
+      "flashinfer_bench_pr": "https://github.com/flashinfer-ai/flashinfer-bench/pull/57"
+    }
   }
 }
 ```
 
-If the skill is re-run with the same model slug, load this manifest to skip already-completed
-phases and resume from where the previous run stopped.
+Re-running `/onboard-model` with the same `--model-name` loads the existing manifest and
+skips any kernel/phase already marked `done` — phases resume from the first incomplete step.
 
 ---
 
-## Error Handling
+## Decision tree
+
+```
+For each required kernel definition:
+
+  Already exists in tmp/flashinfer-trace/definitions/ (HF dataset clone)?
+  ├── YES → skip (existing)
+  └── NO  → Phase 2: generate definition JSON
+              FlashInfer has this kernel?
+              ├── YES → /extract-kernel-definitions (status:verified)
+              │          SGLang integrates this FlashInfer API?
+              │          ├── YES → /collect-workloads
+              │          └── NO  → submit SGLang PR, wait for merge, then /collect-workloads
+              └── NO  → /extract-kernel-definitions (SGLang-sourced, status:unverified)
+                         file GitHub issue in flashinfer-ai/flashinfer
+                         ⛔ skip workload collection (no FlashInfer kernel yet)
+
+Then for each kernel that reached "ready":
+  /submit-onboarding-prs → PR 2 (HF) + PR 1 (bench coverage doc)
+```
+
+---
+
+## Error handling
 
 ### HuggingFace config unavailable
 - Private model or network error: note model as deferred, continue with other models.
 
 ### FlashInfer issue creation fails
-- Requires `gh` CLI authenticated with write access to `flashinfer-ai/flashinfer`.
+- Requires `gh` authenticated with write access to `flashinfer-ai/flashinfer`.
 - If not authenticated, print the issue body and prompt the user to file manually.
 
 ### SGLang PR creation fails
-- Requires `gh` CLI authenticated with write access to `sgl-project/sglang`.
+- Requires `gh` authenticated with write access to `sgl-project/sglang`.
 - If not authenticated, print the diff and PR body for manual submission.
 
 ### Workload collection fails
@@ -870,9 +382,8 @@ phases and resume from where the previous run stopped.
 - Zero tensor dumps: verify `FLASHINFER_DUMP_INCLUDE` matches the actual API name from the
   definition's `fi_api` tag.
 
-### HuggingFace PR creation fails
-- Requires `huggingface_hub` authenticated with write access to `flashinfer-ai/flashinfer-trace`.
-- Fall back to prompting the user to open the PR manually from `tmp/flashinfer-trace`.
+### Phase 4 PR creation fails
+- See [`submit-onboarding-prs`](../submit-onboarding-prs/SKILL.md) "Error Handling".
 
 ---
 
@@ -885,46 +396,50 @@ phases and resume from where the previous run stopped.
 
 ---
 
-## Integration with Other Skills
+## Running sub-phases in isolation
 
-This skill orchestrates all existing skills:
-
-```
-/onboard-model
-  └── /clone-repos         (Phase 0)
-  └── /track-models        (Phase 1 + Phase 4b)
-  └── /extract-kernel-definitions  (Phase 2b)
-  └── /collect-workloads   (Phase 3)
-```
-
-To run a sub-phase in isolation:
+Each phase has a standalone skill, so you can run any phase by itself once the manifest
+exists:
 
 ```bash
 # Just discover models (Phase 1 only)
-/onboard-model --discover --phases 1
+/discover-models --discover --manifest tmp/onboard_{model_slug}_{date}.json
 
 # Just generate definitions for a known model (Phase 2 only)
-/onboard-model --model-name qwen3-235b-a22b --phases 2
+/extract-kernel-definitions --model-name {sglang_model_name}
 
 # Just collect workloads for already-generated definitions (Phase 3 only)
-/onboard-model --model-name qwen3-235b-a22b --phases 3
+/collect-workloads --model-name {model_name} --definition-names {names}
 
 # Just submit PRs for already-collected workloads (Phase 4 only)
-/onboard-model --model-name qwen3-235b-a22b --phases 4
+/submit-onboarding-prs --manifest tmp/onboard_{model_slug}_{date}.json
 ```
 
-## Maintaining This Document
+`/onboard-model --phases N` is the same thing routed through the orchestrator (and keeps the
+manifest in sync).
 
-Update this file when:
-- New op_types are added (update Phase 1e and 3b tables)
-- FlashInfer issue / SGLang PR templates change
-- HuggingFace PR submission method changes
-- State manifest schema changes
+---
+
+## Maintaining this skill
+
+This file is a thin orchestrator. Update it only when:
+- The set of phases changes (a new phase is added or removed).
+- The run-manifest contract changes (new top-level field, new per-kernel field).
+- Phase 2a's issue template changes, or Phase 3b's SGLang PR template changes.
+
+Phase-specific procedures live in the phase skills:
+
+- Phase 1 → [`discover-models`](../discover-models/SKILL.md)
+- Phase 2 → [`extract-kernel-definitions`](../extract-kernel-definitions/SKILL.md)
+- Phase 3 → [`collect-workloads`](../collect-workloads/SKILL.md)
+- Phase 4 → [`submit-onboarding-prs`](../submit-onboarding-prs/SKILL.md)
 
 ## See Also
 
 - [clone-repos](../clone-repos/SKILL.md)
-- [track-models](../track-models/SKILL.md)
+- [discover-models](../discover-models/SKILL.md)
 - [extract-kernel-definitions](../extract-kernel-definitions/SKILL.md)
 - [collect-workloads](../collect-workloads/SKILL.md)
-- [add-reference-tests](../add-reference-tests/SKILL.md)
+- [submit-onboarding-prs](../submit-onboarding-prs/SKILL.md)
+- [add-reference-tests](../add-reference-tests/SKILL.md) (used inside `submit-onboarding-prs`)
+- [track-models](../track-models/SKILL.md) (per-op-type formula reference for Phase 1)

--- a/.claude/skills/onboard-model/SKILL.md
+++ b/.claude/skills/onboard-model/SKILL.md
@@ -24,8 +24,8 @@ Phase 3: Workload collection (only when FlashInfer has the kernel)
           └─ kernel NOT integrated into SGLang → draft + submit SGLang PR,
                                                   then collect-workloads (sglang mode)
 Phase 4: Submit PRs (per definition, not batched)
-          ├─ PR 1 → flashinfer-bench (GitHub): definition JSON + reference tests + model_coverage.mdx
-          └─ PR 2 → flashinfer-ai/flashinfer-trace (HuggingFace): baseline solution + workloads + traces + def JSON + reference tests
+          ├─ PR 1 → flashinfer-bench (GitHub): docs/model_coverage.mdx update only
+          └─ PR 2 → flashinfer-ai/flashinfer-trace (HuggingFace): definition JSON + reference tests + baseline solution + workloads + traces
 ```
 
 ## Usage
@@ -89,8 +89,8 @@ Report the SHAs in the Phase 0 summary so the user can reproduce the run.
 ## Phase 1: Model Discovery and Kernel Inventory
 
 **Goal**: Identify the target model(s), extract their required kernel set, and classify each
-kernel as *known* (definition already exists in `flashinfer_trace/definitions/`) or *new*
-(no definition file found).
+kernel as *known* (definition already exists in the HuggingFace dataset clone at
+`tmp/flashinfer-trace/definitions/`) or *new* (no definition file found there).
 
 ### 1a: Discover candidate models (when `--discover` is set)
 
@@ -142,10 +142,11 @@ complete per-op-type formulas.
 
 ### 1d: Classify each kernel
 
-For each expected definition name:
+For each expected definition name (search the HuggingFace dataset clone — definitions no
+longer live in this repo):
 
 ```bash
-find flashinfer_trace/definitions/ -name "{definition_name}.json"
+find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
 ```
 
 | Result | Classification |
@@ -239,8 +240,9 @@ gh issue create \
 ### Motivation
 
 This kernel is required for serving **{model_display_name}** with FlashInfer.
-A FlashInfer-Bench definition has been generated at:
-`flashinfer_trace/definitions/{op_type}/{definition_name}.json`
+A FlashInfer-Bench definition has been staged at:
+`tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json`
+(landing in the HuggingFace dataset PR for `flashinfer-ai/flashinfer-trace`)
 
 ### Kernel Parameters
 
@@ -286,10 +288,11 @@ Delegate to `extract-kernel-definitions` for each new definition. This skill han
 /extract-kernel-definitions --model-name {sglang_model_name}
 ```
 
-After generation, verify each expected definition now exists:
+After generation, verify each expected definition now exists in the HuggingFace dataset
+clone (the only home for definitions after the refactor):
 
 ```bash
-find flashinfer_trace/definitions/ -name "{definition_name}.json"
+find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
 ```
 
 ---
@@ -452,29 +455,37 @@ with all definitions processed in parallel using git worktrees.
 
 | # | Target repo | Content | Trigger |
 |---|-------------|---------|---------|
-| 1 | `flashinfer-ai/flashinfer-bench` (GitHub) | definition JSON + reference tests + `docs/model_coverage.mdx` | after Phase 2 |
-| 2 | `flashinfer-ai/flashinfer-trace` (HuggingFace) | baseline solution + workload JSONL + safetensors traces + def JSON + reference tests | after PR 1 is open |
+| 1 | `flashinfer-ai/flashinfer-bench` (GitHub) | `docs/model_coverage.mdx` update only | after PR 2 is open |
+| 2 | `flashinfer-ai/flashinfer-trace` (HuggingFace) | definition JSON + reference test + baseline solution + workload JSONL + safetensors blobs + eval traces | after Phase 3 |
+
+After the trace-dataset refactor the local `flashinfer_trace/` directory no longer exists in
+`flashinfer-bench`. Definitions, reference tests, workloads, blobs, baseline solutions, and
+eval traces now live **only** in the HuggingFace dataset (`flashinfer-ai/flashinfer-trace`),
+so PR 2 is the canonical destination for all of those artifacts. PR 1 in `flashinfer-bench`
+contains nothing but the coverage-doc update and a back-link to PR 2.
 
 Do **not** batch multiple definitions into a single PR. Each definition must be independently
 reviewable and mergeable.
 
 ### 4-setup: Create worktrees before spawning agents
 
-For each new definition, create two worktrees: one in the main repo (for PRs 1) and one
-in the `tmp/flashinfer-trace` clone (for PR 2). All worktrees can be created up front, then
-agents run in parallel. Run `pre-commit` for PR1.
+For each new definition, create two worktrees: one in the main repo (for PR 1 — coverage doc
+only) and one in the `tmp/flashinfer-trace` clone (for PR 2 — all dataset content). All
+worktrees can be created up front, then agents run in parallel. Run `pre-commit` in the bench
+worktree before pushing PR 1.
 
 ```bash
 DATE=$(date +%Y%m%d)
 
 # For each {definition_name} in the new definitions list:
 
-# Worktree 1: flashinfer-bench (this repo) — for definition JSON + coverage update
+# Worktree 1: flashinfer-bench (this repo) — for docs/model_coverage.mdx update
 git worktree add \
   tmp/worktrees/bench-{definition_name} \
   -b feat/def-{definition_name}
 
-# Worktree 2: flashinfer-trace (HuggingFace dataset clone) — for workload files
+# Worktree 2: flashinfer-trace (HuggingFace dataset clone) — for definition JSON,
+# reference test, baseline solution, workloads, blobs, eval traces
 git -C tmp/flashinfer-trace worktree add \
   ../worktrees/trace-{definition_name} \
   -b workloads-${DATE}-{definition_name}
@@ -486,10 +497,10 @@ flashinfer-bench/
 └── tmp/
     ├── flashinfer-trace/          # main clone (do not commit here directly)
     └── worktrees/
-        ├── bench-{def1}/          # isolated branch for def1 definition JSON + coverage
-        ├── bench-{def2}/          # isolated branch for def2
-        ├── trace-{def1}/          # isolated branch for def1 workloads (HF repo)
-        └── trace-{def2}/          # isolated branch for def2 workloads (HF repo)
+        ├── bench-{def1}/          # isolated branch for def1 model_coverage.mdx update
+        ├── bench-{def2}/          # isolated branch for def2 model_coverage.mdx update
+        ├── trace-{def1}/          # isolated branch for def1 dataset content (HF repo)
+        └── trace-{def2}/          # isolated branch for def2 dataset content (HF repo)
 ```
 
 ### 4-spawn: Run one agent per definition in parallel
@@ -508,99 +519,55 @@ Your worktrees:
 - flashinfer-trace worktree: tmp/worktrees/trace-{definition_name}/
   (branch: workloads-{date}-{definition_name})
 
-Definition file already written at:
-  flashinfer_trace/definitions/{op_type}/{definition_name}.json
+Definition file already written at (staging path inside the local clone):
+  tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json
 
 Workload files already collected at:
   tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl
   tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/
 
+NOTE: The local `flashinfer_trace/` directory in flashinfer-bench was removed in the
+trace-dataset refactor. All definitions, reference tests, workloads, blobs, baseline
+solutions, and eval traces live ONLY in the HuggingFace dataset (PR 2). PR 1 in
+flashinfer-bench contains nothing but the model_coverage.mdx update.
+
 Do the following in order:
 
-1. PR 1 — GitHub flashinfer-bench (definition JSON + reference tests + coverage):
-   - Copy flashinfer_trace/definitions/{op_type}/{definition_name}.json
-     into tmp/worktrees/bench-{definition_name}/flashinfer_trace/definitions/{op_type}/
-   - Add or update reference test in tests/ for this definition
-   - Update docs/model_coverage.mdx to reflect definition status
-   - Run `pre-commit` to format the changes
-   - Commit all three changes together and push
-   - Open PR to flashinfer-ai/flashinfer-bench
-   - Record the PR number as pr1_number
-
-2. PR 2 — HuggingFace flashinfer-trace (baseline solution + workloads + traces + def + tests):
+1. PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline
+   solution + workloads + blobs + eval traces). Open this FIRST so PR 1 can link to it.
    - Check whether a baseline solution already exists:
        ls tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/*.json 2>/dev/null
    - If baseline solution ALREADY EXISTS: skip creating a new solution and skip running eval.
      Include the existing solution directory in the PR commit as-is.
-   - If baseline solution does NOT exist: create it (see Phase 4b below) and run
-     flashinfer-bench eval — all workloads must show PASSED before opening PR2.
+   - If baseline solution does NOT exist: create it (see Phase 4a below) and run
+     flashinfer-bench eval — all workloads must show PASSED before opening PR 2.
+   - Copy definition JSON into tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
+   - Write a reference test under tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
+     (use the add-reference-tests skill — pytest validating the definition's `reference` field
+     against FlashInfer/SGLang ground truth)
    - Copy workload JSONL into tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
    - Copy safetensors blobs into tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
-   - Copy definition JSON (from flashinfer-bench) into tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
-   - Copy reference test (from flashinfer-bench) into tmp/worktrees/trace-{definition_name}/tests/{op_type}/
+   - Copy baseline eval traces into tmp/worktrees/trace-{definition_name}/traces/{op_type}/{definition_name}.jsonl
    - Commit all together and push
    - Open HuggingFace PR via huggingface_hub.HfApi().create_pull_request()
-   - Record the PR number as pr2_number
+   - Record the PR number/URL as pr2_url
+
+2. PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx ONLY):
+   - In tmp/worktrees/bench-{definition_name}/, edit docs/model_coverage.mdx to mark
+     {definition_name} as ✅ for this model (update the relevant kernel row + summary table).
+   - Do NOT add definition JSON, reference test, workloads, blobs, or solutions to this PR —
+     those live exclusively in flashinfer-trace (PR 2).
+   - Run `pre-commit run --all-files` to format the change.
+   - Commit and push.
+   - Open PR to flashinfer-ai/flashinfer-bench. PR description MUST link to pr2_url.
+   - Record the PR number as pr1_number.
 
 Report the two PR URLs when done.
 ```
 
-### 4a: PR 1 — GitHub flashinfer-bench (definition JSON + reference tests + coverage)
+### 4a: PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline solution + workloads + blobs + eval traces)
 
-Inside `tmp/worktrees/bench-{definition_name}/`:
-
-```bash
-# 1. Copy definition JSON
-cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-   tmp/worktrees/bench-{definition_name}/flashinfer_trace/definitions/{op_type}/
-
-# 2. Add or update reference test
-# Write tests/test_{op_type}_{definition_name}.py with pytest test calling
-# the reference implementation from the definition JSON
-
-# 3. Update model coverage doc
-# Edit docs/model_coverage.mdx: mark {definition_name} row as "definition added"
-
-cd tmp/worktrees/bench-{definition_name}
-git add flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-        tests/test_{op_type}_{definition_name}.py \
-        docs/model_coverage.mdx
-git commit -m "feat: add {definition_name}
-
-- Definition JSON for {op_type} ({model_display_name})
-- Reference test validating the implementation
-- Model coverage doc updated
-{If fi_missing: FlashInfer issue: flashinfer-ai/flashinfer#{issue_number}}
-"
-# Run reference test and capture output for PR description
-pytest tests/test_{op_type}_{definition_name}.py -v 2>&1 | tee /tmp/test_{definition_name}.txt
-
-pre-commit run --all-files
-git push origin feat/def-{definition_name}
-gh pr create \
-  --repo flashinfer-ai/flashinfer-bench \
-  --title "feat: add {definition_name}" \
-  --body "$(cat <<'EOF'
-## Summary
-- Adds kernel definition for `{definition_name}` ({op_type})
-- Model: {model_display_name}
-- Reference implementation sourced from: {source}
-{If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
-
-## Reference Test Results
-\`\`\`
-$(cat /tmp/test_{definition_name}.txt)
-\`\`\`
-
-## Files changed
-- `flashinfer_trace/definitions/{op_type}/{definition_name}.json`
-- `tests/test_{op_type}_{definition_name}.py`
-- `docs/model_coverage.mdx`
-EOF
-)"
-```
-
-### 4b: PR 2 — HuggingFace flashinfer-trace (baseline solution + workloads + traces + def + tests)
+PR 2 is opened **first** so PR 1 can link to it.
 
 **Check first** — if a baseline solution already exists in `tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/`, skip creating a new one and skip running `flashinfer-bench run`. Include the existing solution files in the PR commit as-is; do not regenerate eval traces.
 
@@ -609,49 +576,97 @@ Only create a new baseline solution and run eval when no solution exists yet.
 Inside `tmp/worktrees/trace-{definition_name}/`:
 
 ```bash
-# 1. Copy baseline solution (extract reference_impl field from definition JSON as standalone script)
-cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-   tmp/worktrees/trace-{definition_name}/solutions/{op_type}/{definition_name}.py
-# (extract the reference_impl field from the definition JSON as a standalone script)
+# 1. Copy kernel definition JSON (canonical home — only lives in flashinfer-trace now)
+cp tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json \
+   tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
 
-# 2. Copy workload JSONL and safetensors blobs
+# 2. Write the reference test (use the add-reference-tests skill)
+# Output: tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
+# It must validate the definition's `reference` field against FlashInfer/SGLang ground truth.
+
+# 3. Baseline solution
+# If solutions/baseline/{op_type}/{definition_name}/*.json already exists in the HF clone,
+# copy it through unchanged. Otherwise create a FlashInfer-API-wrapper baseline (NOT a
+# copy of `reference`) and run `flashinfer-bench run` to generate eval traces.
+
+# 4. Copy workload JSONL and safetensors blobs
 cp -r tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl \
       tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
 cp -r tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/ \
       tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
 
-# 3. Copy kernel definition JSON and reference test from flashinfer-bench (this repo)
-cp flashinfer_trace/definitions/{op_type}/{definition_name}.json \
-   tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
-cp tests/test_{op_type}_{definition_name}.py \
-   tmp/worktrees/trace-{definition_name}/tests/{op_type}/
+# 5. Copy eval traces (must show all entries PASSED)
+cp tmp/flashinfer-trace/traces/{op_type}/{definition_name}.jsonl \
+   tmp/worktrees/trace-{definition_name}/traces/{op_type}/
 
 cd tmp/worktrees/trace-{definition_name}
-git add solutions/{op_type}/{definition_name}.py \
+git add definitions/{op_type}/{definition_name}.json \
+        tests/references/test_{definition_name}.py \
+        solutions/baseline/{op_type}/{definition_name}/ \
         workloads/{op_type}/{definition_name}.jsonl \
         blob/workloads/{op_type}/{definition_name}/ \
-        definitions/{op_type}/{definition_name}.json \
-        tests/{op_type}/test_{op_type}_{definition_name}.py
-git commit -m "Add {definition_name}: baseline solution + workloads + traces + def + tests
+        traces/{op_type}/{definition_name}.jsonl
+git commit -m "Add {definition_name}: definition + reference test + baseline solution + workloads + traces
 
 Model: {hf_repo_id}
 SGLang: {sglang_commit_sha}
 FlashInfer: {flashinfer_commit_sha}
 Workload entries: {num_workload_entries}
-GitHub PR: flashinfer-ai/flashinfer-bench#{pr1_number}
 "
-pre-commit run --all-files
 git push origin workloads-{date}-{definition_name}
 python -c "
 from huggingface_hub import HfApi
 HfApi().create_pull_request(
     repo_id='flashinfer-ai/flashinfer-trace',
     repo_type='dataset',
-    title='Add {definition_name}: baseline solution + workloads + traces + def + tests',
+    title='Add {definition_name}: definition + reference test + baseline solution + workloads + traces',
     description='...',
     head='workloads-{date}-{definition_name}',
 )
 "
+# Record the resulting PR URL as pr2_url
+```
+
+### 4b: PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx only)
+
+After PR 2 is open and you have its URL, open PR 1 in `flashinfer-bench`. The local
+`flashinfer_trace/` directory was removed in the trace-dataset refactor, so PR 1 contains
+**only** the model-coverage doc update plus a back-link to PR 2.
+
+Inside `tmp/worktrees/bench-{definition_name}/`:
+
+```bash
+# Edit docs/model_coverage.mdx: mark {definition_name} row as ✅ for this model
+# (and update the per-model summary table).
+
+cd tmp/worktrees/bench-{definition_name}
+pre-commit run --all-files
+git add docs/model_coverage.mdx
+git commit -m "docs: mark {definition_name} as covered for {model_display_name}
+
+Tracks the dataset addition at:
+{pr2_url}
+{If fi_missing: FlashInfer issue: flashinfer-ai/flashinfer#{issue_number}}
+"
+git push origin feat/def-{definition_name}
+gh pr create \
+  --repo flashinfer-ai/flashinfer-bench \
+  --title "docs: mark {definition_name} as covered for {model_display_name}" \
+  --body "$(cat <<EOF
+## Summary
+- Marks \`{definition_name}\` ({op_type}) as covered for **{model_display_name}** in
+  \`docs/model_coverage.mdx\`.
+- Definition JSON, reference test, baseline solution, workloads, blobs, and eval traces
+  all live in the HuggingFace dataset — see ${pr2_url}.
+${If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
+
+## Files changed
+- \`docs/model_coverage.mdx\`
+
+## Linked PRs
+- HuggingFace dataset PR: ${pr2_url}
+EOF
+)"
 ```
 
 ### 4-cleanup: Remove worktrees after PRs are open
@@ -672,32 +687,45 @@ Run this checklist after both PRs are open for a definition. **Both PRs must pas
 before the definition is considered complete.** If any item fails, fix and re-push before
 requesting merge.
 
-### PR 1 — GitHub flashinfer-bench
+After the trace-dataset refactor the local `flashinfer_trace/` directory no longer exists in
+`flashinfer-bench`. The HuggingFace dataset (`flashinfer-ai/flashinfer-trace`) is the only
+home for definition JSONs, reference tests, baseline solutions, workloads, blobs, and eval
+traces — so PR 2 owns all of that. PR 1 only updates `docs/model_coverage.mdx`.
 
-1. **Definition JSON**: `flashinfer_trace/definitions/{op_type}/{name}.json` exists in the PR
-2. **Reference test**: `flashinfer_trace/tests/references/test_{name}.py` exists in the PR
-3. **Coverage**: `docs/model_coverage.mdx` updated — row for this definition shows ✅
-4. **Test results**: PR description includes the full stdout of running the reference test
-5. **PR2 link**: PR description includes a link to the HuggingFace PR 2 (workload addition)
-6. **Tags**: definition JSON has `status:verified` (or `status:unverified` if FlashInfer kernel
-   is missing), `fi_api:*`, and `ep:*`/`tp:*` if applicable
+### PR 1 — GitHub flashinfer-bench (coverage doc only)
 
-### PR 2 — HuggingFace flashinfer-trace
+1. **Coverage**: `docs/model_coverage.mdx` updated — row for `{name}` shows ✅ for
+   `{model_display_name}`, and the per-model summary table reflects the new count.
+2. **Single-file change**: the diff touches **only** `docs/model_coverage.mdx`. No
+   `flashinfer_trace/...` paths, no `tests/references/...`, no workload files, no blobs.
+   (If anything else appears in the diff it belongs in PR 2 instead.)
+3. **PR 2 link**: PR description links to the HuggingFace PR 2 by full URL.
+4. **fi_missing note (if applicable)**: if the kernel is `fi_missing`, PR description links
+   the FlashInfer kernel-request issue (`flashinfer-ai/flashinfer#{issue_number}`).
+5. **pre-commit clean**: `pre-commit run --all-files` passes locally before push.
 
-1. **Workloads**: `workloads/{op_type}/{name}.jsonl` exists and is non-empty
-2. **Blobs**: `blob/workloads/{op_type}/{name}/*.safetensors` files exist
-3. **Baseline solution**: `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json`
+### PR 2 — HuggingFace flashinfer-trace (canonical dataset)
+
+1. **Definition JSON**: `definitions/{op_type}/{name}.json` exists in the PR.
+2. **Definition tags**: definition JSON has `status:verified` (or `status:unverified` when
+   the FlashInfer kernel is missing), plus `fi_api:*` and `ep:*`/`tp:*` where applicable.
+3. **Reference test**: `tests/references/test_{name}.py` exists in the PR and pytest runs
+   green against the definition's `reference` field. PR description includes the full
+   pytest stdout.
+4. **Workloads**: `workloads/{op_type}/{name}.jsonl` exists and is non-empty.
+5. **Blobs**: `blob/workloads/{op_type}/{name}/*.safetensors` files exist.
+6. **Baseline solution**: `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json`
    exists — this must be a FlashInfer API wrapper (calls `BatchDecodeWithPagedKVCacheWrapper`
-   or `BatchPrefillWithPagedKVCacheWrapper`), **not** a copy of `reference_impl`
-4. **Eval trace**: `traces/{op_type}/{name}.jsonl` exists and every entry has
-   `evaluation.status == "PASSED"` — no failures allowed
-5. **Definition JSON**: `definitions/{op_type}/{name}.json` copied from PR 1
-6. **Reference test**: `tests/references/test_{name}.py` copied from PR 1
-7. **SGLang log**: PR description contains a `## SGLang Collection Log` section with the
+   or `BatchPrefillWithPagedKVCacheWrapper`), **not** a copy of the definition's `reference`.
+7. **Eval traces**: `traces/{op_type}/{name}.jsonl` exists and every entry has
+   `evaluation.status == "PASSED"` — no failures allowed.
+8. **SGLang log**: PR description contains a `## SGLang Collection Log` section with the
    full stdout from the `collect_workloads.py sglang` run (model loading, workload counts,
    dump dir info). Workloads must be SGLang-collected (not synthetic) — real workloads have
    diverse `(batch_size, kv_length)` pairs drawn from actual inference. A uniform sweep like
    `batch_size=4096` with 1-page contexts is a red flag for synthetic data.
+9. **Provenance**: commit/PR body records `Model`, `SGLang` and `FlashInfer` commit SHAs,
+   and the workload-entry count.
 
 ---
 
@@ -708,25 +736,33 @@ Every TASK.md for definition onboarding must include:
 
 ```markdown
 ## Objective
-Submit 2 PRs for definition {name}:
-- PR 1 (GitHub flashinfer-bench): Definition JSON + reference tests + docs/model_coverage.mdx (✅) + paste reference test stdout in PR description
-- PR 2 (HuggingFace flashinfer-trace): Baseline solution + workloads + blobs + def JSON + ref test + baseline eval trace (all entries PASSED)
+Submit 2 PRs for definition {name}. After the trace-dataset refactor, all dataset content
+lives only at HuggingFace; flashinfer-bench keeps just the coverage doc.
+- PR 2 (HuggingFace flashinfer-trace, OPEN FIRST): definition JSON + reference test +
+  baseline solution + workloads + blobs + eval traces (all entries PASSED) + SGLang
+  collection log in PR body.
+- PR 1 (GitHub flashinfer-bench, OPEN SECOND): docs/model_coverage.mdx updated to ✅
+  for this definition + back-link to PR 2 in PR body.
 
-## PR 1 Contents
-- `flashinfer_trace/definitions/{op_type}/{name}.json`
-- `flashinfer_trace/tests/references/test_{name}.py`
-- `docs/model_coverage.mdx` updated: ❌/🟡 → ✅ for this definition
-- PR description must include the full stdout of running the reference test
-- PR description must include a link to the HuggingFace PR 2 (workload addition)
-
-## PR 2 Contents
-- `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` (FlashInfer API wrapper — NOT the reference_impl from def JSON; must call flashinfer.BatchDecodeWithPagedKVCacheWrapper or flashinfer.BatchPrefillWithPagedKVCacheWrapper)
+## PR 2 Contents (HuggingFace flashinfer-trace)
+- `definitions/{op_type}/{name}.json`
+- `tests/references/test_{name}.py`
+- `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` (FlashInfer API wrapper —
+  NOT a copy of the definition `reference`; must call
+  flashinfer.BatchDecodeWithPagedKVCacheWrapper or flashinfer.BatchPrefillWithPagedKVCacheWrapper)
 - `workloads/{op_type}/{name}.jsonl`
-- `blob/workloads/{op_type}/*.safetensors`
+- `blob/workloads/{op_type}/{name}/*.safetensors`
 - `traces/{op_type}/{name}.jsonl` (all entries must have `evaluation.status == "PASSED"`)
-- `definitions/{op_type}/{name}.json` (copied from PR 1)
-- `tests/references/test_{name}.py` (copied from PR 1)
-- PR description must include the SGLang inference stdout (capture stdout of `collect_workloads.py sglang` and paste in PR body under `## SGLang Collection Log`)
+- PR description must include the full pytest stdout for the reference test
+- PR description must include the SGLang inference stdout under `## SGLang Collection Log`
+  (capture stdout of `collect_workloads.py sglang`)
+
+## PR 1 Contents (GitHub flashinfer-bench)
+- `docs/model_coverage.mdx` updated: ❌/🟡 → ✅ for this definition (and per-model summary
+  table refreshed)
+- The diff MUST touch only `docs/model_coverage.mdx` — no `flashinfer_trace/...`,
+  no `tests/references/...`, no workload/blob files (those all live in PR 2 now).
+- PR description must include a link to the HuggingFace PR 2 by full URL.
 
 ## Progress Reporting
 Write .agent-progress.md after every major step:
@@ -735,8 +771,8 @@ Write .agent-progress.md after every major step:
   Current: <what you're doing now>
   Next: <next step>
   Blockers: <if any>
-  - PR 1 (def JSON + ref tests + coverage → flashinfer-bench GitHub): <URL or pending>
-  - PR 2 (baseline solution + workloads + traces → flashinfer-trace HF): <URL or pending>
+  - PR 2 (def + ref test + baseline + workloads + traces → flashinfer-trace HF): <URL or pending>
+  - PR 1 (model_coverage.mdx → flashinfer-bench GitHub): <URL or pending>
 
 ## GPU Work
 Use tools/gpu-lock before any SGLang workload collection:
@@ -751,7 +787,7 @@ Where N matches the TP value (1 GPU for TP=1, 4 GPUs for TP=4, etc.)
 ```
 For each required kernel definition:
 
-  Already exists in flashinfer_trace/definitions/?
+  Already exists in tmp/flashinfer-trace/definitions/ (HF dataset clone)?
   ├── YES → skip (existing)
   └── NO  → Phase 2: generate definition JSON
               FlashInfer has this kernel?

--- a/.claude/skills/onboard-model/SKILL.md
+++ b/.claude/skills/onboard-model/SKILL.md
@@ -340,29 +340,6 @@ skips any kernel/phase already marked `done` — phases resume from the first in
 
 ---
 
-## Decision tree
-
-```
-For each required kernel definition:
-
-  Already exists in tmp/flashinfer-trace/definitions/ (HF dataset clone)?
-  ├── YES → skip (existing)
-  └── NO  → Phase 2: generate definition JSON
-              FlashInfer has this kernel?
-              ├── YES → /extract-kernel-definitions (status:verified)
-              │          SGLang integrates this FlashInfer API?
-              │          ├── YES → /collect-workloads
-              │          └── NO  → submit SGLang PR, wait for merge, then /collect-workloads
-              └── NO  → /extract-kernel-definitions (SGLang-sourced, status:unverified)
-                         file GitHub issue in flashinfer-ai/flashinfer
-                         ⛔ skip workload collection (no FlashInfer kernel yet)
-
-Then for each kernel that reached "ready":
-  /submit-onboarding-prs → PR 2 (HF) + PR 1 (bench coverage doc)
-```
-
----
-
 ## Error handling
 
 ### HuggingFace config unavailable
@@ -396,43 +373,19 @@ Then for each kernel that reached "ready":
 
 ---
 
-## Running sub-phases in isolation
-
-Each phase has a standalone skill, so you can run any phase by itself once the manifest
-exists:
-
-```bash
-# Just discover models (Phase 1 only)
-/discover-models --discover --manifest tmp/onboard_{model_slug}_{date}.json
-
-# Just generate definitions for a known model (Phase 2 only)
-/extract-kernel-definitions --model-name {sglang_model_name}
-
-# Just collect workloads for already-generated definitions (Phase 3 only)
-/collect-workloads --model-name {model_name} --definition-names {names}
-
-# Just submit PRs for already-collected workloads (Phase 4 only)
-/submit-onboarding-prs --manifest tmp/onboard_{model_slug}_{date}.json
-```
-
-`/onboard-model --phases N` is the same thing routed through the orchestrator (and keeps the
-manifest in sync).
-
----
-
 ## Maintaining this skill
 
 This file is a thin orchestrator. Update it only when:
 - The set of phases changes (a new phase is added or removed).
 - The run-manifest contract changes (new top-level field, new per-kernel field).
-- Phase 2a's issue template changes, or Phase 3b's SGLang PR template changes.
+- Phase 2a's issue template or Phase 3b's SGLang PR template changes.
 
-Phase-specific procedures live in the phase skills:
+All phase-specific procedures live in the phase skills linked from the overview table at
+the top — keep procedural detail there, not here.
 
-- Phase 1 → [`discover-models`](../discover-models/SKILL.md)
-- Phase 2 → [`extract-kernel-definitions`](../extract-kernel-definitions/SKILL.md)
-- Phase 3 → [`collect-workloads`](../collect-workloads/SKILL.md)
-- Phase 4 → [`submit-onboarding-prs`](../submit-onboarding-prs/SKILL.md)
+To run a single phase by itself, invoke its skill directly (each is documented in its own
+`SKILL.md`); `/onboard-model --phases N` is the same thing routed through the orchestrator
+so the manifest stays in sync.
 
 ## See Also
 

--- a/.claude/skills/submit-onboarding-prs/SKILL.md
+++ b/.claude/skills/submit-onboarding-prs/SKILL.md
@@ -1,0 +1,397 @@
+---
+name: submit-onboarding-prs
+description: Open the per-definition pair of PRs that publishes a model onboarding — PR 2 to the HuggingFace flashinfer-trace dataset (definition + reference test + baseline solution + workloads + blobs + eval traces) and PR 1 to flashinfer-bench (docs/model_coverage.mdx update only). Use as Phase 4 of /onboard-model.
+---
+
+# Submit Onboarding PRs
+
+For each new definition that has reached "ready" state (definition JSON written, workloads
+collected, baseline eval passing), open two atomic PRs in sequence:
+
+| # | Target repo | Content | Trigger |
+|---|-------------|---------|---------|
+| 2 | `flashinfer-ai/flashinfer-trace` (HuggingFace) | definition JSON + reference test + baseline solution + workload JSONL + safetensors blobs + eval traces | after Phase 3 |
+| 1 | `flashinfer-ai/flashinfer-bench` (GitHub) | `docs/model_coverage.mdx` update only | after PR 2 is open (so PR 1 can link to it) |
+
+After the trace-dataset refactor, the local `flashinfer_trace/` directory does not exist in
+`flashinfer-bench`; everything trace-related lives in the HuggingFace dataset. PR 1 is
+**only** the coverage-doc update plus a back-link to PR 2.
+
+**Rule: one definition = one pair of PRs.** Do not batch multiple definitions into one PR —
+each must be independently reviewable and mergeable.
+
+## Usage
+
+```bash
+# Process all "ready" definitions for a model (per the manifest)
+/submit-onboarding-prs --manifest tmp/onboard_qwen3-235b-a22b_20260427.json
+
+# Limit to a specific subset of definitions
+/submit-onboarding-prs \
+  --manifest tmp/onboard_qwen3-235b-a22b_20260427.json \
+  --definitions gqa_paged_decode_h40_kv8_d128_ps1,gqa_paged_decode_h40_kv8_d128_ps64
+
+# Dry-run: print the worktree plan + PR titles without committing or pushing
+/submit-onboarding-prs --manifest ... --dry-run
+```
+
+## Parameters
+
+- `--manifest` (required): Path to the onboard-model run manifest. Reads `model_slug`,
+  `hf_repo_id`, `repo_shas`, and the per-kernel statuses; writes back the `phase4` block
+  with PR URLs as it makes progress.
+- `--definitions` (optional): Comma-separated subset to process. Default: every kernel with
+  `phase2_status=done` and (`phase3_status=done` OR `fi_status=fi_missing`).
+- `--dry-run` (optional): Print the worktree layout, agent plan, and PR titles; do not write
+  commits or open PRs.
+
+## Prerequisites
+
+- `gh` CLI authenticated for `flashinfer-ai/flashinfer-bench` (PR 1).
+- `huggingface_hub` authenticated for `flashinfer-ai/flashinfer-trace` (PR 2).
+- For each definition: definition JSON in `tmp/flashinfer-trace/definitions/{op_type}/`,
+  workload JSONL + blobs in the corresponding `tmp/flashinfer-trace/workloads/` and
+  `tmp/flashinfer-trace/blob/workloads/` paths, baseline solution under
+  `tmp/flashinfer-trace/solutions/baseline/{op_type}/{name}/`, and eval traces under
+  `tmp/flashinfer-trace/traces/{op_type}/{name}.jsonl` with every entry showing
+  `evaluation.status == "PASSED"`. (`fi_missing` definitions skip workloads/baseline/traces.)
+- `pre-commit` installed (PR 1 must pass `pre-commit run --all-files`).
+
+---
+
+## Phase 4-setup: Create worktrees before spawning agents
+
+For each definition, create two worktrees up front so agents can run in parallel:
+
+```bash
+DATE=$(date +%Y%m%d)
+
+# Worktree 1: flashinfer-bench (this repo) — for docs/model_coverage.mdx update
+git worktree add \
+  tmp/worktrees/bench-{definition_name} \
+  -b feat/def-{definition_name}
+
+# Worktree 2: flashinfer-trace (HuggingFace dataset clone) — for definition JSON,
+# reference test, baseline solution, workloads, blobs, eval traces
+git -C tmp/flashinfer-trace worktree add \
+  ../worktrees/trace-{definition_name} \
+  -b workloads-${DATE}-{definition_name}
+```
+
+Worktree layout after setup:
+
+```
+flashinfer-bench/
+└── tmp/
+    ├── flashinfer-trace/          # main clone (do not commit here directly)
+    └── worktrees/
+        ├── bench-{def1}/          # isolated branch for def1 model_coverage.mdx update
+        ├── bench-{def2}/          # isolated branch for def2 model_coverage.mdx update
+        ├── trace-{def1}/          # isolated branch for def1 dataset content (HF repo)
+        └── trace-{def2}/          # isolated branch for def2 dataset content (HF repo)
+```
+
+## Phase 4-spawn: One agent per definition, in parallel
+
+Spawn all definition agents simultaneously. Each agent owns its two worktrees and submits
+both PRs end-to-end. Use this prompt template:
+
+```
+You are handling PR submission for kernel definition: {definition_name}
+
+Your worktrees:
+- flashinfer-bench worktree: tmp/worktrees/bench-{definition_name}/
+  (branch: feat/def-{definition_name})
+- flashinfer-trace worktree: tmp/worktrees/trace-{definition_name}/
+  (branch: workloads-{date}-{definition_name})
+
+Definition file already written at (staging path inside the local clone):
+  tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json
+
+Workload files already collected at:
+  tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl
+  tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/
+
+NOTE: The local `flashinfer_trace/` directory in flashinfer-bench was removed in the
+trace-dataset refactor. All definitions, reference tests, workloads, blobs, baseline
+solutions, and eval traces live ONLY in the HuggingFace dataset (PR 2). PR 1 in
+flashinfer-bench contains nothing but the model_coverage.mdx update.
+
+Do the following in order:
+
+1. PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline
+   solution + workloads + blobs + eval traces). Open this FIRST so PR 1 can link to it.
+   - Check whether a baseline solution already exists:
+       ls tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/*.json 2>/dev/null
+   - If baseline solution ALREADY EXISTS: skip creating a new solution and skip running eval.
+     Include the existing solution directory in the PR commit as-is.
+   - If baseline solution does NOT exist: create it (see Phase 4a below) and run
+     flashinfer-bench eval — all workloads must show PASSED before opening PR 2.
+   - Copy definition JSON into tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
+   - Write a reference test under tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
+     (use the add-reference-tests skill — pytest validating the definition's `reference` field
+     against FlashInfer/SGLang ground truth)
+   - Copy workload JSONL into tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
+   - Copy safetensors blobs into tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
+   - Copy baseline eval traces into tmp/worktrees/trace-{definition_name}/traces/{op_type}/{definition_name}.jsonl
+   - Commit all together and push
+   - Open HuggingFace PR via huggingface_hub.HfApi().create_pull_request()
+   - Record the PR number/URL as pr2_url
+
+2. PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx ONLY):
+   - In tmp/worktrees/bench-{definition_name}/, edit docs/model_coverage.mdx to mark
+     {definition_name} as ✅ for this model (update the relevant kernel row + summary table).
+   - Do NOT add definition JSON, reference test, workloads, blobs, or solutions to this PR —
+     those live exclusively in flashinfer-trace (PR 2).
+   - Run `pre-commit run --all-files` to format the change.
+   - Commit and push.
+   - Open PR to flashinfer-ai/flashinfer-bench. PR description MUST link to pr2_url.
+   - Record the PR number as pr1_number.
+
+Report the two PR URLs when done.
+```
+
+## Phase 4a: PR 2 — HuggingFace flashinfer-trace
+
+PR 2 is opened **first** so PR 1 can link to it.
+
+**Check first** — if a baseline solution already exists in
+`tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/`, skip creating a new
+one and skip running `flashinfer-bench run`. Include the existing solution files in the PR
+commit as-is; do not regenerate eval traces. Only create a new baseline solution and run
+eval when no solution exists yet.
+
+Inside `tmp/worktrees/trace-{definition_name}/`:
+
+```bash
+# 1. Copy kernel definition JSON (canonical home — only lives in flashinfer-trace now)
+cp tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json \
+   tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
+
+# 2. Write the reference test (use the add-reference-tests skill)
+# Output: tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
+# It must validate the definition's `reference` field against FlashInfer/SGLang ground truth.
+
+# 3. Baseline solution
+# If solutions/baseline/{op_type}/{definition_name}/*.json already exists in the HF clone,
+# copy it through unchanged. Otherwise create a FlashInfer-API-wrapper baseline (NOT a
+# copy of `reference`) and run `flashinfer-bench run` to generate eval traces.
+
+# 4. Copy workload JSONL and safetensors blobs
+cp -r tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl \
+      tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
+cp -r tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/ \
+      tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
+
+# 5. Copy eval traces (must show all entries PASSED)
+cp tmp/flashinfer-trace/traces/{op_type}/{definition_name}.jsonl \
+   tmp/worktrees/trace-{definition_name}/traces/{op_type}/
+
+cd tmp/worktrees/trace-{definition_name}
+git add definitions/{op_type}/{definition_name}.json \
+        tests/references/test_{definition_name}.py \
+        solutions/baseline/{op_type}/{definition_name}/ \
+        workloads/{op_type}/{definition_name}.jsonl \
+        blob/workloads/{op_type}/{definition_name}/ \
+        traces/{op_type}/{definition_name}.jsonl
+git commit -m "Add {definition_name}: definition + reference test + baseline solution + workloads + traces
+
+Model: {hf_repo_id}
+SGLang: {sglang_commit_sha}
+FlashInfer: {flashinfer_commit_sha}
+Workload entries: {num_workload_entries}
+"
+git push origin workloads-{date}-{definition_name}
+python -c "
+from huggingface_hub import HfApi
+HfApi().create_pull_request(
+    repo_id='flashinfer-ai/flashinfer-trace',
+    repo_type='dataset',
+    title='Add {definition_name}: definition + reference test + baseline solution + workloads + traces',
+    description='...',
+    head='workloads-{date}-{definition_name}',
+)
+"
+# Record the resulting PR URL as pr2_url
+```
+
+## Phase 4b: PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx only)
+
+After PR 2 is open and you have its URL, open PR 1. The diff must touch **only**
+`docs/model_coverage.mdx`.
+
+Inside `tmp/worktrees/bench-{definition_name}/`:
+
+```bash
+# Edit docs/model_coverage.mdx: mark {definition_name} row as ✅ for this model
+# (and update the per-model summary table).
+
+cd tmp/worktrees/bench-{definition_name}
+pre-commit run --all-files
+git add docs/model_coverage.mdx
+git commit -m "docs: mark {definition_name} as covered for {model_display_name}
+
+Tracks the dataset addition at:
+{pr2_url}
+{If fi_missing: FlashInfer issue: flashinfer-ai/flashinfer#{issue_number}}
+"
+git push origin feat/def-{definition_name}
+gh pr create \
+  --repo flashinfer-ai/flashinfer-bench \
+  --title "docs: mark {definition_name} as covered for {model_display_name}" \
+  --body "$(cat <<EOF
+## Summary
+- Marks \`{definition_name}\` ({op_type}) as covered for **{model_display_name}** in
+  \`docs/model_coverage.mdx\`.
+- Definition JSON, reference test, baseline solution, workloads, blobs, and eval traces
+  all live in the HuggingFace dataset — see ${pr2_url}.
+${If fi_missing: - ⚠️ FlashInfer kernel missing — tracking issue: flashinfer-ai/flashinfer#{issue_number}}
+
+## Files changed
+- \`docs/model_coverage.mdx\`
+
+## Linked PRs
+- HuggingFace dataset PR: ${pr2_url}
+EOF
+)"
+```
+
+## Phase 4-cleanup: Remove worktrees after PRs are open
+
+```bash
+for def in {definition_names}; do
+  git worktree remove tmp/worktrees/bench-${def}
+  git -C tmp/flashinfer-trace worktree remove ../worktrees/trace-${def}
+done
+```
+
+Update the manifest's `phase4` block with the recorded PR URLs.
+
+---
+
+## PR Review Checklist
+
+Run after both PRs are open. **Both PRs must pass all items before the definition is
+considered complete.** If any item fails, fix and re-push before requesting merge.
+
+### PR 1 — GitHub flashinfer-bench (coverage doc only)
+
+1. **Coverage**: `docs/model_coverage.mdx` updated — row for `{name}` shows ✅ for
+   `{model_display_name}`, and the per-model summary table reflects the new count.
+2. **Single-file change**: the diff touches **only** `docs/model_coverage.mdx`. No
+   `flashinfer_trace/...` paths, no `tests/references/...`, no workload files, no blobs.
+   (If anything else appears in the diff it belongs in PR 2 instead.)
+3. **PR 2 link**: PR description links to the HuggingFace PR 2 by full URL.
+4. **fi_missing note (if applicable)**: if the kernel is `fi_missing`, PR description links
+   the FlashInfer kernel-request issue (`flashinfer-ai/flashinfer#{issue_number}`).
+5. **pre-commit clean**: `pre-commit run --all-files` passes locally before push.
+
+### PR 2 — HuggingFace flashinfer-trace (canonical dataset)
+
+1. **Definition JSON**: `definitions/{op_type}/{name}.json` exists in the PR.
+2. **Definition tags**: definition JSON has `status:verified` (or `status:unverified` when
+   the FlashInfer kernel is missing), plus `fi_api:*` and `ep:*`/`tp:*` where applicable.
+3. **Reference test**: `tests/references/test_{name}.py` exists in the PR and pytest runs
+   green against the definition's `reference` field. PR description includes the full
+   pytest stdout.
+4. **Workloads**: `workloads/{op_type}/{name}.jsonl` exists and is non-empty.
+5. **Blobs**: `blob/workloads/{op_type}/{name}/*.safetensors` files exist.
+6. **Baseline solution**: `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json`
+   exists — this must be a FlashInfer API wrapper (calls `BatchDecodeWithPagedKVCacheWrapper`
+   or `BatchPrefillWithPagedKVCacheWrapper`), **not** a copy of the definition's `reference`.
+7. **Eval traces**: `traces/{op_type}/{name}.jsonl` exists and every entry has
+   `evaluation.status == "PASSED"` — no failures allowed.
+8. **SGLang log**: PR description contains a `## SGLang Collection Log` section with the
+   full stdout from the `collect_workloads.py sglang` run (model loading, workload counts,
+   dump dir info). Workloads must be SGLang-collected (not synthetic) — real workloads have
+   diverse `(batch_size, kv_length)` pairs drawn from actual inference. A uniform sweep like
+   `batch_size=4096` with 1-page contexts is a red flag for synthetic data.
+9. **Provenance**: commit/PR body records `Model`, `SGLang` and `FlashInfer` commit SHAs,
+   and the workload-entry count.
+
+---
+
+## Agent TASK.md Template
+
+When spawning an agent for a definition, write `.claude/TASK.md` in its bench worktree with
+the contents below.
+
+```markdown
+## Objective
+Submit 2 PRs for definition {name}. After the trace-dataset refactor, all dataset content
+lives only at HuggingFace; flashinfer-bench keeps just the coverage doc.
+- PR 2 (HuggingFace flashinfer-trace, OPEN FIRST): definition JSON + reference test +
+  baseline solution + workloads + blobs + eval traces (all entries PASSED) + SGLang
+  collection log in PR body.
+- PR 1 (GitHub flashinfer-bench, OPEN SECOND): docs/model_coverage.mdx updated to ✅
+  for this definition + back-link to PR 2 in PR body.
+
+## PR 2 Contents (HuggingFace flashinfer-trace)
+- `definitions/{op_type}/{name}.json`
+- `tests/references/test_{name}.py`
+- `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` (FlashInfer API wrapper —
+  NOT a copy of the definition `reference`; must call
+  flashinfer.BatchDecodeWithPagedKVCacheWrapper or flashinfer.BatchPrefillWithPagedKVCacheWrapper)
+- `workloads/{op_type}/{name}.jsonl`
+- `blob/workloads/{op_type}/{name}/*.safetensors`
+- `traces/{op_type}/{name}.jsonl` (all entries must have `evaluation.status == "PASSED"`)
+- PR description must include the full pytest stdout for the reference test
+- PR description must include the SGLang inference stdout under `## SGLang Collection Log`
+  (capture stdout of `collect_workloads.py sglang`)
+
+## PR 1 Contents (GitHub flashinfer-bench)
+- `docs/model_coverage.mdx` updated: ❌/🟡 → ✅ for this definition (and per-model summary
+  table refreshed)
+- The diff MUST touch only `docs/model_coverage.mdx` — no `flashinfer_trace/...`,
+  no `tests/references/...`, no workload/blob files (those all live in PR 2 now).
+- PR description must include a link to the HuggingFace PR 2 by full URL.
+
+## Progress Reporting
+Write .agent-progress.md after every major step:
+  Status: in_progress | completed | blocked
+  Done: <what's done>
+  Current: <what you're doing now>
+  Next: <next step>
+  Blockers: <if any>
+  - PR 2 (def + ref test + baseline + workloads + traces → flashinfer-trace HF): <URL or pending>
+  - PR 1 (model_coverage.mdx → flashinfer-bench GitHub): <URL or pending>
+
+## GPU Work
+Use tools/gpu-lock before any SGLang workload collection:
+  tools/gpu-lock --gpus <N> --exec-timeout 1800 -- python collect_workloads.py ...
+Where N matches the TP value (1 GPU for TP=1, 4 GPUs for TP=4, etc.)
+```
+
+---
+
+## Output: run-manifest update
+
+When invoked with `--manifest`, append/update the `phase4` block per definition:
+
+```json
+{
+  "phase4": {
+    "gqa_paged_decode_h40_kv8_d128_ps1": {
+      "flashinfer_trace_pr": "https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace/discussions/42",
+      "flashinfer_bench_pr": "https://github.com/flashinfer-ai/flashinfer-bench/pull/57"
+    }
+  }
+}
+```
+
+## Error Handling
+
+- **HuggingFace PR creation fails**: requires `huggingface_hub` authenticated with write
+  access to `flashinfer-ai/flashinfer-trace`. Fall back to opening the PR manually from the
+  worktree.
+- **GitHub PR creation fails**: requires `gh` authenticated with write access to
+  `flashinfer-ai/flashinfer-bench`. Print the diff and PR body for manual submission.
+- **`pre-commit` failure**: do not bypass with `--no-verify`. Fix the formatting and create
+  a new commit.
+
+## See Also
+
+- [onboard-model](../onboard-model/SKILL.md) — pipeline that invokes this skill at Phase 4
+- [discover-models](../discover-models/SKILL.md) — Phase 1 counterpart
+- [collect-workloads](../collect-workloads/SKILL.md) — produces workload JSONL + blobs
+- [add-reference-tests](../add-reference-tests/SKILL.md) — produces the reference test in PR 2

--- a/.claude/skills/submit-onboarding-prs/SKILL.md
+++ b/.claude/skills/submit-onboarding-prs/SKILL.md
@@ -93,63 +93,11 @@ flashinfer-bench/
 
 ## Phase 4-spawn: One agent per definition, in parallel
 
-Spawn all definition agents simultaneously. Each agent owns its two worktrees and submits
-both PRs end-to-end. Use this prompt template:
-
-```
-You are handling PR submission for kernel definition: {definition_name}
-
-Your worktrees:
-- flashinfer-bench worktree: tmp/worktrees/bench-{definition_name}/
-  (branch: feat/def-{definition_name})
-- flashinfer-trace worktree: tmp/worktrees/trace-{definition_name}/
-  (branch: workloads-{date}-{definition_name})
-
-Definition file already written at (staging path inside the local clone):
-  tmp/flashinfer-trace/definitions/{op_type}/{definition_name}.json
-
-Workload files already collected at:
-  tmp/flashinfer-trace/workloads/{op_type}/{definition_name}.jsonl
-  tmp/flashinfer-trace/blob/workloads/{op_type}/{definition_name}/
-
-NOTE: The local `flashinfer_trace/` directory in flashinfer-bench was removed in the
-trace-dataset refactor. All definitions, reference tests, workloads, blobs, baseline
-solutions, and eval traces live ONLY in the HuggingFace dataset (PR 2). PR 1 in
-flashinfer-bench contains nothing but the model_coverage.mdx update.
-
-Do the following in order:
-
-1. PR 2 — HuggingFace flashinfer-trace (definition JSON + reference test + baseline
-   solution + workloads + blobs + eval traces). Open this FIRST so PR 1 can link to it.
-   - Check whether a baseline solution already exists:
-       ls tmp/flashinfer-trace/solutions/baseline/{op_type}/{definition_name}/*.json 2>/dev/null
-   - If baseline solution ALREADY EXISTS: skip creating a new solution and skip running eval.
-     Include the existing solution directory in the PR commit as-is.
-   - If baseline solution does NOT exist: create it (see Phase 4a below) and run
-     flashinfer-bench eval — all workloads must show PASSED before opening PR 2.
-   - Copy definition JSON into tmp/worktrees/trace-{definition_name}/definitions/{op_type}/
-   - Write a reference test under tmp/worktrees/trace-{definition_name}/tests/references/test_{definition_name}.py
-     (use the add-reference-tests skill — pytest validating the definition's `reference` field
-     against FlashInfer/SGLang ground truth)
-   - Copy workload JSONL into tmp/worktrees/trace-{definition_name}/workloads/{op_type}/
-   - Copy safetensors blobs into tmp/worktrees/trace-{definition_name}/blob/workloads/{op_type}/
-   - Copy baseline eval traces into tmp/worktrees/trace-{definition_name}/traces/{op_type}/{definition_name}.jsonl
-   - Commit all together and push
-   - Open HuggingFace PR via huggingface_hub.HfApi().create_pull_request()
-   - Record the PR number/URL as pr2_url
-
-2. PR 1 — GitHub flashinfer-bench (docs/model_coverage.mdx ONLY):
-   - In tmp/worktrees/bench-{definition_name}/, edit docs/model_coverage.mdx to mark
-     {definition_name} as ✅ for this model (update the relevant kernel row + summary table).
-   - Do NOT add definition JSON, reference test, workloads, blobs, or solutions to this PR —
-     those live exclusively in flashinfer-trace (PR 2).
-   - Run `pre-commit run --all-files` to format the change.
-   - Commit and push.
-   - Open PR to flashinfer-ai/flashinfer-bench. PR description MUST link to pr2_url.
-   - Record the PR number as pr1_number.
-
-Report the two PR URLs when done.
-```
+Spawn all definition agents simultaneously. Each agent owns its two worktrees and runs
+**Phase 4a then Phase 4b** (below) end-to-end. Write a `.claude/TASK.md` into each agent's
+bench worktree using the [TASK.md template](#agent-taskmd-template) and include the two
+worktree paths plus the staging paths for the definition JSON, workloads, and blobs. The
+agent reports the two PR URLs when done.
 
 ## Phase 4a: PR 2 — HuggingFace flashinfer-trace
 
@@ -311,55 +259,80 @@ considered complete.** If any item fails, fix and re-push before requesting merg
 
 ---
 
-## Agent TASK.md Template
+## Fixing PR checklist failures
 
-When spawning an agent for a definition, write `.claude/TASK.md` in its bench worktree with
-the contents below.
+When a checklist item fails on an already-open PR, fix it in the same worktree and push a
+follow-up commit to the same branch — both PR 1 and PR 2 update in place. **Never close and
+re-open a PR for a fixable item**, and **never amend the head commit after the PR has been
+reviewed** (push a new commit instead).
+
+### PR 1 — flashinfer-bench (coverage doc only)
+
+| Failed item | Fix |
+|-------------|-----|
+| 1. Coverage row not ✅ | Edit `docs/model_coverage.mdx`: flip the `{name}` row to ✅ for `{model_display_name}` and bump the per-model summary count. Commit + push to `feat/def-{name}`. |
+| 2. Diff touches paths other than `docs/model_coverage.mdx` | `git restore --staged --source=origin/main -- :^docs/model_coverage.mdx` in the bench worktree; commit the cleaned diff. Anything you remove here belongs in the PR 2 worktree — re-stage it there if needed. |
+| 3. Missing PR 2 link | `gh pr edit {pr1_number} --body-file -` and re-paste the body with the full HF PR URL. |
+| 4. Missing fi_missing issue link | Same — append the `flashinfer-ai/flashinfer#{issue_number}` line to the PR body. |
+| 5. pre-commit failed | Run `pre-commit run --all-files` in the bench worktree, fix what it reports, commit + push (do **not** use `--no-verify`). |
+
+### PR 2 — flashinfer-trace (HuggingFace)
+
+| Failed item | Fix |
+|-------------|-----|
+| 1. Definition JSON missing | Copy from `tmp/flashinfer-trace/definitions/{op_type}/{name}.json` into the trace worktree at the same path. Commit + `git push origin workloads-{date}-{name}`. |
+| 2. Definition tags wrong | Edit the `tags` array in the JSON inside the worktree (`status:verified`/`status:unverified`, `fi_api:*`, `tp:*`/`ep:*`). Re-validate with `flashinfer-bench validate --dataset tmp/worktrees/trace-{name}`. Commit + push. |
+| 3. Reference test missing or red | Run `/add-reference-tests --definition-name {name}`, save output under `tests/references/test_{name}.py` in the trace worktree, then `pytest tests/references/test_{name}.py -v` until green. Paste the full pytest stdout into the PR body via `huggingface_hub.HfApi().edit_discussion(...)` (or the dataset web UI). |
+| 4. Workload JSONL missing/empty | Re-run `/collect-workloads --definition-names {name} --model-name {model}`, then copy the regenerated `workloads/{op_type}/{name}.jsonl` into the trace worktree. Commit + push. |
+| 5. Blobs missing | Same flow as item 4 — `collect-workloads` writes the safetensors to `blob/workloads/{op_type}/{name}/`; copy them into the worktree. |
+| 6. Baseline solution wrong (copies `reference` instead of wrapping FlashInfer) | Replace `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` with one that calls the actual FlashInfer wrapper (`BatchDecodeWithPagedKVCacheWrapper` etc.). Re-run `flashinfer-bench run` to regenerate the eval trace, then commit both. |
+| 7. Eval traces have non-PASSED entries | Inspect failing entries first — usually a baseline/wrapper bug or a tolerance issue. Fix the baseline (item 6) or the workload (items 4–5), re-run `flashinfer-bench run`, and commit the regenerated `traces/{op_type}/{name}.jsonl` only after every entry shows `evaluation.status == "PASSED"`. |
+| 8. SGLang collection log missing or shows synthetic data | Re-run `/collect-workloads` with the real SGLang config (correct `--model-name`, full prompt set). Capture stdout to a file and paste it into the PR body under `## SGLang Collection Log`. A red flag is uniform `(batch_size, kv_length)` pairs — that's synthetic, not real inference. |
+| 9. Provenance missing | Append `Model: {hf_repo_id}`, `SGLang: {sglang_sha}`, `FlashInfer: {flashinfer_sha}`, and `Workload entries: {count}` to the PR description (and the next commit message if you push another commit). |
+
+After any PR 2 fix, refresh the PR description so the pytest stdout / SGLang log reflect
+the latest state — old log output can mask the real status.
+
+If the failure is a structural mistake (e.g. PR 1 contains workload files, PR 2 doesn't
+contain the definition JSON), the cleanest recovery is to fix the worktrees and force-push
+**only the per-definition feature branch** (never the dataset's `main`). Coordinate with the
+reviewer before force-pushing a PR they've already reviewed.
+
+---
+
+## Agent TASK.md template
+
+Write `.claude/TASK.md` into each agent's bench worktree. Keep it short — the canonical
+content lives in [Phase 4a/4b](#phase-4a-pr-2--huggingface-flashinfer-trace) and the
+[PR Review Checklist](#pr-review-checklist).
 
 ```markdown
 ## Objective
-Submit 2 PRs for definition {name}. After the trace-dataset refactor, all dataset content
-lives only at HuggingFace; flashinfer-bench keeps just the coverage doc.
-- PR 2 (HuggingFace flashinfer-trace, OPEN FIRST): definition JSON + reference test +
-  baseline solution + workloads + blobs + eval traces (all entries PASSED) + SGLang
-  collection log in PR body.
-- PR 1 (GitHub flashinfer-bench, OPEN SECOND): docs/model_coverage.mdx updated to ✅
-  for this definition + back-link to PR 2 in PR body.
+Submit two PRs for definition `{name}` per Phase 4a then Phase 4b in
+`.claude/skills/submit-onboarding-prs/SKILL.md`. PR 2 (HF flashinfer-trace) opens first;
+PR 1 (flashinfer-bench coverage doc) opens second and links to PR 2.
 
-## PR 2 Contents (HuggingFace flashinfer-trace)
-- `definitions/{op_type}/{name}.json`
-- `tests/references/test_{name}.py`
-- `solutions/baseline/{op_type}/{name}/flashinfer_wrapper_*.json` (FlashInfer API wrapper —
-  NOT a copy of the definition `reference`; must call
-  flashinfer.BatchDecodeWithPagedKVCacheWrapper or flashinfer.BatchPrefillWithPagedKVCacheWrapper)
-- `workloads/{op_type}/{name}.jsonl`
-- `blob/workloads/{op_type}/{name}/*.safetensors`
-- `traces/{op_type}/{name}.jsonl` (all entries must have `evaluation.status == "PASSED"`)
-- PR description must include the full pytest stdout for the reference test
-- PR description must include the SGLang inference stdout under `## SGLang Collection Log`
-  (capture stdout of `collect_workloads.py sglang`)
+## Worktrees
+- bench: `tmp/worktrees/bench-{name}/`  (branch `feat/def-{name}`)
+- trace: `tmp/worktrees/trace-{name}/`  (branch `workloads-{date}-{name}`)
 
-## PR 1 Contents (GitHub flashinfer-bench)
-- `docs/model_coverage.mdx` updated: ❌/🟡 → ✅ for this definition (and per-model summary
-  table refreshed)
-- The diff MUST touch only `docs/model_coverage.mdx` — no `flashinfer_trace/...`,
-  no `tests/references/...`, no workload/blob files (those all live in PR 2 now).
-- PR description must include a link to the HuggingFace PR 2 by full URL.
+## Staging paths (already populated by earlier phases)
+- definition: `tmp/flashinfer-trace/definitions/{op_type}/{name}.json`
+- workloads:  `tmp/flashinfer-trace/workloads/{op_type}/{name}.jsonl`
+- blobs:      `tmp/flashinfer-trace/blob/workloads/{op_type}/{name}/`
 
-## Progress Reporting
-Write .agent-progress.md after every major step:
-  Status: in_progress | completed | blocked
-  Done: <what's done>
-  Current: <what you're doing now>
-  Next: <next step>
-  Blockers: <if any>
-  - PR 2 (def + ref test + baseline + workloads + traces → flashinfer-trace HF): <URL or pending>
-  - PR 1 (model_coverage.mdx → flashinfer-bench GitHub): <URL or pending>
+## Done criteria
+Every item in the PR Review Checklist (PR 1 + PR 2) passes. Use the
+[fix-up table](#fixing-pr-checklist-failures) when an item is missing after the PR is open.
 
-## GPU Work
-Use tools/gpu-lock before any SGLang workload collection:
-  tools/gpu-lock --gpus <N> --exec-timeout 1800 -- python collect_workloads.py ...
-Where N matches the TP value (1 GPU for TP=1, 4 GPUs for TP=4, etc.)
+## Progress reporting
+Append to `.agent-progress.md` after each step (Status / Done / Current / Next / Blockers,
+plus the two PR URLs when each is open).
+
+## GPU work
+Use `tools/gpu-lock` before any SGLang workload collection:
+`tools/gpu-lock --gpus <N> --exec-timeout 1800 -- python collect_workloads.py ...`
+where N matches the TP value (1 GPU for TP=1, 4 GPUs for TP=4, etc.).
 ```
 
 ---

--- a/.claude/skills/track-models/SKILL.md
+++ b/.claude/skills/track-models/SKILL.md
@@ -34,8 +34,10 @@ Discover popular or newly released open-source LLMs, determine their kernel cove
 ## Prerequisites
 
 - `docs/model_coverage.mdx` must exist (it does — managed by this skill)
-- `flashinfer_trace/definitions/` must exist with current definition JSON files
-- Run `/clone-repos` first if you need SGLang or sgl-cookbook configs for a model that isn't in the existing patterns
+- `tmp/flashinfer-trace/definitions/` must exist with current definition JSON files
+  (this is the HuggingFace dataset clone — populated by `/clone-repos`; the in-repo
+  `flashinfer_trace/` directory was removed in the trace-dataset refactor)
+- Run `/clone-repos` first if you need SGLang or sgl-cookbook configs for a model that isn't in the existing patterns, or to ensure the trace dataset clone is current
 
 ---
 
@@ -203,7 +205,7 @@ If no sgl-cookbook config exists, use TP=1 (single GPU baseline).
 
 ### Phase 3: Map Kernels to Definitions
 
-For each model, compute the full list of expected definition names, then check which ones exist in `flashinfer_trace/definitions/`.
+For each model, compute the full list of expected definition names, then check which ones exist in `tmp/flashinfer-trace/definitions/` (the HF dataset clone — the only location where definition JSONs live).
 
 #### 3a: Compute expected definitions
 
@@ -265,11 +267,11 @@ Where `ckv_dim = kv_lora_rank + qk_rope_head_dim` and `kpe_dim = qk_rope_head_di
 
 For each expected definition name, check:
 ```bash
-find flashinfer_trace/definitions/ -name "{definition_name}.json"
+find tmp/flashinfer-trace/definitions/ -name "{definition_name}.json"
 ```
 
 Assign status:
-- **✅** — JSON file exists in `flashinfer_trace/definitions/`
+- **✅** — JSON file exists in `tmp/flashinfer-trace/definitions/`
 - **❌** — Name computed from model config, but no JSON file found (missing, needs to be created)
 - **—** — Module exists in the model architecture but definition is not computed/mapped (unmapped)
 
@@ -472,7 +474,7 @@ This skill is also called by `onboard-model` (Phase 1 and Phase 4b) to update
 
 ### Definition file naming ambiguity
 - **Cause**: Computed name doesn't match any definition (off-by-one in dims, different naming convention)
-- **Handling**: Mark as ❌ and list the computed name in the detailed section. Cross-check with actual files in `flashinfer_trace/definitions/` before marking as missing.
+- **Handling**: Mark as ❌ and list the computed name in the detailed section. Cross-check with actual files in `tmp/flashinfer-trace/definitions/` before marking as missing.
 
 ### Model not in SGLang
 - **Cause**: Model isn't implemented in SGLang yet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,6 @@ flashinfer-bench/
 │   ├── integration/            #   FlashInfer integration
 │   ├── tracing/                #   Workload tracing utilities
 │   └── agents/                 #   Agent orchestration tools
-├── flashinfer_trace/           # Internal trace dataset (see below)
-│   ├── definitions/            #   Kernel definition JSON files, by op_type
-│   ├── tests/                  #   Definition tests and reference tests
-│   └── workloads/              #   Workload JSONL files
 ├── tests/                      # Pytest test suite
 ├── scripts/                    # Standalone scripts (workload collection, sanitization)
 ├── tools/                      # Developer tools (GPU locking, etc.)
@@ -44,40 +40,48 @@ flashinfer-bench/
 ├── web/                        # Web UI for visualization
 ├── examples/                   # Example code and benchmarks
 ├── .claude/skills/             # Agent skill definitions (see below)
-└── tmp/                        # Cloned external repos (SGLang, FlashInfer, sgl-cookbook)
+└── tmp/                        # Cloned external repos, including the
+                                #   flashinfer-trace HF dataset clone
+                                #   (SGLang, FlashInfer, sgl-cookbook, flashinfer-trace)
 ```
 
 ## Trace Dataset
 
-### Internal Trace Layer (`flashinfer_trace/`)
+### Single source of truth: HuggingFace
 
-The `flashinfer_trace/` directory is the repo-managed trace layer. Definitions are organized
-by `op_type` subdirectory:
+The canonical (and only) trace dataset lives at
+[`flashinfer-ai/flashinfer-trace`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace)
+on HuggingFace. It contains definitions, reference tests, baseline solutions, workloads,
+blobs, and evaluation traces.
+
+There is **no** in-repo `flashinfer_trace/` directory in `flashinfer-bench`. The earlier
+"internal trace layer" was removed in the trace-dataset refactor (PR #418); definitions,
+reference tests, and workloads no longer live here. Skills that need to read or edit trace
+content do so through a local clone of the HF dataset at `tmp/flashinfer-trace/`:
 
 ```
-flashinfer_trace/
+tmp/flashinfer-trace/                  # local clone of the HuggingFace dataset
 ├── definitions/{op_type}/{definition_name}.json
 ├── tests/references/test_{definition_name}.py
-└── workloads/{op_type}/{definition_name}.jsonl
+├── solutions/baseline/{op_type}/{definition_name}/...
+├── workloads/{op_type}/{definition_name}.jsonl
+├── blob/workloads/{op_type}/{definition_name}/*.safetensors
+└── traces/{op_type}/{definition_name}.jsonl
 ```
 
-Browse `flashinfer_trace/definitions/` to see the current set of supported op_types.
-Each op_type subdirectory contains one JSON file per kernel definition.
-
-### External Dataset
-
-The canonical published dataset lives at
-[`flashinfer-ai/flashinfer-trace`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace)
-on HuggingFace. It contains definitions, baseline solutions, workloads, and evaluation traces.
+Browse `tmp/flashinfer-trace/definitions/` to see the current set of supported op_types
+once `/clone-repos` has been run.
 
 ### Lifecycle
 
-1. Generate or update definitions in the internal `flashinfer_trace/` directory
-2. Open a PR in this repository for review
-3. After merge, manually sync to the external HuggingFace dataset
+1. Run `/clone-repos` to ensure `tmp/flashinfer-trace/` is checked out and up to date.
+2. Generate or update content under `tmp/flashinfer-trace/` and commit on a feature branch.
+3. Open a PR against the HuggingFace dataset repo (PR 2 in the onboard-model flow).
+4. Open a companion PR against `flashinfer-bench` that updates **only** `docs/model_coverage.mdx`
+   to reflect the new coverage (PR 1 in the onboard-model flow).
 
-New definitions should always be generated into the internal trace layer first.
-The external dataset is not the primary edit surface.
+The HuggingFace dataset is the primary edit surface — flashinfer-bench owns code, docs,
+and the coverage doc, not the trace data itself.
 
 ### Definition JSON Structure
 
@@ -107,7 +111,7 @@ Key conventions:
   local expert counts). Other kernel types (normalization, GEMM, RoPE, sampling) are
   parallelism-agnostic. See the `extract-kernel-definitions` skill for the full rules.
 
-Refer to `flashinfer_trace/definition.md` for the complete schema documentation.
+Refer to `docs/flashinfer-trace/definition.mdx` for the complete schema documentation.
 
 ## Documentation Structure (`docs/`)
 
@@ -176,13 +180,6 @@ Start with `.claude/skills/`. Each subdirectory contains a `SKILL.md` with full 
 
 ## Common Misunderstandings
 
-### `flashinfer_trace/` is the complete dataset
-
-Not necessarily. `flashinfer_trace/` is the internal repo-managed trace layer. The canonical
-published dataset lives at
-[`flashinfer-ai/flashinfer-trace`](https://huggingface.co/datasets/flashinfer-ai/flashinfer-trace)
-on HuggingFace and may contain additional content (baseline solutions, evaluation traces).
-
 ### Tracing and apply are unrelated entry points
 
 They are different runtimes, but the `apply(...)` call path is a shared entry point for both
@@ -203,13 +200,14 @@ workloads.
 
 To add a new op_type beyond what currently exists:
 
-1. Create operation documentation in `docs/op_type_schema/`
-2. Create Definition JSON files under `flashinfer_trace/definitions/{new_op_type}/`
+1. Create operation documentation in `docs/op-types/`
+2. Create Definition JSON files under `tmp/flashinfer-trace/definitions/{new_op_type}/`
+   (the HuggingFace dataset clone — submit via a PR to `flashinfer-ai/flashinfer-trace`)
 3. Provide a Python reference implementation in the definition's `reference` field
 4. Create Solution implementations (Triton/CUDA optimized)
 5. Optionally create a FlashInfer adapter in `flashinfer_bench/integration/`
 
-The existing op_type directories under `flashinfer_trace/definitions/` serve as templates.
+The existing op_type directories under `tmp/flashinfer-trace/definitions/` serve as templates.
 
 ## Maintenance Notes
 
@@ -229,5 +227,5 @@ op_type-specific details belong in their respective skill files.
 - [FlashInfer Documentation](https://docs.flashinfer.ai)
 - [SGLang GitHub](https://github.com/sgl-project/sglang)
 - [HuggingFace Hub](https://huggingface.co/models)
-- [Definition Schema Documentation](flashinfer_trace/definition.md)
-- [Operation Type Schema](docs/op_type_schema/)
+- [Definition Schema Documentation](docs/flashinfer-trace/definition.mdx)
+- [Operation Type Schema](docs/op-types/)


### PR DESCRIPTION
## Summary

Promote the two inline phases of `/onboard-model` into their own skills so each phase
can be invoked, debugged, and resumed independently. The orchestrator becomes a thin
contract that chains the phase skills via a shared run manifest. Also adds an explicit
fix-up table for when an open PR fails the PR Review Checklist.

> Stacks on top of #421 (HF-only trace dataset alignment). The diff against `main`
> includes both that PR's commits and this one — please merge #421 first; this PR will
> rebase cleanly afterward.

## What changed

- **New skill `discover-models`** (Phase 1): candidate-model discovery + kernel
  inventory + `fi_supported`/`fi_missing` and `sgl_integrated`/`sgl_missing`
  classification. Writes the `kernels[]` array of the run manifest.
- **New skill `submit-onboarding-prs`** (Phase 4): per-definition worktrees + agent
  fan-out + PR 2 → HuggingFace flashinfer-trace + PR 1 → flashinfer-bench coverage doc,
  plus the PR Review Checklist and the Agent TASK.md template.
- **Slimmed `onboard-model`** (930 → 398 lines): now a thin orchestrator that chains
  `/clone-repos` → `/discover-models` → `/extract-kernel-definitions` (+ inline
  `gh issue create` for `fi_missing`) → `/collect-workloads` (+ inline SGLang PR for
  `sgl_missing`) → `/submit-onboarding-prs`. The run manifest at
  `tmp/onboard_{slug}_{date}.json` is the contract that flows state between skills.
- **Redundancy cuts**:
  - Removed the agent-prompt template that re-stated Phase 4a/4b verbatim
    (~50 lines).
  - Trimmed the agent TASK.md template (no longer re-lists checklist items).
  - Dropped the Decision tree section (overlapped the phase overview table).
  - Dropped "Running sub-phases in isolation" (each phase already shows the
    standalone command at its heading).
- **New: "Fixing PR checklist failures"** in `submit-onboarding-prs/SKILL.md` — a
  two-table reference (PR 1 + PR 2) mapping every checklist item to its remediation.
  Calls out the rules: never close-and-reopen for a fixable item, never bypass
  `pre-commit`, never force-push someone else's reviewed PR without coordinating.

## Phase contract (run manifest)

```json
{
  "model_slug": "...",
  "hf_repo_id": "...",
  "repo_shas": { "sglang": "...", "flashinfer": "...", ... },
  "kernels": [
    {
      "definition_name": "...",
      "phase1_status": "new|existing",
      "fi_status": "fi_supported|fi_missing",
      "sgl_status": "sgl_integrated|sgl_missing|n/a",
      "phase2_status": "done|...",
      "phase3_status": "done|skipped (fi_missing)",
      "fi_issue_url": "..."
    }
  ],
  "phase4": { "{name}": { "flashinfer_trace_pr": "...", "flashinfer_bench_pr": "..." } }
}
```

`/discover-models` writes the kernels array; `/submit-onboarding-prs` writes `phase4`;
intermediate skills update their per-phase status fields.

## Test plan

- [ ] Walk through onboard-model overview → confirm each phase points at the right
      sub-skill and the table matches the body.
- [ ] Open `submit-onboarding-prs/SKILL.md` and verify each PR Review Checklist item
      has a corresponding row in the fix-up table.
- [ ] Sanity-check the `discover-models` output schema matches what `onboard-model`
      claims to consume (`phase1_status`, `fi_status`, `sgl_status`).
- [ ] Re-read the slim onboard-model — is the inline content (Phase 2a issue body,
      Phase 3b SGLang PR template) still substantive enough to act on, or should
      either of those also move into a dedicated skill?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized model onboarding workflow into dedicated skills for each phase
  * Added new model discovery skill for identifying candidate LLMs
  * Introduced PR submission skill for streamlined model onboarding
  * Updated workflow prerequisites and manifest structure for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->