### PR TITLE
feat: add synthetic random dataset ported from InferenceX benchmark 

### DIFF
--- a/.claude/skills/collect-workloads-bench/SKILL.md
+++ b/.claude/skills/collect-workloads-bench/SKILL.md
@@ -4,7 +4,7 @@ Collect real workloads using `examples/sglang_bench/bench_serving.py` as the ser
 launcher. This is an improved alternative to `collect_workloads.py sglang` that:
 
 - Pulls model-specific server flags (TP, EP, attention-backend, etc.) from `examples/sglang_bench/model_configs.json`
-- Uses ShareGPT prompts with batch sweeps for diverse (batch_size, kv_len) coverage
+- Drives the server with random or ShareGPT prompts (default `--dataset random`, controlled via `--isl`/`--osl`) for diverse `(batch_size, kv_len)` coverage
 - Handles server lifecycle cleanly via `popen_launch_server` / `kill_process_tree`
 - Still uses the same FlashInfer Level-10 tensor dump + `sanitize_dumps.py` pipeline
 

--- a/.claude/skills/collect-workloads-bench/SKILL.md
+++ b/.claude/skills/collect-workloads-bench/SKILL.md
@@ -1,6 +1,6 @@
 # collect-workloads-bench
 
-Collect real workloads using `examples/sglang_bench/bench_sharegpt.py` as the server
+Collect real workloads using `examples/sglang_bench/bench_serving.py` as the server
 launcher. This is an improved alternative to `collect_workloads.py sglang` that:
 
 - Pulls model-specific server flags (TP, EP, attention-backend, etc.) from `examples/sglang_bench/model_configs.json`
@@ -34,13 +34,13 @@ Edit `examples/sglang_bench/model_configs.json` to add/confirm entry:
 ```
 For paged prefill: always include `--disable-radix-cache` and `--enable-deterministic-inference`.
 
-### 2. Set FlashInfer Level-10 dump env vars and run bench_sharegpt.py (incremental)
+### 2. Set FlashInfer Level-10 dump env vars and run bench_serving.py (incremental)
 
 Run one batch size at a time to avoid node overload. After each run, sanitize to collect
 2–3 workloads, then delete the dump dir before the next run.
 
 **Multi-node auto-detection**: when model config TP > local GPU count (e.g. TP=8 config but
-only 4 GPUs visible via `nvidia-smi`), `bench_sharegpt.py` automatically triggers multi-node
+only 4 GPUs visible via `nvidia-smi`), `bench_serving.py` automatically triggers multi-node
 mode. Peer nodes are discovered from `SLURM_JOB_ID`; workers are launched via SSH.
 FLASHINFER dump env vars are forwarded only to the head node (rank 0) — workers don't dump.
 Passwordless SSH between allocated nodes is required (standard in SLURM environments).
@@ -48,7 +48,7 @@ Passwordless SSH between allocated nodes is required (standard in SLURM environm
 ```bash
 DUMP_DIR=/tmp/flashinfer_dumps_<name>
 TRACE_DIR=<trace_dir>
-LOG=/tmp/bench_sharegpt_<name>.log
+LOG=/tmp/bench_serving_<name>.log
 
 cd /home/averyh/flashinfer-bench
 
@@ -69,7 +69,7 @@ for BS in 1 64 128 256; do
       FLASHINFER_DISABLE_VERSION_CHECK=1 \
       SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK=1 \
       SGLANG_ENABLE_TP_MEMORY_INBALANCE_CHECK=0 \
-    python examples/sglang_bench/bench_sharegpt.py \
+    python examples/sglang_bench/bench_serving.py \
       --model <model-key> \
       --model-path <model-path> \
       --batch-sizes $BS \
@@ -78,7 +78,7 @@ for BS in 1 64 128 256; do
       2>&1 | tee -a $LOG
 
   # Kill any lingering processes (including remote workers if multi-node)
-  pkill -f bench_sharegpt.py || true
+  pkill -f bench_serving.py || true
   pkill -f sglang.launch_server || true
 
   # Sanitize (no --replace so workloads from previous batch sizes are kept)
@@ -92,7 +92,7 @@ for BS in 1 64 128 256; do
 done
 ```
 
-#### Multi-node flags (bench_sharegpt.py)
+#### Multi-node flags (bench_serving.py)
 
 | Flag | Default | Purpose |
 |------|---------|---------|
@@ -102,7 +102,7 @@ done
 | `--conda-env ENV` | `$CONDA_DEFAULT_ENV` | Fallback: conda env for peer SSH (only used when `sys.executable` is a relative path, i.e. non-NFS clusters) |
 
 **Peer worker SSH environment**: on NFS-shared clusters (e.g. SLURM where `/home` is shared),
-`bench_sharegpt.py` passes `sys.executable` (absolute path) as the Python binary on the remote
+`bench_serving.py` passes `sys.executable` (absolute path) as the Python binary on the remote
 node — no conda activation needed. It also passes:
 
 - `CUDA_HOME=<conda_prefix>`: `deep_gemm` checks this first; conda prefix contains nvcc/include/lib
@@ -151,7 +151,7 @@ CPATH="$(python -c "import sys,pathlib; print(':'.join(str(p) for p in pathlib.P
 **Manual peer override** (when not in SLURM or peer auto-detection fails):
 ```bash
 SLURM_JOB_NODELIST=head-node,peer-node \
-python examples/sglang_bench/bench_sharegpt.py \
+python examples/sglang_bench/bench_serving.py \
   --model deepseek-v3 --model-path /nfs/path/to/model \
   --peer-node-addr peer-node \
   --dist-init-port 20010 \
@@ -242,16 +242,16 @@ Then commit and force-push to HF PR2:
 ```bash
 cd <trace_dir>
 git add workloads/ blob/ traces/ solutions/
-git commit -m "workloads: SGLang-collected <def_name> via bench_sharegpt.py"
+git commit -m "workloads: SGLang-collected <def_name> via bench_serving.py"
 git push origin HEAD:refs/pr/<pr2_num> --force
 ```
 
-Post the bench_sharegpt.py log to the HF PR2 discussion under `## SGLang Collection Log`.
+Post the bench_serving.py log to the HF PR2 discussion under `## SGLang Collection Log`.
 
 ## Notes
 
 - For `--enable-deterministic-inference` (paged prefill): add it to the model's `server_flags`
-  in `model_configs.json`, or pass it via bench_sharegpt.py's `server_args` list
+  in `model_configs.json`, or pass it via bench_serving.py's `server_args` list
 - The existing `collect_workloads.py` dump-processing pipeline (sanitize_dumps.py) is unchanged
-- `bench_sharegpt.py` passes `**os.environ` to the server process, so all `FLASHINFER_*` vars
+- `bench_serving.py` passes `**os.environ` to the server process, so all `FLASHINFER_*` vars
   set in the outer shell are inherited by the SGLang server automatically

--- a/.claude/skills/collect-workloads/SKILL.md
+++ b/.claude/skills/collect-workloads/SKILL.md
@@ -53,7 +53,7 @@ tools/gpu-lock --gpus 8 --exec-timeout 10800 -- \
 ```
 
 **Streaming workflow per batch size:**
-1. `bench_sharegpt.py` with `DUMP_MAX_COUNT=500` (exhausted in round 1 of 2)
+1. `bench_serving.py` with `DUMP_MAX_COUNT=500` (exhausted in round 1 of 2)
 2. `sanitize_dumps.py --max-new-workloads 4` — appends 4 diverse workloads
 3. Incremental HF push: updated JSONL + new blobs (no deletes)
 4. `rm -rf` dump dir
@@ -119,7 +119,7 @@ FLASHINFER_DUMP_MAX_SIZE_GB=30
 
 **Batch sizes**: `[8, 32, 64, 128]` — powers of 2 matching SGLang CUDA graph capture points, run multiple rounds each for KV-length diversity.
 
-**Per-batch-size isolation** (`--restart-per-batch-size`): pass this flag to `bench_sharegpt.py` when using `FLASHINFER_DUMP_MAX_COUNT`.  Without it, the first batch size exhausts the dump budget (DUMP_MAX_COUNT is a global counter per server process) and later batch sizes capture nothing.  With it, each batch size gets its own server session and therefore its own fresh counter.
+**Per-batch-size isolation** (`--restart-per-batch-size`): pass this flag to `bench_serving.py` when using `FLASHINFER_DUMP_MAX_COUNT`.  Without it, the first batch size exhausts the dump budget (DUMP_MAX_COUNT is a global counter per server process) and later batch sizes capture nothing.  With it, each batch size gets its own server session and therefore its own fresh counter.
 
 Standard collection invocation with isolation:
 ```bash
@@ -127,7 +127,7 @@ FLASHINFER_DUMP_MAX_COUNT=500 \
 FLASHINFER_DUMP_INCLUDE="BatchDecodeWithPagedKVCacheWrapper*" \
 FLASHINFER_DUMP_EXCLUDE="*.__init__" \
 ... \
-python3 examples/sglang_bench/bench_sharegpt.py \
+python3 examples/sglang_bench/bench_serving.py \
   --model <model-key> \
   --model-path /path/to/model \
   --dataset random --isl 1024 --osl 1024 \

--- a/.claude/skills/collect-workloads/SKILL.md
+++ b/.claude/skills/collect-workloads/SKILL.md
@@ -119,6 +119,8 @@ FLASHINFER_DUMP_MAX_SIZE_GB=30
 
 **Batch sizes**: `[8, 32, 64, 128]` — powers of 2 matching SGLang CUDA graph capture points, run multiple rounds each for KV-length diversity.
 
+**Dispatch**: sustained inflight (matches InferenceX `--request-rate inf`). sglang's async semaphore caps concurrent requests at `batch_size` and backfills on each completion, so new prefills overlap with ongoing decodes — yielding mixed prefill+decode batches and varied intra-batch kv_lens.
+
 **Per-batch-size isolation** (`--restart-per-batch-size`): pass this flag to `bench_serving.py` when using `FLASHINFER_DUMP_MAX_COUNT`.  Without it, the first batch size exhausts the dump budget (DUMP_MAX_COUNT is a global counter per server process) and later batch sizes capture nothing.  With it, each batch size gets its own server session and therefore its own fresh counter.
 
 Standard collection invocation with isolation:

--- a/.claude/skills/collect-workloads/SKILL.md
+++ b/.claude/skills/collect-workloads/SKILL.md
@@ -110,9 +110,14 @@ FLASHINFER_DUMP_MAX_SIZE_GB=30
 
 ### Phase 3: SGLang Inference
 
-**Inference source**: real ShareGPT prompts (from `--dataset` path or downloaded from HuggingFace `anon8231489123/ShareGPT_Vicuna_unfiltered`). Falls back to synthetic prompts only if ShareGPT is unavailable.
+**Inference source**: synthetic random prompts (default, `--dataset random`) or real ShareGPT prompts (`--dataset sharegpt`).
 
-**Batch sizes**: `[8, 32, 64, 128]` — powers of 2 matching SGLang CUDA graph capture points, run 4 rounds each with fresh ShareGPT slices for natural KV-length diversity.
+- **`random`** (default): generates token-id prompts of a chosen length via `sample_random_requests` (ported from InferenceX `utils/bench_serving/benchmark_serving.py`). Use when you need controlled prefill length and a guaranteed decode budget. Each request decodes for exactly `--osl` tokens because `ignore_eos=True` is on by default.
+  - Recommended pairs: `--isl 1024 --osl 1024` (decode-heavy, big-batch decode shapes) and `--isl 8192 --osl 1024` (prefill-heavy).
+  - `--random-range-ratio` jitters lengths uniformly in `[ratio*len, len]`. Leave at `1.0` for exact lengths.
+- **`sharegpt`**: real prompts from `anon8231489123/ShareGPT_Vicuna_unfiltered`. Length distribution is uncontrolled; use only when prompt realism matters more than coverage.
+
+**Batch sizes**: `[8, 32, 64, 128]` — powers of 2 matching SGLang CUDA graph capture points, run multiple rounds each for KV-length diversity.
 
 **Per-batch-size isolation** (`--restart-per-batch-size`): pass this flag to `bench_sharegpt.py` when using `FLASHINFER_DUMP_MAX_COUNT`.  Without it, the first batch size exhausts the dump budget (DUMP_MAX_COUNT is a global counter per server process) and later batch sizes capture nothing.  With it, each batch size gets its own server session and therefore its own fresh counter.
 
@@ -125,11 +130,14 @@ FLASHINFER_DUMP_EXCLUDE="*.__init__" \
 python3 examples/sglang_bench/bench_sharegpt.py \
   --model <model-key> \
   --model-path /path/to/model \
+  --dataset random --isl 1024 --osl 1024 \
   --batch-sizes 64 128 \
   --num-batches 4 \
   --restart-per-batch-size \
   --disable-cuda-graph
 ```
+
+For prefill-heavy coverage, run a second pass with `--isl 8192 --osl 1024`. For ShareGPT prompts pass `--dataset sharegpt` (no `--isl`/`--osl` needed).
 
 **Three execution modes** (chosen automatically based on definition type):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Start with `.claude/skills/`. Each subdirectory contains a `SKILL.md` with full 
   with deduplication, generate Definition JSON files
 - **collect-workloads**: Collect real workloads from SGLang inference runs using FlashInfer
   logging API, sanitize and submit to flashinfer-trace
-- **collect-workloads-bench**: Collect workloads using `bench_sharegpt.py` with model-specific
+- **collect-workloads-bench**: Collect workloads using `bench_serving.py` with model-specific
   server configs from `model_configs.json`
 - **add-reference-tests**: Add pytest tests to validate reference implementations against
   FlashInfer or SGLang ground truth

--- a/examples/sglang_bench/bench_serving.py
+++ b/examples/sglang_bench/bench_serving.py
@@ -3,8 +3,7 @@ Benchmark SGLang serving throughput.
 
 Launches an SGLang server and sends batched requests from a configurable
 prompt source — synthetic random prompts (default, controlled ISL/OSL,
-ported from InferenceX) or real ShareGPT prompts. Reports throughput and
-latency statistics across a sweep of batch sizes. Model server flags are
+ported from InferenceX) or real ShareGPT prompts. Model server flags are
 loaded from model_configs.json, keyed by GPU type and model name.
 
 Usage:
@@ -362,12 +361,7 @@ def log(msg: str) -> None:
 
 
 def load_prompts_from_sharegpt(n: int) -> List[Tuple[str, int, int]]:
-    """Load n prompts from the ShareGPT dataset.
-
-    Returns ``(prompt, prompt_len=0, output_len=0)`` tuples. The zeros mean
-    "let the server choose" — caller-side prompt/output length control is only
-    exercised for the random dataset.
-    """
+    """Load n prompts from the ShareGPT dataset."""
     ds = load_dataset(
         "anon8231489123/ShareGPT_Vicuna_unfiltered",
         data_files="ShareGPT_V3_unfiltered_cleaned_split.json",
@@ -487,13 +481,7 @@ class DummyTokenizer:
 
 
 def build_bench_args(disable_ignore_eos: bool = False) -> SimpleNamespace:
-    """Build the SimpleNamespace expected by bench_serving.benchmark.
-
-    `disable_ignore_eos=False` (default) → server is told to ignore EOS, so each
-    request decodes for its full output_len budget. This matches InferenceX's
-    `--ignore-eos` and is what we want for workload collection (otherwise
-    decode-heavy kernels get under-sampled).
-    """
+    """Build the SimpleNamespace expected by bench_serving.benchmark."""
     return SimpleNamespace(
         backend="sglang",
         dataset_name="custom",
@@ -668,7 +656,7 @@ def _launch_server_session(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Benchmark SGLang serving with InferenceX (random) or ShareGPT prompts",
+        description="Benchmark SGLang serving with random (InferenceX) or ShareGPT prompts",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )
@@ -777,10 +765,9 @@ def main():
         choices=["random", "sharegpt"],
         default="random",
         help=(
-            "Prompt source. 'random' (default) generates synthetic prompts of "
-            "controlled token length — gives diverse decode-heavy and "
-            "prefill-heavy kernel inputs. 'sharegpt' uses real prompts but "
-            "their length distribution is uncontrolled."
+            "Prompt source. 'random' (default): synthetic prompts of "
+            "controlled token length for diverse kernel input shapes. "
+            "'sharegpt': real ShareGPT prompts."
         ),
     )
     parser.add_argument(

--- a/examples/sglang_bench/bench_serving.py
+++ b/examples/sglang_bench/bench_serving.py
@@ -449,9 +449,7 @@ def sample_random_requests(
             prompt_token_ids = tokenizer.encode(prompt, add_special_tokens=False)
             if len(prompt_token_ids) < tgt_prompt_len:
                 num_extras = tgt_prompt_len - len(prompt_token_ids)
-                prompt_token_ids.extend(
-                    np.random.randint(0, vocab_size, size=num_extras).tolist()
-                )
+                prompt_token_ids.extend(np.random.randint(0, vocab_size, size=num_extras).tolist())
             elif len(prompt_token_ids) > tgt_prompt_len:
                 prompt_token_ids = prompt_token_ids[:tgt_prompt_len]
             else:
@@ -518,61 +516,55 @@ def run_benchmark(
     top_p: float = 1.0,
     disable_ignore_eos: bool = False,
 ) -> list:
-    """Run the benchmark over prompts in batches and return all results.
+    """Run the benchmark over `prompts` and return results.
 
-    `prompts` is a list of ``(prompt, prompt_len, output_len)`` tuples.
-    Random-dataset entries carry real lengths; ShareGPT entries pass zeros and
-    let the server pick the output budget.
+    Sustained inflight: all prompts dispatched in a single benchmark() call;
+    sglang's semaphore caps concurrency at `batch_size` and refills on each
+    completion. Matches InferenceX --request-rate inf.
     """
     tokenizer = DummyTokenizer()
     set_global_args(build_bench_args(disable_ignore_eos=disable_ignore_eos))
 
-    num_batches = math.ceil(len(prompts) / batch_size)
-    all_results = []
+    if not prompts:
+        return []
 
-    for i in range(num_batches):
-        batch_prompts = prompts[i * batch_size : (i + 1) * batch_size]
-        current_time = time.time()
-        input_requests = [
-            TestRequest(
-                prompt=p,
-                prompt_len=plen,
-                output_len=olen,
-                timestamp=current_time,
-                text_prompt_len=plen,
-                vision_prompt_len=0,
-            )
-            for (p, plen, olen) in batch_prompts
-        ]
-
-        log(f"Running batch {i + 1}/{num_batches} with {len(input_requests)} prompts")
-        results = asyncio.run(
-            benchmark(
-                backend="sglang",
-                api_url=f"{base_url}/generate",
-                base_url=base_url,
-                model_id="default",
-                tokenizer=tokenizer,
-                input_requests=input_requests,
-                request_rate=float("inf"),
-                max_concurrency=batch_size,
-                disable_tqdm=False,
-                lora_names=None,
-                lora_request_distribution=None,
-                lora_zipf_alpha=None,
-                extra_request_body={
-                    "sampling_params": {
-                        "temperature": temperature,
-                        **({"top_k": top_k} if top_k > 0 else {}),
-                        **({"top_p": top_p} if top_p < 1.0 else {}),
-                    }
-                },
-                profile=False,
-            )
+    input_requests = [
+        TestRequest(
+            prompt=p,
+            prompt_len=plen,
+            output_len=olen,
+            timestamp=time.time(),
+            text_prompt_len=plen,
+            vision_prompt_len=0,
         )
-        all_results.append(results)
+        for (p, plen, olen) in prompts
+    ]
 
-    return all_results
+    log(f"Dispatching {len(input_requests)} prompts, max_concurrency={batch_size}")
+    return asyncio.run(
+        benchmark(
+            backend="sglang",
+            api_url=f"{base_url}/generate",
+            base_url=base_url,
+            model_id="default",
+            tokenizer=tokenizer,
+            input_requests=input_requests,
+            request_rate=float("inf"),
+            max_concurrency=batch_size,
+            disable_tqdm=False,
+            lora_names=None,
+            lora_request_distribution=None,
+            lora_zipf_alpha=None,
+            extra_request_body={
+                "sampling_params": {
+                    "temperature": temperature,
+                    **({"top_k": top_k} if top_k > 0 else {}),
+                    **({"top_p": top_p} if top_p < 1.0 else {}),
+                }
+            },
+            profile=False,
+        )
+    )
 
 
 def _shutdown_server(process: subprocess.Popen, peer_processes: List[subprocess.Popen]) -> None:

--- a/examples/sglang_bench/bench_serving.py
+++ b/examples/sglang_bench/bench_serving.py
@@ -1,21 +1,23 @@
 """
-Benchmark SGLang serving throughput using the ShareGPT dataset.
+Benchmark SGLang serving throughput.
 
-Launches an SGLang server, sends batched requests from ShareGPT, and reports
-throughput and latency statistics across a sweep of batch sizes. Model server
-flags are loaded from model_configs.json, keyed by GPU type and model name.
+Launches an SGLang server and sends batched requests from a configurable
+prompt source — synthetic random prompts (default, controlled ISL/OSL,
+ported from InferenceX) or real ShareGPT prompts. Reports throughput and
+latency statistics across a sweep of batch sizes. Model server flags are
+loaded from model_configs.json, keyed by GPU type and model name.
 
 Usage:
     # Auto-detect GPU type from nvidia-smi
-    python3 bench_sharegpt.py --model llama-3.1-8b  --model-path /path/to/Llama-3.1-8B-Instruct
-    python3 bench_sharegpt.py --model deepseek-v3   --model-path /path/to/DeepSeek-V3
-    python3 bench_sharegpt.py --model qwen3-235b-a22b --model-path /path/to/Qwen3-235B-A22B
+    python3 bench_serving.py --model llama-3.1-8b  --model-path /path/to/Llama-3.1-8B-Instruct
+    python3 bench_serving.py --model deepseek-v3   --model-path /path/to/DeepSeek-V3
+    python3 bench_serving.py --model qwen3-235b-a22b --model-path /path/to/Qwen3-235B-A22B
 
     # Explicitly specify GPU type (b200, h200, h100, mi300x)
-    python3 bench_sharegpt.py --gpu h100 --model llama-3.1-70b --model-path /path/to/Llama-3.1-70B-Instruct
+    python3 bench_serving.py --gpu h100 --model llama-3.1-70b --model-path /path/to/Llama-3.1-70B-Instruct
 
     # TP size is auto-detected from CUDA_VISIBLE_DEVICES (set by gpu-lock):
-    #   tools/gpu-lock --gpus 4 -- python3 bench_sharegpt.py --model qwen3-235b-a22b ...
+    #   tools/gpu-lock --gpus 4 -- python3 bench_serving.py --model qwen3-235b-a22b ...
     #   → CUDA_VISIBLE_DEVICES=0,1,2,3 → TP=4 used automatically
 
     # Multi-node mode (auto-detected when config TP > local GPU count):
@@ -26,16 +28,20 @@ Usage:
 
 
     # Tracing flags
-    python3 bench_sharegpt.py --model llama-3.1-8b --model-path /path/to/model --disable-radix-cache
-    python3 bench_sharegpt.py --model qwen3-235b-a22b --model-path /path/to/model --enable-deterministic-inference
+    python3 bench_serving.py --model llama-3.1-8b --model-path /path/to/model --disable-radix-cache
+    python3 bench_serving.py --model qwen3-235b-a22b --model-path /path/to/model --enable-deterministic-inference
+
+    # Dataset selection (default: random)
+    python3 bench_serving.py --model llama-3.1-8b --model-path /path/to/model --dataset random --isl 1024 --osl 1024
+    python3 bench_serving.py --model llama-3.1-8b --model-path /path/to/model --dataset sharegpt
 
     # Custom batch sizes and number of batches
-    python3 bench_sharegpt.py --model llama-3.1-8b --model-path /path/to/model --batch-sizes 32 128 --num-batches 8
+    python3 bench_serving.py --model llama-3.1-8b --model-path /path/to/model --batch-sizes 32 128 --num-batches 8
 
     # Workload collection: restart server per batch size so each gets its own DUMP_MAX_COUNT budget
     FLASHINFER_DUMP_MAX_COUNT=500 FLASHINFER_DUMP_INCLUDE="BatchDecodeWithPagedKVCacheWrapper*" \
     FLASHINFER_DUMP_EXCLUDE="*.__init__" \
-    python3 bench_sharegpt.py --model llama-4-scout-ps64 --model-path /path/to/model \
+    python3 bench_serving.py --model llama-4-scout-ps64 --model-path /path/to/model \
         --batch-sizes 64 128 --num-batches 4 --restart-per-batch-size --disable-cuda-graph
 
 Environment variables (optional, for flashinfer-bench tracing):
@@ -43,7 +49,7 @@ Environment variables (optional, for flashinfer-bench tracing):
     FIB_DATASET_PATH=<dir>    Directory to write flashinfer trace data
 
     Example:
-        FIB_ENABLE_APPLY=1 FIB_DATASET_PATH=/path/to/traces/ python3 bench_sharegpt.py --model llama-3.1-8b --model-path /path/to/model
+        FIB_ENABLE_APPLY=1 FIB_DATASET_PATH=/path/to/traces/ python3 bench_serving.py --model llama-3.1-8b --model-path /path/to/model
 """
 
 import argparse
@@ -662,7 +668,7 @@ def _launch_server_session(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Benchmark ShareGPT dataset with SGLang using different models",
+        description="Benchmark SGLang serving with InferenceX (random) or ShareGPT prompts",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=__doc__,
     )

--- a/examples/sglang_bench/bench_serving.py
+++ b/examples/sglang_bench/bench_serving.py
@@ -296,6 +296,7 @@ def launch_peer_worker(
     return subprocess.Popen(ssh_cmd, stdout=log_file, stderr=log_file)
 
 
+import numpy as np
 from datasets import load_dataset
 from sglang.bench_serving import benchmark, set_global_args
 from sglang.test.test_utils import (
@@ -303,6 +304,7 @@ from sglang.test.test_utils import (
     kill_process_tree,
     popen_launch_server,
 )
+from transformers import AutoTokenizer
 
 
 @dataclass
@@ -420,11 +422,7 @@ def sample_random_requests(
 
     Returns ``(prompt, prompt_len, output_len)`` tuples.
     """
-    import numpy as np
-    from transformers import AutoTokenizer
-
-    if seed is not None:
-        np.random.seed(seed)
+    rng = np.random.default_rng(seed)
 
     tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     vocab_size = tokenizer.vocab_size
@@ -432,11 +430,11 @@ def sample_random_requests(
     def sample_uniform(seq_len: int) -> List[int]:
         lower = int(seq_len * range_ratio)
         upper = seq_len
-        return np.random.randint(lower, upper + 1, size=num_prompts).tolist()
+        return rng.integers(lower, upper + 1, size=num_prompts).tolist()
 
     input_lens = sample_uniform(input_len)
     output_lens = sample_uniform(output_len)
-    offsets = np.random.randint(0, vocab_size, size=num_prompts)
+    offsets = rng.integers(0, vocab_size, size=num_prompts)
 
     requests: List[Tuple[str, int, int]] = []
     for i in range(num_prompts):
@@ -449,7 +447,7 @@ def sample_random_requests(
             prompt_token_ids = tokenizer.encode(prompt, add_special_tokens=False)
             if len(prompt_token_ids) < tgt_prompt_len:
                 num_extras = tgt_prompt_len - len(prompt_token_ids)
-                prompt_token_ids.extend(np.random.randint(0, vocab_size, size=num_extras).tolist())
+                prompt_token_ids.extend(rng.integers(0, vocab_size, size=num_extras).tolist())
             elif len(prompt_token_ids) > tgt_prompt_len:
                 prompt_token_ids = prompt_token_ids[:tgt_prompt_len]
             else:
@@ -528,12 +526,13 @@ def run_benchmark(
     if not prompts:
         return []
 
+    now = time.time()
     input_requests = [
         TestRequest(
             prompt=p,
             prompt_len=plen,
             output_len=olen,
-            timestamp=time.time(),
+            timestamp=now,
             text_prompt_len=plen,
             vision_prompt_len=0,
         )

--- a/examples/sglang_bench/bench_sharegpt.py
+++ b/examples/sglang_bench/bench_sharegpt.py
@@ -355,15 +355,20 @@ def log(msg: str) -> None:
     print(f"[BENCHMARK] {time.strftime('%Y-%m-%d %H:%M:%S')} - {msg}")
 
 
-def load_prompts_from_sharegpt(n: int) -> List[str]:
-    """Load n prompts from the ShareGPT dataset."""
+def load_prompts_from_sharegpt(n: int) -> List[Tuple[str, int, int]]:
+    """Load n prompts from the ShareGPT dataset.
+
+    Returns ``(prompt, prompt_len=0, output_len=0)`` tuples. The zeros mean
+    "let the server choose" — caller-side prompt/output length control is only
+    exercised for the random dataset.
+    """
     ds = load_dataset(
         "anon8231489123/ShareGPT_Vicuna_unfiltered",
         data_files="ShareGPT_V3_unfiltered_cleaned_split.json",
         split="train",
         streaming=True,
     )
-    prompts = []
+    prompts: List[str] = []
     for example in ds:
         conv = example.get("conversations", [])
         if not conv:
@@ -391,7 +396,81 @@ def load_prompts_from_sharegpt(n: int) -> List[str]:
             f"Max: {max(prompt_lengths)}, "
             f"Avg: {sum(prompt_lengths) / len(prompt_lengths):.1f}"
         )
-    return prompts
+    return [(p, 0, 0) for p in prompts]
+
+
+def sample_random_requests(
+    model_path: str,
+    num_prompts: int,
+    input_len: int,
+    output_len: int,
+    range_ratio: float,
+    seed: Optional[int] = None,
+) -> List[Tuple[str, int, int]]:
+    """Generate `num_prompts` synthetic prompts whose token length matches `input_len`.
+
+    Ported (serial path) from InferenceX's `utils/bench_serving/benchmark_serving.py`
+    `sample_random_requests`. Random token IDs are decoded then re-encoded; if the
+    re-encoded length drifts, we pad/truncate until it matches.
+
+    `range_ratio` controls per-request length jitter:
+        lower = floor(seq_len * range_ratio); upper = seq_len (inclusive).
+        range_ratio=1.0 -> all requests at exactly `input_len`/`output_len`.
+        range_ratio=0.8 -> uniform between 80% and 100% of the target length.
+
+    Returns ``(prompt, prompt_len, output_len)`` tuples.
+    """
+    import numpy as np
+    from transformers import AutoTokenizer
+
+    if seed is not None:
+        np.random.seed(seed)
+
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    vocab_size = tokenizer.vocab_size
+
+    def sample_uniform(seq_len: int) -> List[int]:
+        lower = int(seq_len * range_ratio)
+        upper = seq_len
+        return np.random.randint(lower, upper + 1, size=num_prompts).tolist()
+
+    input_lens = sample_uniform(input_len)
+    output_lens = sample_uniform(output_len)
+    offsets = np.random.randint(0, vocab_size, size=num_prompts)
+
+    requests: List[Tuple[str, int, int]] = []
+    for i in range(num_prompts):
+        tgt_prompt_len = input_lens[i]
+        prompt_token_ids = [(int(offsets[i]) + i + j) % vocab_size for j in range(tgt_prompt_len)]
+        prompt = tokenizer.decode(prompt_token_ids)
+
+        # Decode/encode round-trip can drift; pad or truncate to the target length.
+        for _ in range(10):
+            prompt_token_ids = tokenizer.encode(prompt, add_special_tokens=False)
+            if len(prompt_token_ids) < tgt_prompt_len:
+                num_extras = tgt_prompt_len - len(prompt_token_ids)
+                prompt_token_ids.extend(
+                    np.random.randint(0, vocab_size, size=num_extras).tolist()
+                )
+            elif len(prompt_token_ids) > tgt_prompt_len:
+                prompt_token_ids = prompt_token_ids[:tgt_prompt_len]
+            else:
+                break
+            prompt = tokenizer.decode(prompt_token_ids)
+
+        actual_len = len(tokenizer.encode(prompt, add_special_tokens=False))
+        requests.append((prompt, actual_len, int(output_lens[i])))
+
+    actual_in = [r[1] for r in requests]
+    actual_out = [r[2] for r in requests]
+    log(
+        f"Generated {num_prompts} random prompts | "
+        f"input_len min/mean/max = {min(actual_in)}/"
+        f"{sum(actual_in) / len(actual_in):.1f}/{max(actual_in)} | "
+        f"output_len min/mean/max = {min(actual_out)}/"
+        f"{sum(actual_out) / len(actual_out):.1f}/{max(actual_out)}"
+    )
+    return requests
 
 
 class DummyTokenizer:
@@ -401,12 +480,18 @@ class DummyTokenizer:
         return []
 
 
-def build_bench_args() -> SimpleNamespace:
-    """Build the SimpleNamespace expected by bench_serving.benchmark."""
+def build_bench_args(disable_ignore_eos: bool = False) -> SimpleNamespace:
+    """Build the SimpleNamespace expected by bench_serving.benchmark.
+
+    `disable_ignore_eos=False` (default) → server is told to ignore EOS, so each
+    request decodes for its full output_len budget. This matches InferenceX's
+    `--ignore-eos` and is what we want for workload collection (otherwise
+    decode-heavy kernels get under-sampled).
+    """
     return SimpleNamespace(
         backend="sglang",
         dataset_name="custom",
-        disable_ignore_eos=False,
+        disable_ignore_eos=disable_ignore_eos,
         disable_stream=True,
         return_logprob=False,
         return_routed_experts=False,
@@ -432,15 +517,21 @@ def build_bench_args() -> SimpleNamespace:
 
 def run_benchmark(
     base_url: str,
-    prompts: List[str],
+    prompts: List[Tuple[str, int, int]],
     batch_size: int,
     temperature: float = 0.0,
     top_k: int = -1,
     top_p: float = 1.0,
+    disable_ignore_eos: bool = False,
 ) -> list:
-    """Run the benchmark over prompts in batches and return all results."""
+    """Run the benchmark over prompts in batches and return all results.
+
+    `prompts` is a list of ``(prompt, prompt_len, output_len)`` tuples.
+    Random-dataset entries carry real lengths; ShareGPT entries pass zeros and
+    let the server pick the output budget.
+    """
     tokenizer = DummyTokenizer()
-    set_global_args(build_bench_args())
+    set_global_args(build_bench_args(disable_ignore_eos=disable_ignore_eos))
 
     num_batches = math.ceil(len(prompts) / batch_size)
     all_results = []
@@ -451,13 +542,13 @@ def run_benchmark(
         input_requests = [
             TestRequest(
                 prompt=p,
-                prompt_len=0,
-                output_len=0,
+                prompt_len=plen,
+                output_len=olen,
                 timestamp=current_time,
-                text_prompt_len=0,
+                text_prompt_len=plen,
                 vision_prompt_len=0,
             )
-            for p in batch_prompts
+            for (p, plen, olen) in batch_prompts
         ]
 
         log(f"Running batch {i + 1}/{num_batches} with {len(input_requests)} prompts")
@@ -676,6 +767,53 @@ def main():
         "Defaults to $CONDA_DEFAULT_ENV or 'flashinfer_bench'.",
     )
     parser.add_argument(
+        "--dataset",
+        choices=["random", "sharegpt"],
+        default="random",
+        help=(
+            "Prompt source. 'random' (default) generates synthetic prompts of "
+            "controlled token length — gives diverse decode-heavy and "
+            "prefill-heavy kernel inputs. 'sharegpt' uses real prompts but "
+            "their length distribution is uncontrolled."
+        ),
+    )
+    parser.add_argument(
+        "--isl",
+        type=int,
+        default=1024,
+        help="Random-dataset input sequence length in tokens (default: 1024).",
+    )
+    parser.add_argument(
+        "--osl",
+        type=int,
+        default=1024,
+        help="Random-dataset output sequence length in tokens (default: 1024).",
+    )
+    parser.add_argument(
+        "--random-range-ratio",
+        type=float,
+        default=1.0,
+        help=(
+            "Random-dataset length jitter. lower=floor(len*ratio), upper=len. "
+            "1.0 (default) = exact lengths; 0.8 = uniform between 80%% and 100%%."
+        ),
+    )
+    parser.add_argument(
+        "--disable-ignore-eos",
+        action="store_true",
+        help=(
+            "Let the server stop at EOS instead of decoding for the full output "
+            "length. By default ignore_eos is enabled so each request decodes "
+            "for the full output_len budget (matches InferenceX --ignore-eos)."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducible random-dataset prompts.",
+    )
+    parser.add_argument(
         "--restart-per-batch-size",
         action="store_true",
         help=(
@@ -698,8 +836,24 @@ def main():
     log(f"Model path:     {args.model_path}")
     log(f"Batch sizes:    {args.batch_sizes}")
     log(f"Total prompts:  {num_prompts} ({args.num_batches} batches per sweep)")
+    log(f"Dataset:        {args.dataset}")
 
-    prompts = load_prompts_from_sharegpt(num_prompts)
+    if args.dataset == "random":
+        log(
+            f"Random dataset: isl={args.isl}, osl={args.osl}, "
+            f"range_ratio={args.random_range_ratio}, "
+            f"ignore_eos={not args.disable_ignore_eos}"
+        )
+        prompts = sample_random_requests(
+            model_path=args.model_path,
+            num_prompts=num_prompts,
+            input_len=args.isl,
+            output_len=args.osl,
+            range_ratio=args.random_range_ratio,
+            seed=args.seed,
+        )
+    else:
+        prompts = load_prompts_from_sharegpt(num_prompts)
 
     server_args = []
 
@@ -823,6 +977,7 @@ def main():
                     temperature=args.temperature,
                     top_k=args.top_k,
                     top_p=args.top_p,
+                    disable_ignore_eos=args.disable_ignore_eos,
                 )
             except Exception as e:
                 log(f"Benchmark failed: {e}")
@@ -856,6 +1011,7 @@ def main():
                     temperature=args.temperature,
                     top_k=args.top_k,
                     top_p=args.top_p,
+                    disable_ignore_eos=args.disable_ignore_eos,
                 )
         except Exception as e:
             log(f"Benchmark failed: {e}")

--- a/scripts/collect_stream.py
+++ b/scripts/collect_stream.py
@@ -3,7 +3,7 @@
 Streaming workload collection with incremental HuggingFace push.
 
 For each batch size:
-  1. Run bench_sharegpt.py (DUMP_MAX_COUNT=500, single batch size, 2 rounds);
+  1. Run bench_serving.py (DUMP_MAX_COUNT=500, single batch size, 2 rounds);
      dump budget is typically exhausted in round 1, so collection is fast.
   2. sanitize_dumps.py --max-new-workloads 4  →  append 4 diverse workloads.
   3. Push updated JSONL + new blob safetensors to HF PR (append-only, no deletes).
@@ -52,7 +52,7 @@ from typing import Optional
 # Paths (relative to repo root, resolved at startup)
 # ---------------------------------------------------------------------------
 _REPO_ROOT = Path(__file__).parent.parent
-_BENCH_SCRIPT = _REPO_ROOT / "examples" / "sglang_bench" / "bench_sharegpt.py"
+_BENCH_SCRIPT = _REPO_ROOT / "examples" / "sglang_bench" / "bench_serving.py"
 _SANITIZE_SCRIPT = _REPO_ROOT / "scripts" / "sanitize_dumps.py"
 
 HF_REPO_ID = "flashinfer-ai/flashinfer-trace"
@@ -152,7 +152,7 @@ def run_inference(
     disable_ignore_eos: bool,
     seed: Optional[int],
 ) -> None:
-    """Run bench_sharegpt.py for *one* batch size, collecting dumps into dump_dir."""
+    """Run bench_serving.py for *one* batch size, collecting dumps into dump_dir."""
     cubins_dir = "/tmp/flashinfer_cubins"
     env = {
         **os.environ,
@@ -219,7 +219,7 @@ def run_inference(
     result = subprocess.run(cmd, env=env)
     if result.returncode != 0:
         raise RuntimeError(
-            f"bench_sharegpt.py exited {result.returncode} for batch_size={batch_size}"
+            f"bench_serving.py exited {result.returncode} for batch_size={batch_size}"
         )
 
     n_dumps = sum(1 for _ in dump_dir.iterdir()) if dump_dir.exists() else 0
@@ -385,7 +385,7 @@ def main():
     parser.add_argument(
         "--model-key",
         required=True,
-        help="Model key for bench_sharegpt.py (e.g. llama-4-scout-ps64)",
+        help="Model key for bench_serving.py (e.g. llama-4-scout-ps64)",
     )
     parser.add_argument("--model-path", required=True, help="Path to model weights directory")
     parser.add_argument(
@@ -465,7 +465,7 @@ def main():
         dest="extra_server_flags",
         metavar="FLAG",
         help=(
-            "Extra flags forwarded verbatim to bench_sharegpt.py. "
+            "Extra flags forwarded verbatim to bench_serving.py. "
             "Default: --disable-cuda-graph. "
             "Example: --extra-server-flag --disable-radix-cache --disable-piecewise-cuda-graph"
         ),
@@ -475,7 +475,7 @@ def main():
         choices=["random", "sharegpt"],
         default="random",
         help=(
-            "Prompt source forwarded to bench_sharegpt.py. 'random' (default) "
+            "Prompt source forwarded to bench_serving.py. 'random' (default) "
             "generates synthetic prompts of controlled token length for diverse "
             "kernel input shapes; 'sharegpt' uses real ShareGPT prompts."
         ),

--- a/scripts/collect_stream.py
+++ b/scripts/collect_stream.py
@@ -145,6 +145,12 @@ def run_inference(
     dist_init_port: int,
     conda_env: Optional[str],
     base_url: str,
+    dataset: str,
+    isl: int,
+    osl: int,
+    random_range_ratio: float,
+    disable_ignore_eos: bool,
+    seed: Optional[int],
 ) -> None:
     """Run bench_sharegpt.py for *one* batch size, collecting dumps into dump_dir."""
     cubins_dir = "/tmp/flashinfer_cubins"
@@ -181,7 +187,23 @@ def run_inference(
         str(num_batches),
         "--base-url",
         base_url,
+        "--dataset",
+        dataset,
     ] + extra_server_flags
+
+    if dataset == "random":
+        cmd += [
+            "--isl",
+            str(isl),
+            "--osl",
+            str(osl),
+            "--random-range-ratio",
+            str(random_range_ratio),
+        ]
+        if seed is not None:
+            cmd += ["--seed", str(seed)]
+    if disable_ignore_eos:
+        cmd.append("--disable-ignore-eos")
 
     if peer_node_addr:
         for addr in peer_node_addr:
@@ -449,6 +471,49 @@ def main():
         ),
     )
     parser.add_argument(
+        "--dataset",
+        choices=["random", "sharegpt"],
+        default="random",
+        help=(
+            "Prompt source forwarded to bench_sharegpt.py. 'random' (default) "
+            "generates synthetic prompts of controlled token length for diverse "
+            "kernel input shapes; 'sharegpt' uses real ShareGPT prompts."
+        ),
+    )
+    parser.add_argument(
+        "--isl",
+        type=int,
+        default=1024,
+        help="Random-dataset input sequence length in tokens (default: 1024).",
+    )
+    parser.add_argument(
+        "--osl",
+        type=int,
+        default=1024,
+        help="Random-dataset output sequence length in tokens (default: 1024).",
+    )
+    parser.add_argument(
+        "--random-range-ratio",
+        type=float,
+        default=1.0,
+        help="Random-dataset length jitter; 1.0 means exact lengths (default: 1.0).",
+    )
+    parser.add_argument(
+        "--disable-ignore-eos",
+        action="store_true",
+        help=(
+            "Let the server stop at EOS instead of decoding for the full output "
+            "length. Default ignore_eos=True ensures every request produces "
+            "output_len decode steps (matches InferenceX --ignore-eos)."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducible random-dataset prompts.",
+    )
+    parser.add_argument(
         "--replace-first",
         action="store_true",
         help="Replace (not append) existing workloads when processing the first batch size",
@@ -515,6 +580,12 @@ def main():
             dist_init_port=args.dist_init_port,
             conda_env=args.conda_env,
             base_url=args.base_url,
+            dataset=args.dataset,
+            isl=args.isl,
+            osl=args.osl,
+            random_range_ratio=args.random_range_ratio,
+            disable_ignore_eos=args.disable_ignore_eos,
+            seed=args.seed,
         )
 
         # --- Step 2: sanitize ---


### PR DESCRIPTION
## Summary 
- Add random dataset ported from InferenceX for collect-workloads 
   - Generates random, synthetic dataset with ISL / OSL specified 
   - --isl / --osl defaults to (1024, 1024)*
   - --random-range-ratio` jitters lengths uniformly in [ratio*len, len]
- Add sustained inflight dispatch, matching InferenceX 
   - Instead of sending multiple waves of requests, fill to specified concurrency whenever earlier request completes
   - No idle gaps between waves and new prefills overlap with ongoing decodes 
- Rename bench_sharegpt.py to bench_serving.py 

## Notes 
- Although OSL defaults to 1024 (to match InferenceX), in practice workload dumps are often capped early due to `FLASHINFER_DUMP_MAX_COUNT`, which defaults to 500 currently
- For typical models (e.g., 16 layers), this limit is reached after ~30 decode steps (500 / 16 ~= 30), making long OSL less effective for data collection
- I plan to follow up with a dump deduplication PR, but we may consider lowering the default OSL (e.g., 128) to improve collection efficiency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dataset selector (default: random synthetic) with reproducible seed control
  * Configurable input/output lengths with optional length variation and EOS behavior toggle
  * Benchmark dispatch now uses sustained concurrency bounded by batch size for more realistic overlap

* **Documentation**
  * Updated workload collection and example commands to reflect the new benchmark launcher, dataset options, and runtime guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->