### PR TITLE
feat: add low-level GPU judge server

### DIFF
--- a/flashinfer_bench/__init__.py
+++ b/flashinfer_bench/__init__.py
@@ -33,12 +33,7 @@ from flashinfer_bench.tracing import (
     disable_tracing,
     enable_tracing,
 )
-
-try:
-    from ._version import __version__, __version_tuple__
-except Exception:
-    __version__ = "0.0.0.dev0"
-    __version_tuple__ = (0, 0, 0, "dev0")
+from flashinfer_bench.version import __version__, __version_tuple__
 
 __all__ = [
     # Benchmark

--- a/flashinfer_bench/serve/low_level/__init__.py
+++ b/flashinfer_bench/serve/low_level/__init__.py
@@ -1,5 +1,6 @@
 """Low-level GPU judge server. This is an experimental feature and under active development."""
 
-from flashinfer_bench.serve.low_level.app import app, create_app, create_default_app
+from flashinfer_bench.serve.low_level.app import create_app
+from flashinfer_bench.serve.low_level.server import LowLevelServer
 
-__all__ = ["app", "create_app", "create_default_app"]
+__all__ = ["LowLevelServer", "create_app"]

--- a/flashinfer_bench/serve/low_level/__init__.py
+++ b/flashinfer_bench/serve/low_level/__init__.py
@@ -1,0 +1,5 @@
+"""Low-level GPU judge server. This is an experimental feature and under active development."""
+
+from flashinfer_bench.serve.low_level.app import app, create_app, create_default_app
+
+__all__ = ["app", "create_app", "create_default_app"]

--- a/flashinfer_bench/serve/low_level/app.py
+++ b/flashinfer_bench/serve/low_level/app.py
@@ -1,0 +1,469 @@
+"""FastAPI app for the low-level GPU server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from multiprocessing import shared_memory
+from time import perf_counter
+from typing import Literal, Optional
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, ValidationError
+from starlette.datastructures import UploadFile
+
+from flashinfer_bench.serve.low_level.errors import InvalidProgramError, TimeoutError
+from flashinfer_bench.serve.low_level.executor import (
+    ErrorResult,
+    ExecuteResult,
+    Instruction,
+    Program,
+    SharedMemoryBlob,
+)
+from flashinfer_bench.serve.low_level.multipart import build_success_response
+from flashinfer_bench.serve.low_level.worker import (
+    LowLevelScheduler,
+    WorkerExecuteErrorResponse,
+    WorkerExecuteSuccessResponse,
+)
+from flashinfer_bench.utils import list_cuda_devices
+from flashinfer_bench.version import __version__
+
+# ---------------------------------------------------------------------------
+# HTTP request/response schemas
+# ---------------------------------------------------------------------------
+
+
+class ExecuteRequest(BaseModel):
+    """JSON payload stored in the `program` multipart field for `/execute`."""
+
+    instructions: list[Instruction]
+    """Ordered instruction sequence to execute."""
+    timeout_seconds: float | None = None
+    """Optional per-request timeout override in seconds."""
+
+    @property
+    def program(self) -> Program:
+        """Return the execution program without HTTP-only request metadata.
+
+        Returns
+        -------
+        Program
+            Program object containing only execution instructions.
+        """
+        return Program(instructions=self.instructions)
+
+
+class WorkerStatus(BaseModel):
+    """Health summary for a single GPU worker."""
+
+    gpu_id: int
+    """Physical GPU index assigned to the worker."""
+    status: Literal["idle", "busy", "restarting"]
+    """Current worker runtime status."""
+    queue_length: int
+    """Number of in-flight requests assigned to this worker."""
+    uptime_seconds: int
+    """Worker uptime since the last process start."""
+
+
+class HealthResponse(BaseModel):
+    """Response payload for the `/health` endpoint."""
+
+    status: Literal["ok"] = "ok"
+    """Health check status."""
+    gpu_count: int
+    """Number of configured GPU workers."""
+    workers: list[WorkerStatus]
+    """Per-worker runtime status entries."""
+
+
+class RequestSharedMemoryStore:
+    """Own shared-memory blobs created for one HTTP request."""
+
+    blobs: dict[str, SharedMemoryBlob]
+    """Shared-memory blob metadata keyed by blob hash."""
+    _shared_memories: list[shared_memory.SharedMemory]
+    """Owned shared-memory objects that must be released after the request."""
+
+    def __init__(self) -> None:
+        """Initialize an empty request-local shared-memory store.
+
+        Returns
+        -------
+        None
+            This constructor initializes internal storage in place.
+        """
+        self.blobs: dict[str, SharedMemoryBlob] = {}
+        self._shared_memories: list[shared_memory.SharedMemory] = []
+
+    def add_blob(self, blob_hash: str, blob_bytes: bytes) -> None:
+        """Create one shared-memory blob and record its metadata.
+
+        Parameters
+        ----------
+        blob_hash
+            Blob hash used as the logical blob key.
+        blob_bytes
+            Raw blob payload received from the HTTP request.
+
+        Returns
+        -------
+        None
+            This method mutates the shared-memory store in place.
+        """
+        if blob_hash in self.blobs:
+            raise InvalidProgramError(f"Duplicate blob: {blob_hash}")
+
+        shared_memory_size = max(1, len(blob_bytes))
+        blob_shared_memory = shared_memory.SharedMemory(create=True, size=shared_memory_size)
+        try:
+            blob_shared_memory.buf[: len(blob_bytes)] = blob_bytes
+        except Exception:
+            blob_shared_memory.close()
+            blob_shared_memory.unlink()
+            raise
+
+        self._shared_memories.append(blob_shared_memory)
+        self.blobs[blob_hash] = SharedMemoryBlob(name=blob_shared_memory.name, size=len(blob_bytes))
+
+    def cleanup(self) -> None:
+        """Release all request shared-memory blobs.
+
+        Returns
+        -------
+        None
+            This method releases owned shared-memory objects in place.
+        """
+        for blob_shared_memory in self._shared_memories:
+            try:
+                blob_shared_memory.close()
+            except Exception:
+                pass
+            try:
+                blob_shared_memory.unlink()
+            except FileNotFoundError:
+                pass
+        self._shared_memories.clear()
+        self.blobs.clear()
+
+
+# ---------------------------------------------------------------------------
+# FastAPI app
+# ---------------------------------------------------------------------------
+
+_scheduler: Optional[LowLevelScheduler] = None
+
+
+def _get_scheduler() -> LowLevelScheduler:
+    """Return the initialized scheduler instance.
+
+    Returns
+    -------
+    LowLevelScheduler
+        Initialized scheduler singleton for the current process.
+    """
+    if _scheduler is None:
+        raise RuntimeError("Low-level server is not initialized")
+    return _scheduler
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    """Own the scheduler lifecycle for the module-level FastAPI app.
+
+    Parameters
+    ----------
+    app
+        FastAPI application bound to this lifespan handler.
+
+    Yields
+    ------
+    None
+        Control returns to FastAPI while the app is serving requests.
+    """
+    yield
+    if _scheduler is not None:
+        _scheduler.close()
+
+
+app = FastAPI(title="FlashInfer-Bench Low-Level Server", version=__version__, lifespan=_lifespan)
+
+
+def create_app(devices: list[str], default_timeout_seconds: int = 30) -> FastAPI:
+    """Create the low-level app with a concrete scheduler.
+
+    Parameters
+    ----------
+    devices
+        CUDA device strings assigned to worker processes.
+    default_timeout_seconds
+        Default request timeout in seconds.
+
+    Returns
+    -------
+    FastAPI
+        Configured FastAPI application instance.
+    """
+    global _scheduler
+    _scheduler = LowLevelScheduler(devices=devices, default_timeout_seconds=default_timeout_seconds)
+    return app
+
+
+def create_default_app() -> FastAPI:
+    """Factory for ad-hoc uvicorn startup.
+
+    Returns
+    -------
+    FastAPI
+        Configured FastAPI application using detected CUDA devices.
+    """
+    devices = list_cuda_devices()
+    return create_app(devices=devices, default_timeout_seconds=30)
+
+
+@app.post(
+    "/execute",
+    responses={
+        200: {"description": "Success (multipart)", "model": ExecuteResult},
+        400: {"description": "Invalid program or execution failed", "model": ErrorResult},
+        408: {"description": "Timeout", "model": ErrorResult},
+    },
+)
+async def execute(request: Request):
+    """Execute a program on GPU.
+
+    Input: multipart/form-data
+      - program: ExecuteRequest JSON
+      - blob:<sha256>: binary data (referenced by instructions)
+    Output: multipart/form-data
+      - result: ExecuteResult JSON (including optional stdout/stderr)
+      - return:<key>: binary return values (tensors, bytes)
+
+    Parameters
+    ----------
+    request
+        Incoming HTTP request carrying one multipart execution payload.
+
+    Returns
+    -------
+    Response
+        Multipart success response or JSON error response.
+    """
+    execute_start_time = perf_counter()
+    blob_store = RequestSharedMemoryStore()
+    validate_program_ms: float | None = None
+    scheduler_execute_ms: float | None = None
+    build_response_ms: float | None = None
+    request_cleanup_ms: float | None = None
+    status_code: int | None = None
+    try:
+        raw_json = await _parse_request_into_shared_memory(request, blob_store)
+        try:
+            validate_start_time = perf_counter()
+            execute_request = ExecuteRequest.model_validate(raw_json)
+            validate_program_ms = (perf_counter() - validate_start_time) * 1000.0
+        except ValidationError as error:
+            raise InvalidProgramError(str(error)) from error
+        program = execute_request.program
+        scheduler_execute_start_time = perf_counter()
+        response = await asyncio.to_thread(
+            _get_scheduler().execute, program, execute_request.timeout_seconds, blob_store.blobs
+        )
+        scheduler_execute_ms = (perf_counter() - scheduler_execute_start_time) * 1000.0
+        if isinstance(response, WorkerExecuteErrorResponse):
+            error_result: ErrorResult = response.error
+            status_code = 400
+            return JSONResponse(
+                status_code=status_code, content=error_result.model_dump(exclude_none=True)
+            )
+
+        success_response: WorkerExecuteSuccessResponse = response
+        result: ExecuteResult = success_response.result
+        binary_parts: dict[str, bytes] = success_response.binary_parts
+        build_response_start_time = perf_counter()
+        body, content_type = build_success_response(
+            result_payload=result.model_dump(), binary_parts=binary_parts
+        )
+        build_response_ms = (perf_counter() - build_response_start_time) * 1000.0
+        status_code = 200
+        return Response(content=body, media_type=content_type)
+    except InvalidProgramError as error:
+        result = ErrorResult(error="invalid_program", message=error.message)
+        status_code = 400
+        return JSONResponse(status_code=status_code, content=result.model_dump(exclude_none=True))
+    except TimeoutError as error:
+        result = ErrorResult(error="timeout", timeout_seconds=error.timeout_seconds)
+        status_code = 408
+        return JSONResponse(status_code=status_code, content=result.model_dump(exclude_none=True))
+    finally:
+        cleanup_start_time = perf_counter()
+        blob_store.cleanup()
+        request_cleanup_ms = (perf_counter() - cleanup_start_time) * 1000.0
+        print(
+            "APP_TIMING "
+            f"status_code={status_code} "
+            f"total_execute_ms={(perf_counter() - execute_start_time) * 1000.0:.3f} "
+            f"validate_program_ms={validate_program_ms} "
+            f"scheduler_execute_ms={scheduler_execute_ms} "
+            f"build_response_ms={build_response_ms} "
+            f"request_cleanup_ms={request_cleanup_ms}",
+            flush=True,
+        )
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Server health check with per-worker status.
+
+    Returns
+    -------
+    HealthResponse
+        Structured health summary for all managed workers.
+    """
+    scheduler = _get_scheduler()
+    workers = [
+        WorkerStatus(
+            gpu_id=worker.gpu_id,
+            status=worker.status,
+            queue_length=worker.queue_length,
+            uptime_seconds=worker.uptime_seconds,
+        )
+        for worker in scheduler._workers
+    ]
+    return HealthResponse(gpu_count=len(workers), workers=workers)
+
+
+async def _parse_request_into_shared_memory(
+    request: Request, blob_store: RequestSharedMemoryStore
+) -> dict:
+    """Parse multipart request parts and materialize uploaded blobs into shared memory.
+
+    Parameters
+    ----------
+    request
+        Incoming multipart HTTP request.
+    blob_store
+        Request-local shared-memory store that will receive uploaded blobs.
+
+    Returns
+    -------
+    dict
+        Raw decoded JSON object from the `program` multipart field.
+    """
+    parse_start_time = perf_counter()
+    form_parse_start_time = perf_counter()
+    form = await request.form()
+    request_form_ms = (perf_counter() - form_parse_start_time) * 1000.0
+    program: Optional[dict] = None
+    num_blobs = 0
+    total_blob_bytes = 0
+    program_read_ms = 0.0
+    program_json_decode_ms = 0.0
+    blob_read_ms = 0.0
+    blob_store_ms = 0.0
+
+    for key, value in form.multi_items():
+        if key == "program":
+            program_read_start_time = perf_counter()
+            program_bytes = await _read_form_part_bytes(value)
+            program_read_ms += (perf_counter() - program_read_start_time) * 1000.0
+            try:
+                program_json_decode_start_time = perf_counter()
+                program = json.loads(program_bytes.decode("utf-8"))
+                program_json_decode_ms += (perf_counter() - program_json_decode_start_time) * 1000.0
+            except Exception as error:
+                raise InvalidProgramError(f"Invalid program JSON: {error}") from error
+            continue
+
+        if key.startswith("blob:"):
+            blob_hash = key.split(":", 1)[1]
+            blob_read_start_time = perf_counter()
+            blob_bytes = await _read_form_part_bytes(value)
+            blob_read_ms += (perf_counter() - blob_read_start_time) * 1000.0
+            blob_store_start_time = perf_counter()
+            blob_store.add_blob(blob_hash, blob_bytes)
+            blob_store_ms += (perf_counter() - blob_store_start_time) * 1000.0
+            num_blobs += 1
+            total_blob_bytes += len(blob_bytes)
+
+    if program is None:
+        raise InvalidProgramError("Missing program part")
+    print(
+        "APP_PARSE_TIMING "
+        f"total_parse_ms={(perf_counter() - parse_start_time) * 1000.0:.3f} "
+        f"request_form_ms={request_form_ms:.3f} "
+        f"program_read_ms={program_read_ms:.3f} "
+        f"program_json_decode_ms={program_json_decode_ms:.3f} "
+        f"blob_read_ms={blob_read_ms:.3f} "
+        f"blob_store_ms={blob_store_ms:.3f} "
+        f"num_blobs={num_blobs} "
+        f"total_blob_bytes={total_blob_bytes}",
+        flush=True,
+    )
+    return program
+
+
+async def _read_form_part_bytes(value: object) -> bytes:
+    """Normalize one multipart field into raw bytes.
+
+    Parameters
+    ----------
+    value
+        Multipart field value returned by Starlette form parsing.
+
+    Returns
+    -------
+    bytes
+        Raw bytes representing the multipart field payload.
+    """
+    if isinstance(value, UploadFile):
+        return await value.read()
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    if isinstance(value, bytes):
+        return value
+    raise InvalidProgramError(f"Unsupported multipart part type: {type(value)!r}")
+
+
+def main():
+    """Run the low-level server as a standalone uvicorn process.
+
+    Returns
+    -------
+    None
+        This function configures logging, creates the app, and starts Uvicorn.
+    """
+    import argparse
+    import logging
+
+    import uvicorn
+
+    parser = argparse.ArgumentParser(description="Low-level GPU judge server")
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8001)
+    parser.add_argument(
+        "--devices", type=str, default=None, help="Comma-separated, e.g. cuda:0,cuda:1"
+    )
+    parser.add_argument(
+        "--timeout", type=int, default=30, help="Default execution timeout in seconds"
+    )
+    parser.add_argument(
+        "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level))
+
+    devices = args.devices.split(",") if args.devices else list_cuda_devices()
+    if not devices:
+        raise RuntimeError("No CUDA devices available")
+
+    create_app(devices=devices, default_timeout_seconds=args.timeout)
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/flashinfer_bench/serve/low_level/app.py
+++ b/flashinfer_bench/serve/low_level/app.py
@@ -2,177 +2,34 @@
 
 from __future__ import annotations
 
-import asyncio
-import json
+import time
+import uuid
 from contextlib import asynccontextmanager
-from multiprocessing import shared_memory
-from time import perf_counter
-from typing import Literal, Optional
 
-from fastapi import FastAPI, Request
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import JSONResponse, Response
-from pydantic import BaseModel, ValidationError
-from starlette.datastructures import UploadFile
 
-from flashinfer_bench.serve.low_level.errors import InvalidProgramError, TimeoutError
-from flashinfer_bench.serve.low_level.executor import (
+from flashinfer_bench.serve.low_level.errors import InvalidProgramError
+from flashinfer_bench.serve.low_level.multipart import (
+    build_multipart_response,
+    parse_multipart_request,
+)
+from flashinfer_bench.serve.low_level.schema import (
     ErrorResult,
     ExecuteResult,
-    Instruction,
-    Program,
-    SharedMemoryBlob,
+    HealthResponse,
+    ServerExecuteResponseKind,
 )
-from flashinfer_bench.serve.low_level.multipart import build_success_response
-from flashinfer_bench.serve.low_level.worker import (
-    LowLevelScheduler,
-    WorkerExecuteErrorResponse,
-    WorkerExecuteSuccessResponse,
-)
+from flashinfer_bench.serve.low_level.server import LowLevelServer
 from flashinfer_bench.utils import list_cuda_devices
 from flashinfer_bench.version import __version__
 
-# ---------------------------------------------------------------------------
-# HTTP request/response schemas
-# ---------------------------------------------------------------------------
-
-
-class ExecuteRequest(BaseModel):
-    """JSON payload stored in the `program` multipart field for `/execute`."""
-
-    instructions: list[Instruction]
-    """Ordered instruction sequence to execute."""
-    timeout_seconds: float | None = None
-    """Optional per-request timeout override in seconds."""
-
-    @property
-    def program(self) -> Program:
-        """Return the execution program without HTTP-only request metadata.
-
-        Returns
-        -------
-        Program
-            Program object containing only execution instructions.
-        """
-        return Program(instructions=self.instructions)
-
-
-class WorkerStatus(BaseModel):
-    """Health summary for a single GPU worker."""
-
-    gpu_id: int
-    """Physical GPU index assigned to the worker."""
-    status: Literal["idle", "busy", "restarting"]
-    """Current worker runtime status."""
-    queue_length: int
-    """Number of in-flight requests assigned to this worker."""
-    uptime_seconds: int
-    """Worker uptime since the last process start."""
-
-
-class HealthResponse(BaseModel):
-    """Response payload for the `/health` endpoint."""
-
-    status: Literal["ok"] = "ok"
-    """Health check status."""
-    gpu_count: int
-    """Number of configured GPU workers."""
-    workers: list[WorkerStatus]
-    """Per-worker runtime status entries."""
-
-
-class RequestSharedMemoryStore:
-    """Own shared-memory blobs created for one HTTP request."""
-
-    blobs: dict[str, SharedMemoryBlob]
-    """Shared-memory blob metadata keyed by blob hash."""
-    _shared_memories: list[shared_memory.SharedMemory]
-    """Owned shared-memory objects that must be released after the request."""
-
-    def __init__(self) -> None:
-        """Initialize an empty request-local shared-memory store.
-
-        Returns
-        -------
-        None
-            This constructor initializes internal storage in place.
-        """
-        self.blobs: dict[str, SharedMemoryBlob] = {}
-        self._shared_memories: list[shared_memory.SharedMemory] = []
-
-    def add_blob(self, blob_hash: str, blob_bytes: bytes) -> None:
-        """Create one shared-memory blob and record its metadata.
-
-        Parameters
-        ----------
-        blob_hash
-            Blob hash used as the logical blob key.
-        blob_bytes
-            Raw blob payload received from the HTTP request.
-
-        Returns
-        -------
-        None
-            This method mutates the shared-memory store in place.
-        """
-        if blob_hash in self.blobs:
-            raise InvalidProgramError(f"Duplicate blob: {blob_hash}")
-
-        shared_memory_size = max(1, len(blob_bytes))
-        blob_shared_memory = shared_memory.SharedMemory(create=True, size=shared_memory_size)
-        try:
-            blob_shared_memory.buf[: len(blob_bytes)] = blob_bytes
-        except Exception:
-            blob_shared_memory.close()
-            blob_shared_memory.unlink()
-            raise
-
-        self._shared_memories.append(blob_shared_memory)
-        self.blobs[blob_hash] = SharedMemoryBlob(name=blob_shared_memory.name, size=len(blob_bytes))
-
-    def cleanup(self) -> None:
-        """Release all request shared-memory blobs.
-
-        Returns
-        -------
-        None
-            This method releases owned shared-memory objects in place.
-        """
-        for blob_shared_memory in self._shared_memories:
-            try:
-                blob_shared_memory.close()
-            except Exception:
-                pass
-            try:
-                blob_shared_memory.unlink()
-            except FileNotFoundError:
-                pass
-        self._shared_memories.clear()
-        self.blobs.clear()
-
-
-# ---------------------------------------------------------------------------
-# FastAPI app
-# ---------------------------------------------------------------------------
-
-_scheduler: Optional[LowLevelScheduler] = None
-
-
-def _get_scheduler() -> LowLevelScheduler:
-    """Return the initialized scheduler instance.
-
-    Returns
-    -------
-    LowLevelScheduler
-        Initialized scheduler singleton for the current process.
-    """
-    if _scheduler is None:
-        raise RuntimeError("Low-level server is not initialized")
-    return _scheduler
+router = APIRouter()
 
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    """Own the scheduler lifecycle for the module-level FastAPI app.
+    """Own the runtime lifecycle for one FastAPI app instance.
 
     Parameters
     ----------
@@ -184,16 +41,119 @@ async def _lifespan(app: FastAPI):
     None
         Control returns to FastAPI while the app is serving requests.
     """
-    yield
-    if _scheduler is not None:
-        _scheduler.close()
+    server = app.state.server
+    assert isinstance(server, LowLevelServer), "Low-level server is not initialized"
+    await server.start()
+    try:
+        yield
+    finally:
+        await server.shutdown()
+        app.state.server = None
 
 
-app = FastAPI(title="FlashInfer-Bench Low-Level Server", version=__version__, lifespan=_lifespan)
+@router.post(
+    "/execute",
+    responses={
+        200: {"description": "Success (multipart)", "model": ExecuteResult},
+        400: {"description": "Invalid program or execution failed", "model": ErrorResult},
+        408: {"description": "Timeout", "model": ErrorResult},
+    },
+)
+async def execute(request: Request):
+    """Execute a program on GPU.
+
+    Parameters
+    ----------
+    request
+        Incoming HTTP request carrying one multipart execution payload.
+
+    Returns
+    -------
+    Response
+        Multipart success response or JSON error response.
+    """
+    server = request.app.state.server
+    assert isinstance(server, LowLevelServer), "Low-level server is not initialized"
+    trace_id = uuid.uuid4().hex
+    request_start_time = time.perf_counter()
+    print(f"TRACE request_id={trace_id} span=app.request phase=begin", flush=True)
+    try:
+        parse_start_time = time.perf_counter()
+        print(f"TRACE request_id={trace_id} span=app.parse_request phase=begin", flush=True)
+        server_execute_request = await parse_multipart_request(request, server.cache_manager)
+        print(
+            f"TRACE request_id={trace_id} span=app.parse_request phase=end "
+            f"duration_ms={(time.perf_counter() - parse_start_time) * 1000.0:.3f}",
+            flush=True,
+        )
+    except InvalidProgramError as error:
+        result = ErrorResult(error="invalid_program", message=error.message)
+        return JSONResponse(status_code=400, content=result.model_dump(exclude_none=True))
+
+    server_execute_start_time = time.perf_counter()
+    print(f"TRACE request_id={trace_id} span=app.server_execute phase=begin", flush=True)
+    server_response = await server.execute_request(server_execute_request, trace_id=trace_id)
+    print(
+        f"TRACE request_id={trace_id} span=app.server_execute phase=end "
+        f"duration_ms={(time.perf_counter() - server_execute_start_time) * 1000.0:.3f}",
+        flush=True,
+    )
+    if server_response.kind is ServerExecuteResponseKind.OK:
+        success_payload = server_response.payload
+        assert isinstance(
+            success_payload, ExecuteResult
+        ), "Successful server response must carry ExecuteResult"
+        build_response_start_time = time.perf_counter()
+        print(f"TRACE request_id={trace_id} span=app.build_response phase=begin", flush=True)
+        body, content_type = build_multipart_response(
+            result=success_payload, binary_parts=server_response.binary_parts
+        )
+        print(
+            f"TRACE request_id={trace_id} span=app.build_response phase=end "
+            f"duration_ms={(time.perf_counter() - build_response_start_time) * 1000.0:.3f}",
+            flush=True,
+        )
+        print(
+            f"TRACE request_id={trace_id} span=app.request phase=end "
+            f"duration_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f}",
+            flush=True,
+        )
+        return Response(content=body, media_type=content_type, status_code=200)
+    elif server_response.kind is ServerExecuteResponseKind.TIMEOUT:
+        print(
+            f"TRACE request_id={trace_id} span=app.request phase=end "
+            f"duration_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f}",
+            flush=True,
+        )
+        return JSONResponse(
+            status_code=408, content=server_response.payload.model_dump(exclude_none=True)
+        )
+    print(
+        f"TRACE request_id={trace_id} span=app.request phase=end "
+        f"duration_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f}",
+        flush=True,
+    )
+    return JSONResponse(
+        status_code=400, content=server_response.payload.model_dump(exclude_none=True)
+    )
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health(request: Request) -> HealthResponse:
+    """Server health check with per-worker status.
+
+    Returns
+    -------
+    HealthResponse
+        Structured health summary for all managed workers.
+    """
+    server = request.app.state.server
+    assert isinstance(server, LowLevelServer), "Low-level server is not initialized"
+    return server.health_response()
 
 
 def create_app(devices: list[str], default_timeout_seconds: int = 30) -> FastAPI:
-    """Create the low-level app with a concrete scheduler.
+    """Create the low-level app with a concrete server instance.
 
     Parameters
     ----------
@@ -207,225 +167,14 @@ def create_app(devices: list[str], default_timeout_seconds: int = 30) -> FastAPI
     FastAPI
         Configured FastAPI application instance.
     """
-    global _scheduler
-    _scheduler = LowLevelScheduler(devices=devices, default_timeout_seconds=default_timeout_seconds)
-    return app
-
-
-def create_default_app() -> FastAPI:
-    """Factory for ad-hoc uvicorn startup.
-
-    Returns
-    -------
-    FastAPI
-        Configured FastAPI application using detected CUDA devices.
-    """
-    devices = list_cuda_devices()
-    return create_app(devices=devices, default_timeout_seconds=30)
-
-
-@app.post(
-    "/execute",
-    responses={
-        200: {"description": "Success (multipart)", "model": ExecuteResult},
-        400: {"description": "Invalid program or execution failed", "model": ErrorResult},
-        408: {"description": "Timeout", "model": ErrorResult},
-    },
-)
-async def execute(request: Request):
-    """Execute a program on GPU.
-
-    Input: multipart/form-data
-      - program: ExecuteRequest JSON
-      - blob:<sha256>: binary data (referenced by instructions)
-    Output: multipart/form-data
-      - result: ExecuteResult JSON (including optional stdout/stderr)
-      - return:<key>: binary return values (tensors, bytes)
-
-    Parameters
-    ----------
-    request
-        Incoming HTTP request carrying one multipart execution payload.
-
-    Returns
-    -------
-    Response
-        Multipart success response or JSON error response.
-    """
-    execute_start_time = perf_counter()
-    blob_store = RequestSharedMemoryStore()
-    validate_program_ms: float | None = None
-    scheduler_execute_ms: float | None = None
-    build_response_ms: float | None = None
-    request_cleanup_ms: float | None = None
-    status_code: int | None = None
-    try:
-        raw_json = await _parse_request_into_shared_memory(request, blob_store)
-        try:
-            validate_start_time = perf_counter()
-            execute_request = ExecuteRequest.model_validate(raw_json)
-            validate_program_ms = (perf_counter() - validate_start_time) * 1000.0
-        except ValidationError as error:
-            raise InvalidProgramError(str(error)) from error
-        program = execute_request.program
-        scheduler_execute_start_time = perf_counter()
-        response = await asyncio.to_thread(
-            _get_scheduler().execute, program, execute_request.timeout_seconds, blob_store.blobs
-        )
-        scheduler_execute_ms = (perf_counter() - scheduler_execute_start_time) * 1000.0
-        if isinstance(response, WorkerExecuteErrorResponse):
-            error_result: ErrorResult = response.error
-            status_code = 400
-            return JSONResponse(
-                status_code=status_code, content=error_result.model_dump(exclude_none=True)
-            )
-
-        success_response: WorkerExecuteSuccessResponse = response
-        result: ExecuteResult = success_response.result
-        binary_parts: dict[str, bytes] = success_response.binary_parts
-        build_response_start_time = perf_counter()
-        body, content_type = build_success_response(
-            result_payload=result.model_dump(), binary_parts=binary_parts
-        )
-        build_response_ms = (perf_counter() - build_response_start_time) * 1000.0
-        status_code = 200
-        return Response(content=body, media_type=content_type)
-    except InvalidProgramError as error:
-        result = ErrorResult(error="invalid_program", message=error.message)
-        status_code = 400
-        return JSONResponse(status_code=status_code, content=result.model_dump(exclude_none=True))
-    except TimeoutError as error:
-        result = ErrorResult(error="timeout", timeout_seconds=error.timeout_seconds)
-        status_code = 408
-        return JSONResponse(status_code=status_code, content=result.model_dump(exclude_none=True))
-    finally:
-        cleanup_start_time = perf_counter()
-        blob_store.cleanup()
-        request_cleanup_ms = (perf_counter() - cleanup_start_time) * 1000.0
-        print(
-            "APP_TIMING "
-            f"status_code={status_code} "
-            f"total_execute_ms={(perf_counter() - execute_start_time) * 1000.0:.3f} "
-            f"validate_program_ms={validate_program_ms} "
-            f"scheduler_execute_ms={scheduler_execute_ms} "
-            f"build_response_ms={build_response_ms} "
-            f"request_cleanup_ms={request_cleanup_ms}",
-            flush=True,
-        )
-
-
-@app.get("/health", response_model=HealthResponse)
-async def health() -> HealthResponse:
-    """Server health check with per-worker status.
-
-    Returns
-    -------
-    HealthResponse
-        Structured health summary for all managed workers.
-    """
-    scheduler = _get_scheduler()
-    workers = [
-        WorkerStatus(
-            gpu_id=worker.gpu_id,
-            status=worker.status,
-            queue_length=worker.queue_length,
-            uptime_seconds=worker.uptime_seconds,
-        )
-        for worker in scheduler._workers
-    ]
-    return HealthResponse(gpu_count=len(workers), workers=workers)
-
-
-async def _parse_request_into_shared_memory(
-    request: Request, blob_store: RequestSharedMemoryStore
-) -> dict:
-    """Parse multipart request parts and materialize uploaded blobs into shared memory.
-
-    Parameters
-    ----------
-    request
-        Incoming multipart HTTP request.
-    blob_store
-        Request-local shared-memory store that will receive uploaded blobs.
-
-    Returns
-    -------
-    dict
-        Raw decoded JSON object from the `program` multipart field.
-    """
-    parse_start_time = perf_counter()
-    form_parse_start_time = perf_counter()
-    form = await request.form()
-    request_form_ms = (perf_counter() - form_parse_start_time) * 1000.0
-    program: Optional[dict] = None
-    num_blobs = 0
-    total_blob_bytes = 0
-    program_read_ms = 0.0
-    program_json_decode_ms = 0.0
-    blob_read_ms = 0.0
-    blob_store_ms = 0.0
-
-    for key, value in form.multi_items():
-        if key == "program":
-            program_read_start_time = perf_counter()
-            program_bytes = await _read_form_part_bytes(value)
-            program_read_ms += (perf_counter() - program_read_start_time) * 1000.0
-            try:
-                program_json_decode_start_time = perf_counter()
-                program = json.loads(program_bytes.decode("utf-8"))
-                program_json_decode_ms += (perf_counter() - program_json_decode_start_time) * 1000.0
-            except Exception as error:
-                raise InvalidProgramError(f"Invalid program JSON: {error}") from error
-            continue
-
-        if key.startswith("blob:"):
-            blob_hash = key.split(":", 1)[1]
-            blob_read_start_time = perf_counter()
-            blob_bytes = await _read_form_part_bytes(value)
-            blob_read_ms += (perf_counter() - blob_read_start_time) * 1000.0
-            blob_store_start_time = perf_counter()
-            blob_store.add_blob(blob_hash, blob_bytes)
-            blob_store_ms += (perf_counter() - blob_store_start_time) * 1000.0
-            num_blobs += 1
-            total_blob_bytes += len(blob_bytes)
-
-    if program is None:
-        raise InvalidProgramError("Missing program part")
-    print(
-        "APP_PARSE_TIMING "
-        f"total_parse_ms={(perf_counter() - parse_start_time) * 1000.0:.3f} "
-        f"request_form_ms={request_form_ms:.3f} "
-        f"program_read_ms={program_read_ms:.3f} "
-        f"program_json_decode_ms={program_json_decode_ms:.3f} "
-        f"blob_read_ms={blob_read_ms:.3f} "
-        f"blob_store_ms={blob_store_ms:.3f} "
-        f"num_blobs={num_blobs} "
-        f"total_blob_bytes={total_blob_bytes}",
-        flush=True,
+    app = FastAPI(
+        title="FlashInfer-Bench Low-Level Server", version=__version__, lifespan=_lifespan
     )
-    return program
-
-
-async def _read_form_part_bytes(value: object) -> bytes:
-    """Normalize one multipart field into raw bytes.
-
-    Parameters
-    ----------
-    value
-        Multipart field value returned by Starlette form parsing.
-
-    Returns
-    -------
-    bytes
-        Raw bytes representing the multipart field payload.
-    """
-    if isinstance(value, UploadFile):
-        return await value.read()
-    if isinstance(value, str):
-        return value.encode("utf-8")
-    if isinstance(value, bytes):
-        return value
-    raise InvalidProgramError(f"Unsupported multipart part type: {type(value)!r}")
+    app.state.server = LowLevelServer(
+        devices=devices, default_timeout_seconds=default_timeout_seconds
+    )
+    app.include_router(router)
+    return app
 
 
 def main():
@@ -461,8 +210,8 @@ def main():
     if not devices:
         raise RuntimeError("No CUDA devices available")
 
-    create_app(devices=devices, default_timeout_seconds=args.timeout)
-    uvicorn.run(app, host=args.host, port=args.port)
+    application = create_app(devices=devices, default_timeout_seconds=args.timeout)
+    uvicorn.run(application, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":

--- a/flashinfer_bench/serve/low_level/cache.py
+++ b/flashinfer_bench/serve/low_level/cache.py
@@ -1,0 +1,286 @@
+"""Server-side persistent blob cache backed by shared-memory files."""
+
+from __future__ import annotations
+
+import mmap
+import os
+import threading
+from collections import OrderedDict
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class ShmUtils:
+    """Thin helpers for shared-memory blob file operations."""
+
+    @staticmethod
+    def write(cache_root: str | Path, blob_hash: str, blob: bytes) -> str:
+        """Write one blob into the cache root and return its file path."""
+        cache_root_path = Path(cache_root)
+        cache_root_path.mkdir(parents=True, exist_ok=True)
+        blob_path = cache_root_path / blob_hash
+        if not blob_path.exists():
+            blob_path.write_bytes(blob)
+        return str(blob_path)
+
+    @staticmethod
+    def read(file_path: str | Path) -> memoryview:
+        """Map one cached blob file and return a memoryview."""
+        with open(file_path, "rb") as blob_file:
+            blob_map = mmap.mmap(blob_file.fileno(), length=0, access=mmap.ACCESS_READ)
+        return memoryview(blob_map)
+
+    @staticmethod
+    def list(cache_root: str | Path) -> list[str]:
+        """List all cached blob file paths under one cache root."""
+        cache_root_path = Path(cache_root)
+        if not cache_root_path.exists():
+            return []
+        return [str(path) for path in cache_root_path.iterdir() if path.is_file()]
+
+    @staticmethod
+    def delete(file_path: str | Path) -> None:
+        """Delete one cached blob file if it exists."""
+        Path(file_path).unlink(missing_ok=True)
+
+
+class CacheEntry(BaseModel):
+    """One cached blob object stored as a file on tmpfs."""
+
+    blob_hash: str
+    """Content hash identifying the blob."""
+    path: str
+    """Absolute file-system path of the cached blob object."""
+    size: int
+    """Logical blob size in bytes."""
+    ref_count: int = 0
+    """Number of in-flight requests currently using this blob."""
+
+
+class CacheManager:
+    """Manage persistent cached blob files for the low-level server.
+
+    The public API includes:
+
+    - ``get``, ``set``, and ``set_staged`` all return an already-acquired
+      ``CacheEntry``.
+    - Every ``CacheEntry`` returned to the caller must eventually be passed
+      to ``release`` exactly once.
+    - ``clear`` wipes the cache directory, but only when no entry is active.
+    """
+
+    def __init__(
+        self,
+        cache_root: str | Path = "/dev/shm/flashinfer-bench-cache",
+        cache_capacity_bytes: int = 64 * 1024 * 1024 * 1024,
+    ) -> None:
+        """Initialize the cache manager.
+
+        Parameters
+        ----------
+        cache_root
+            Root directory storing blob files.
+        cache_capacity_bytes
+            Best-effort capacity limit for in-memory indexed cache objects.
+
+        Returns
+        -------
+        None
+            This constructor prepares directories and internal state in place.
+        """
+        self.cache_root = Path(cache_root)
+        self.cache_root.mkdir(parents=True, exist_ok=True)
+        self.cache_capacity_bytes = cache_capacity_bytes
+        # OrderedDict doubles as the LRU queue: oldest first, newest last.
+        self._entries: OrderedDict[str, CacheEntry] = OrderedDict()
+        self._indexed_bytes = 0
+        self._lock = threading.Lock()
+
+    def get(self, blob_hash: str) -> CacheEntry | None:
+        """Return one cached entry and acquire a reference on it.
+
+        Parameters
+        ----------
+        blob_hash
+            Content hash identifying the requested blob.
+
+        Returns
+        -------
+        CacheEntry | None
+            Cached blob entry already acquired by the caller, or ``None``
+            when the blob does not exist.
+        """
+        with self._lock:
+            entry = self._entries.get(blob_hash)
+            if entry is None:
+                entry = self._find_disk_entry(blob_hash)
+            if entry is None:
+                return None
+            entry.ref_count += 1
+            self._entries.move_to_end(entry.blob_hash)
+            return entry
+
+    def set(self, blob_hash: str, blob: bytes) -> CacheEntry:
+        """Commit one blob into the cache and acquire a reference.
+
+        Parameters
+        ----------
+        blob_hash
+            Content hash identifying the blob.
+        blob
+            Raw blob payload bytes.
+
+        Returns
+        -------
+        CacheEntry
+            Cached blob entry already acquired by the caller.
+        """
+        blob_size = len(blob)
+        with self._lock:
+            existing = self._entries.get(blob_hash)
+            if existing is None:
+                existing = self._find_disk_entry(blob_hash)
+            if existing is not None:
+                existing.ref_count += 1
+                self._entries.move_to_end(existing.blob_hash)
+                return existing
+
+            blob_path = ShmUtils.write(self.cache_root, blob_hash, blob)
+            entry = CacheEntry(blob_hash=blob_hash, path=blob_path, size=blob_size, ref_count=0)
+            self._entries[blob_hash] = entry
+            self._indexed_bytes += blob_size
+            entry.ref_count += 1
+            self._entries.move_to_end(entry.blob_hash)
+            self._evict_entries()
+            return entry
+
+    def set_staged(self, blob_hash: str, staged_path: str | Path, size: int) -> CacheEntry:
+        """Commit one staged blob file into the cache and acquire a reference.
+
+        Parameters
+        ----------
+        blob_hash
+            Content hash identifying the blob.
+        staged_path
+            Temporary file path holding the already-written blob bytes.
+        size
+            Logical blob size in bytes.
+
+        Returns
+        -------
+        CacheEntry
+            Cached blob entry already acquired by the caller.
+        """
+        staged_path = Path(staged_path)
+        with self._lock:
+            existing = self._entries.get(blob_hash)
+            if existing is None:
+                existing = self._find_disk_entry(blob_hash)
+            if existing is not None:
+                staged_path.unlink(missing_ok=True)
+                existing.ref_count += 1
+                self._entries.move_to_end(existing.blob_hash)
+                return existing
+
+            blob_path = self.cache_root / blob_hash
+            os.replace(staged_path, blob_path)
+            entry = CacheEntry(blob_hash=blob_hash, path=str(blob_path), size=size, ref_count=0)
+            self._entries[blob_hash] = entry
+            self._indexed_bytes += size
+            entry.ref_count += 1
+            self._entries.move_to_end(entry.blob_hash)
+            self._evict_entries()
+            return entry
+
+    def release(self, entry: CacheEntry) -> None:
+        """Release one previously acquired cache entry.
+
+        Parameters
+        ----------
+        entry
+            Cache entry returned by a prior ``get`` or ``set`` call.
+
+        Returns
+        -------
+        None
+            This method decrements the entry's active reference count in place.
+        """
+        with self._lock:
+            tracked = self._entries.get(entry.blob_hash)
+            if tracked is None or tracked is not entry:
+                raise RuntimeError(f"Cannot release unknown blob: {entry.blob_hash}")
+            if tracked.ref_count <= 0:
+                raise RuntimeError(f"Blob {entry.blob_hash} has no active references")
+            tracked.ref_count -= 1
+
+    def clear(self) -> None:
+        """Remove every cached object when no blob is actively referenced.
+
+        Returns
+        -------
+        None
+            This method clears cache files and in-memory state in place.
+        """
+        with self._lock:
+            if any(entry.ref_count > 0 for entry in self._entries.values()):
+                raise RuntimeError("Cannot clear cache while requests are in flight")
+
+            for file_path in ShmUtils.list(self.cache_root):
+                ShmUtils.delete(file_path)
+
+            self._entries.clear()
+            self._indexed_bytes = 0
+
+    def _find_disk_entry(self, blob_hash: str) -> CacheEntry | None:
+        """Find one on-disk cache entry and add it to the in-memory index.
+
+        The caller must already hold ``self._lock``.
+
+        Parameters
+        ----------
+        blob_hash
+            Content hash identifying the requested blob.
+
+        Returns
+        -------
+        CacheEntry | None
+            Cached blob entry already acquired by the caller, or ``None``
+            when the blob does not exist.
+        """
+        blob_path = self.cache_root / blob_hash
+        if not blob_path.exists():
+            return None
+
+        entry = CacheEntry(
+            blob_hash=blob_hash, path=str(blob_path), size=blob_path.stat().st_size, ref_count=0
+        )
+        self._entries[blob_hash] = entry
+        self._indexed_bytes += entry.size
+        return entry
+
+    def _evict_entries(self) -> None:
+        """Evict inactive indexed entries until the cache fits the capacity.
+
+        Returns
+        -------
+        None
+            This method mutates cache files and in-memory state in place. The
+            caller must already hold ``self._lock``. Entries with active
+            references are skipped.
+        """
+        if self._indexed_bytes <= self.cache_capacity_bytes:
+            return
+
+        for blob_hash, entry in list(self._entries.items()):
+            if self._indexed_bytes <= self.cache_capacity_bytes:
+                return
+            if entry.ref_count > 0:
+                continue
+
+            ShmUtils.delete(entry.path)
+            self._indexed_bytes -= entry.size
+            self._entries.pop(blob_hash, None)
+
+
+__all__ = ["CacheEntry", "CacheManager", "ShmUtils"]

--- a/flashinfer_bench/serve/low_level/errors.py
+++ b/flashinfer_bench/serve/low_level/errors.py
@@ -1,0 +1,60 @@
+"""Error types for the low-level GPU server."""
+
+from __future__ import annotations
+
+
+class InvalidProgramError(Exception):
+    def __init__(self, message: str):
+        """Initialize an invalid-program error.
+
+        Parameters
+        ----------
+        message
+            Human-readable validation error message.
+
+        Returns
+        -------
+        None
+            This constructor initializes the exception state in place.
+        """
+        self.message = message
+        super().__init__(message)
+
+
+class ExecutionFailedError(Exception):
+    def __init__(self, message: str, instruction_index: int | None = None):
+        """Initialize an execution-failed error.
+
+        Parameters
+        ----------
+        message
+            Human-readable execution failure message.
+        instruction_index
+            Optional zero-based instruction index associated with the failure.
+
+        Returns
+        -------
+        None
+            This constructor initializes the exception state in place.
+        """
+        self.message = message
+        self.instruction_index = instruction_index
+        super().__init__(message)
+
+
+class TimeoutError(Exception):
+    def __init__(self, timeout_seconds: float):
+        """Initialize a timeout error.
+
+        Parameters
+        ----------
+        timeout_seconds
+            Effective timeout exceeded by the request in seconds.
+
+        Returns
+        -------
+        None
+            This constructor initializes the exception state in place.
+        """
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"Timeout after {timeout_seconds}s")

--- a/flashinfer_bench/serve/low_level/executor.py
+++ b/flashinfer_bench/serve/low_level/executor.py
@@ -3,243 +3,46 @@
 from __future__ import annotations
 
 import importlib.util
+import math
 import sys
 import tempfile
 import uuid
 from dataclasses import dataclass, field
-from multiprocessing import shared_memory
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Dict, Literal, Tuple, Union
+from typing import Any, Dict, Tuple
 
-import numpy as np
 import torch
 import tvm_ffi
-from pydantic import BaseModel, ValidationError
 from tvm_ffi.registry import list_global_func_names
 
+from flashinfer_bench.serve.low_level.cache import CacheEntry, ShmUtils
 from flashinfer_bench.serve.low_level.errors import ExecutionFailedError, InvalidProgramError
-from flashinfer_bench.utils import dtype_str_to_torch_dtype
-
-# ---------------------------------------------------------------------------
-# Instruction schemas
-# ---------------------------------------------------------------------------
-
-SUPPORTED_DTYPES = Literal[
-    "float16", "bfloat16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "bool"
-]
-
-
-class RegisterRef(BaseModel):
-    """Reference a value previously stored in the register file."""
-
-    r: int
-    """Register index to read from."""
-
-
-Operand = Union[RegisterRef, int, float, str, bool, list, None]
-
-
-class UploadPythonModuleInstruction(BaseModel):
-    """Import a Python module blob into the worker process."""
-
-    op: Literal["upload_python_module"]
-    """Instruction opcode."""
-    blob: str
-    """Blob key referencing the uploaded Python module source."""
-
-
-class UploadFfiModuleInstruction(BaseModel):
-    """Load a TVM FFI shared library blob and store its module handle."""
-
-    op: Literal["upload_ffi_module"]
-    """Instruction opcode."""
-    blob: str
-    """Blob key referencing the uploaded shared library bytes."""
-    dst: int
-    """Destination register for the loaded FFI module handle."""
-
-
-class UploadTensorInstruction(BaseModel):
-    """Load a tensor blob onto the worker GPU and store it in a register."""
-
-    op: Literal["upload_tensor"]
-    """Instruction opcode."""
-    dst: int
-    """Destination register for the uploaded tensor."""
-    blob: str
-    """Blob key referencing the raw tensor bytes."""
-    shape: list[int]
-    """Tensor shape in row-major order."""
-    dtype: SUPPORTED_DTYPES
-    """Tensor dtype name."""
-
-
-class CallInstruction(BaseModel):
-    """Call a function with literal operands or register references."""
-
-    op: Literal["call"]
-    """Instruction opcode."""
-    func: str
-    """Function name to invoke."""
-    args: list[Operand]
-    """Function arguments in call order."""
-    dst: int | None = None
-    """Destination register for the return value."""
-    module: RegisterRef | None = None
-    """Optional register reference to a module handle used for function lookup."""
-
-
-class ReturnInstruction(BaseModel):
-    """Expose a register value in the final response payload."""
-
-    op: Literal["return"]
-    """Instruction opcode."""
-    reg: int
-    """Register index to export."""
-    key: str
-    """Response key used in the returns map."""
-
-
-Instruction = Union[
-    UploadPythonModuleInstruction,
-    UploadFfiModuleInstruction,
-    UploadTensorInstruction,
+from flashinfer_bench.serve.low_level.schema import (
+    BytesReturnValue,
     CallInstruction,
+    ExecuteResult,
+    Instruction,
+    JsonReturnValue,
+    Program,
+    RegisterRef,
     ReturnInstruction,
-]
-
-
-class Program(BaseModel):
-    """Executable low-level program independent of HTTP request metadata."""
-
-    instructions: list[Instruction]
-    """Ordered instruction sequence to execute."""
-
-
-def parse_program(raw: dict) -> Program:
-    """Parse and validate a raw JSON dict into a typed `Program`.
-
-    Parameters
-    ----------
-    raw
-        Raw JSON object decoded from the request payload.
-
-    Returns
-    -------
-    Program
-        Validated execution program.
-    """
-    try:
-        return Program.model_validate(raw)
-    except ValidationError as error:
-        raise InvalidProgramError(str(error)) from error
-
-
-# ---------------------------------------------------------------------------
-# Response schemas
-# ---------------------------------------------------------------------------
-
-
-class TensorReturnValue(BaseModel):
-    """Tensor return value described by metadata plus a binary blob part."""
-
-    type: Literal["tensor"] = "tensor"
-    """Return value kind."""
-    dtype: SUPPORTED_DTYPES
-    """Tensor dtype name."""
-    shape: list[int]
-    """Tensor shape in row-major order."""
-    blob: str
-    """Multipart part name containing the raw tensor bytes."""
-
-
-class BytesReturnValue(BaseModel):
-    """Opaque bytes return value stored in a multipart blob part."""
-
-    type: Literal["bytes"] = "bytes"
-    """Return value kind."""
-    blob: str
-    """Multipart part name containing the raw bytes."""
-
-
-class JsonReturnValue(BaseModel):
-    """JSON-serializable return value embedded directly in the result payload."""
-
-    type: Literal["json"] = "json"
-    """Return value kind."""
-    value: Any
-    """JSON-serializable return value."""
-
-
-ReturnValue = Union[TensorReturnValue, BytesReturnValue, JsonReturnValue]
-
-
-class ExecuteResult(BaseModel):
-    """Successful execution result returned in the `result` multipart field."""
-
-    status: Literal["ok"] = "ok"
-    """Execution status."""
-    returns: dict[str, ReturnValue]
-    """Named return values exported by `return` instructions."""
-    elapsed_ms: float
-    """Wall-clock execution time in milliseconds."""
-    stdout: str | None = None
-    """Captured standard output from the worker process."""
-    stderr: str | None = None
-    """Captured standard error from the worker process."""
-
-
-class ErrorResult(BaseModel):
-    """Structured execution error returned as JSON when the request fails."""
-
-    status: Literal["error"] = "error"
-    """Execution status."""
-    error: str
-    """Stable machine-readable error code."""
-    message: str | None = None
-    """Human-readable error summary."""
-    instruction_index: int | None = None
-    """Zero-based instruction index associated with the failure, when available."""
-    timeout_seconds: float | None = None
-    """Effective timeout that was exceeded, when the error is a timeout."""
-    stdout: str | None = None
-    """Captured standard output before the failure."""
-    stderr: str | None = None
-    """Captured standard error before the failure."""
-
-
-class SharedMemoryBlob(BaseModel):
-    """Shared-memory blob metadata passed from the frontend to a worker."""
-
-    name: str
-    """Operating-system shared-memory object name."""
-    size: int
-    """Logical blob size in bytes."""
-
-
-# ---------------------------------------------------------------------------
-# Dtype mappings
-# ---------------------------------------------------------------------------
-
-_DTYPE_TO_NUMPY: Dict[str, np.dtype] = {
-    "float16": np.dtype(np.float16),
-    "bfloat16": np.dtype(np.uint16),
-    "float32": np.dtype(np.float32),
-    "float64": np.dtype(np.float64),
-    "int8": np.dtype(np.int8),
-    "int16": np.dtype(np.int16),
-    "int32": np.dtype(np.int32),
-    "int64": np.dtype(np.int64),
-    "uint8": np.dtype(np.uint8),
-    "bool": np.dtype(np.bool_),
-}
+    ReturnValue,
+    TensorReturnValue,
+    UploadFfiModuleInstruction,
+    UploadPythonModuleInstruction,
+    UploadTensorInstruction,
+)
+from flashinfer_bench.utils import dtype_str_to_torch_dtype
 
 _TORCH_DTYPE_TO_NAME: Dict[torch.dtype, str] = {
     torch.float16: "float16",
     torch.bfloat16: "bfloat16",
     torch.float32: "float32",
     torch.float64: "float64",
+    torch.float8_e4m3fn: "float8_e4m3fn",
+    torch.float8_e5m2: "float8_e5m2",
+    torch.float4_e2m1fn_x2: "float4_e2m1",
     torch.int8: "int8",
     torch.int16: "int16",
     torch.int32: "int32",
@@ -265,10 +68,8 @@ class RequestContext:
     """Imported Python module objects kept alive for the current request."""
     loaded_python_module_names: list[str] = field(default_factory=list)
     """Temporary module names inserted into `sys.modules` for uploaded Python modules."""
-    blobs: Dict[str, SharedMemoryBlob] = field(default_factory=dict)
+    blobs: Dict[str, CacheEntry] = field(default_factory=dict)
     """Uploaded request blobs addressable by blob hash."""
-    attached_shared_memories: Dict[str, shared_memory.SharedMemory] = field(default_factory=dict)
-    """Worker-local shared-memory attachments opened for uploaded blobs."""
 
     def get_register(self, register_index: int) -> Any:
         """Read a value from the request register file.
@@ -330,19 +131,17 @@ class RequestContext:
         Returns
         -------
         memoryview
-            Shared-memory view spanning the logical blob bytes.
+            Memory-mapped view spanning the logical blob bytes.
         """
         if blob_hash not in self.blobs:
             raise InvalidProgramError(f"Missing blob: {blob_hash}")
         blob = self.blobs[blob_hash]
-        if blob_hash not in self.attached_shared_memories:
-            try:
-                self.attached_shared_memories[blob_hash] = shared_memory.SharedMemory(
-                    name=blob.name
-                )
-            except FileNotFoundError as error:
-                raise InvalidProgramError(f"Missing shared-memory blob: {blob_hash}") from error
-        return self.attached_shared_memories[blob_hash].buf[: blob.size]
+        if blob.size == 0:
+            return memoryview(b"")
+        try:
+            return ShmUtils.read(blob.path)[: blob.size]
+        except FileNotFoundError as error:
+            raise InvalidProgramError(f"Missing blob file: {blob_hash}") from error
 
     def read_blob_bytes(self, blob_hash: str) -> bytes:
         """Copy one uploaded blob into an immutable bytes object.
@@ -357,6 +156,11 @@ class RequestContext:
         bytes
             Immutable copy of the requested blob payload.
         """
+        if blob_hash not in self.blobs:
+            raise InvalidProgramError(f"Missing blob: {blob_hash}")
+        blob = self.blobs[blob_hash]
+        if blob.size == 0:
+            return b""
         blob_buffer = self.get_blob_buffer(blob_hash)
         try:
             return bytes(blob_buffer)
@@ -382,9 +186,6 @@ class RequestContext:
             sys.modules.pop(module_name, None)
         self.loaded_python_modules.clear()
         self.loaded_python_module_names.clear()
-        for attached_shared_memory in self.attached_shared_memories.values():
-            attached_shared_memory.close()
-        self.attached_shared_memories.clear()
         self.blobs.clear()
         self.registered_function_names.clear()
 
@@ -395,7 +196,7 @@ class RequestContext:
 
 
 def execute_program(
-    program: Program, blobs: Dict[str, SharedMemoryBlob]
+    program: Program, blobs: Dict[str, CacheEntry], request_id: str | None = None
 ) -> Tuple[ExecuteResult, Dict[str, bytes]]:
     """Execute a validated program against request blobs.
 
@@ -404,7 +205,7 @@ def execute_program(
     program
         Validated low-level program to execute.
     blobs
-        Uploaded request blobs stored in shared memory and keyed by blob hash.
+        Uploaded request blobs stored in the server cache and keyed by blob hash.
 
     Returns
     -------
@@ -419,27 +220,60 @@ def execute_program(
     elapsed_ms: float | None = None
     cleanup_ms: float | None = None
     try:
+        if request_id is not None:
+            print(f"TRACE request_id={request_id} span=executor.total phase=begin", flush=True)
         with tempfile.TemporaryDirectory(prefix="fib_low_level_worker_") as temporary_directory:
             tmp_dir = Path(temporary_directory)
             start_time = perf_counter()
             instruction_loop_start_time = perf_counter()
+            if request_id is not None:
+                print(
+                    f"TRACE request_id={request_id} span=executor.instruction_loop phase=begin",
+                    flush=True,
+                )
             for instruction_index, instruction in enumerate(program.instructions):
                 _execute_instruction(
                     context, tmp_dir, instruction, instruction_index, returned_values
                 )
             instruction_loop_ms = (perf_counter() - instruction_loop_start_time) * 1000.0
+            if request_id is not None:
+                print(
+                    f"TRACE request_id={request_id} span=executor.instruction_loop phase=end "
+                    f"duration_ms={instruction_loop_ms:.3f}",
+                    flush=True,
+                )
             serialize_returns_start_time = perf_counter()
+            if request_id is not None:
+                print(
+                    f"TRACE request_id={request_id} span=executor.serialize_returns phase=begin",
+                    flush=True,
+                )
             returns, binary_parts = _serialize_returns(returned_values)
             serialize_returns_ms = (perf_counter() - serialize_returns_start_time) * 1000.0
+            if request_id is not None:
+                print(
+                    f"TRACE request_id={request_id} span=executor.serialize_returns phase=end "
+                    f"duration_ms={serialize_returns_ms:.3f}",
+                    flush=True,
+                )
             elapsed_ms = (perf_counter() - start_time) * 1000.0
             result = ExecuteResult(returns=returns, elapsed_ms=elapsed_ms)
             return result, binary_parts
     finally:
         cleanup_start_time = perf_counter()
+        if request_id is not None:
+            print(f"TRACE request_id={request_id} span=executor.cleanup phase=begin", flush=True)
         context.cleanup()
         cleanup_ms = (perf_counter() - cleanup_start_time) * 1000.0
+        if request_id is not None:
+            print(
+                f"TRACE request_id={request_id} span=executor.cleanup phase=end "
+                f"duration_ms={cleanup_ms:.3f}",
+                flush=True,
+            )
         print(
             "EXECUTOR_TIMING "
+            f"request_id={request_id} "
             f"total_execute_program_ms={(perf_counter() - execute_program_start_time) * 1000.0:.3f} "
             f"elapsed_ms={elapsed_ms} "
             f"instruction_loop_ms={instruction_loop_ms} "
@@ -447,6 +281,12 @@ def execute_program(
             f"cleanup_ms={cleanup_ms}",
             flush=True,
         )
+        if request_id is not None:
+            print(
+                f"TRACE request_id={request_id} span=executor.total phase=end "
+                f"duration_ms={(perf_counter() - execute_program_start_time) * 1000.0:.3f}",
+                flush=True,
+            )
 
 
 def _execute_instruction(
@@ -661,22 +501,16 @@ def _execute_upload_tensor(context: RequestContext, instruction: UploadTensorIns
         This function mutates the request context in place.
     """
     blob_buffer = context.get_blob_buffer(instruction.blob)
-    numpy_dtype = _DTYPE_TO_NUMPY[instruction.dtype]
-    expected_nbytes = int(np.prod(instruction.shape, dtype=np.int64)) * numpy_dtype.itemsize
+    torch_dtype = dtype_str_to_torch_dtype(instruction.dtype)
+    expected_nbytes = math.prod(instruction.shape) * torch_dtype.itemsize
     try:
         if len(blob_buffer) != expected_nbytes:
             raise InvalidProgramError(
                 f"upload_tensor blob size mismatch: expected {expected_nbytes} bytes, got {len(blob_buffer)}"
             )
 
-        numpy_array = (
-            np.frombuffer(blob_buffer, dtype=numpy_dtype).copy().reshape(instruction.shape)
-        )
-        torch_dtype = dtype_str_to_torch_dtype(instruction.dtype)
-        if instruction.dtype == "bfloat16":
-            tensor = torch.from_numpy(numpy_array.view(np.int16)).view(torch.bfloat16)
-        else:
-            tensor = torch.from_numpy(numpy_array).to(dtype=torch_dtype)
+        tensor = torch.frombuffer(blob_buffer, dtype=torch_dtype)
+        tensor = tensor.view(instruction.shape)
         tensor = tensor.to("cuda:0")
         context.set_register(instruction.dst, tensor)
     finally:
@@ -810,7 +644,7 @@ def _serialize_returns(
         if isinstance(value, torch.Tensor):
             tensor = value.detach().contiguous().cpu()
             part_name = f"return:{key}"
-            binary_parts[part_name] = tensor.numpy().tobytes()
+            binary_parts[part_name] = bytes(tensor.untyped_storage())
             returns[key] = TensorReturnValue(
                 dtype=_TORCH_DTYPE_TO_NAME[tensor.dtype], shape=list(tensor.shape), blob=part_name
             )

--- a/flashinfer_bench/serve/low_level/executor.py
+++ b/flashinfer_bench/serve/low_level/executor.py
@@ -1,0 +1,824 @@
+"""Program executor for the low-level GPU server."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from multiprocessing import shared_memory
+from pathlib import Path
+from time import perf_counter
+from typing import Any, Dict, Literal, Tuple, Union
+
+import numpy as np
+import torch
+import tvm_ffi
+from pydantic import BaseModel, ValidationError
+from tvm_ffi.registry import list_global_func_names
+
+from flashinfer_bench.serve.low_level.errors import ExecutionFailedError, InvalidProgramError
+from flashinfer_bench.utils import dtype_str_to_torch_dtype
+
+# ---------------------------------------------------------------------------
+# Instruction schemas
+# ---------------------------------------------------------------------------
+
+SUPPORTED_DTYPES = Literal[
+    "float16", "bfloat16", "float32", "float64", "int8", "int16", "int32", "int64", "uint8", "bool"
+]
+
+
+class RegisterRef(BaseModel):
+    """Reference a value previously stored in the register file."""
+
+    r: int
+    """Register index to read from."""
+
+
+Operand = Union[RegisterRef, int, float, str, bool, list, None]
+
+
+class UploadPythonModuleInstruction(BaseModel):
+    """Import a Python module blob into the worker process."""
+
+    op: Literal["upload_python_module"]
+    """Instruction opcode."""
+    blob: str
+    """Blob key referencing the uploaded Python module source."""
+
+
+class UploadFfiModuleInstruction(BaseModel):
+    """Load a TVM FFI shared library blob and store its module handle."""
+
+    op: Literal["upload_ffi_module"]
+    """Instruction opcode."""
+    blob: str
+    """Blob key referencing the uploaded shared library bytes."""
+    dst: int
+    """Destination register for the loaded FFI module handle."""
+
+
+class UploadTensorInstruction(BaseModel):
+    """Load a tensor blob onto the worker GPU and store it in a register."""
+
+    op: Literal["upload_tensor"]
+    """Instruction opcode."""
+    dst: int
+    """Destination register for the uploaded tensor."""
+    blob: str
+    """Blob key referencing the raw tensor bytes."""
+    shape: list[int]
+    """Tensor shape in row-major order."""
+    dtype: SUPPORTED_DTYPES
+    """Tensor dtype name."""
+
+
+class CallInstruction(BaseModel):
+    """Call a function with literal operands or register references."""
+
+    op: Literal["call"]
+    """Instruction opcode."""
+    func: str
+    """Function name to invoke."""
+    args: list[Operand]
+    """Function arguments in call order."""
+    dst: int | None = None
+    """Destination register for the return value."""
+    module: RegisterRef | None = None
+    """Optional register reference to a module handle used for function lookup."""
+
+
+class ReturnInstruction(BaseModel):
+    """Expose a register value in the final response payload."""
+
+    op: Literal["return"]
+    """Instruction opcode."""
+    reg: int
+    """Register index to export."""
+    key: str
+    """Response key used in the returns map."""
+
+
+Instruction = Union[
+    UploadPythonModuleInstruction,
+    UploadFfiModuleInstruction,
+    UploadTensorInstruction,
+    CallInstruction,
+    ReturnInstruction,
+]
+
+
+class Program(BaseModel):
+    """Executable low-level program independent of HTTP request metadata."""
+
+    instructions: list[Instruction]
+    """Ordered instruction sequence to execute."""
+
+
+def parse_program(raw: dict) -> Program:
+    """Parse and validate a raw JSON dict into a typed `Program`.
+
+    Parameters
+    ----------
+    raw
+        Raw JSON object decoded from the request payload.
+
+    Returns
+    -------
+    Program
+        Validated execution program.
+    """
+    try:
+        return Program.model_validate(raw)
+    except ValidationError as error:
+        raise InvalidProgramError(str(error)) from error
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class TensorReturnValue(BaseModel):
+    """Tensor return value described by metadata plus a binary blob part."""
+
+    type: Literal["tensor"] = "tensor"
+    """Return value kind."""
+    dtype: SUPPORTED_DTYPES
+    """Tensor dtype name."""
+    shape: list[int]
+    """Tensor shape in row-major order."""
+    blob: str
+    """Multipart part name containing the raw tensor bytes."""
+
+
+class BytesReturnValue(BaseModel):
+    """Opaque bytes return value stored in a multipart blob part."""
+
+    type: Literal["bytes"] = "bytes"
+    """Return value kind."""
+    blob: str
+    """Multipart part name containing the raw bytes."""
+
+
+class JsonReturnValue(BaseModel):
+    """JSON-serializable return value embedded directly in the result payload."""
+
+    type: Literal["json"] = "json"
+    """Return value kind."""
+    value: Any
+    """JSON-serializable return value."""
+
+
+ReturnValue = Union[TensorReturnValue, BytesReturnValue, JsonReturnValue]
+
+
+class ExecuteResult(BaseModel):
+    """Successful execution result returned in the `result` multipart field."""
+
+    status: Literal["ok"] = "ok"
+    """Execution status."""
+    returns: dict[str, ReturnValue]
+    """Named return values exported by `return` instructions."""
+    elapsed_ms: float
+    """Wall-clock execution time in milliseconds."""
+    stdout: str | None = None
+    """Captured standard output from the worker process."""
+    stderr: str | None = None
+    """Captured standard error from the worker process."""
+
+
+class ErrorResult(BaseModel):
+    """Structured execution error returned as JSON when the request fails."""
+
+    status: Literal["error"] = "error"
+    """Execution status."""
+    error: str
+    """Stable machine-readable error code."""
+    message: str | None = None
+    """Human-readable error summary."""
+    instruction_index: int | None = None
+    """Zero-based instruction index associated with the failure, when available."""
+    timeout_seconds: float | None = None
+    """Effective timeout that was exceeded, when the error is a timeout."""
+    stdout: str | None = None
+    """Captured standard output before the failure."""
+    stderr: str | None = None
+    """Captured standard error before the failure."""
+
+
+class SharedMemoryBlob(BaseModel):
+    """Shared-memory blob metadata passed from the frontend to a worker."""
+
+    name: str
+    """Operating-system shared-memory object name."""
+    size: int
+    """Logical blob size in bytes."""
+
+
+# ---------------------------------------------------------------------------
+# Dtype mappings
+# ---------------------------------------------------------------------------
+
+_DTYPE_TO_NUMPY: Dict[str, np.dtype] = {
+    "float16": np.dtype(np.float16),
+    "bfloat16": np.dtype(np.uint16),
+    "float32": np.dtype(np.float32),
+    "float64": np.dtype(np.float64),
+    "int8": np.dtype(np.int8),
+    "int16": np.dtype(np.int16),
+    "int32": np.dtype(np.int32),
+    "int64": np.dtype(np.int64),
+    "uint8": np.dtype(np.uint8),
+    "bool": np.dtype(np.bool_),
+}
+
+_TORCH_DTYPE_TO_NAME: Dict[torch.dtype, str] = {
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.int8: "int8",
+    torch.int16: "int16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.uint8: "uint8",
+    torch.bool: "bool",
+}
+
+# ---------------------------------------------------------------------------
+# Request context
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RequestContext:
+    register_file: Dict[int, Any] = field(default_factory=dict)
+    """Request-local register file keyed by register index."""
+    registered_function_names: set[str] = field(default_factory=set)
+    """Global function names registered during the current request."""
+    loaded_shared_modules: list[Any] = field(default_factory=list)
+    """Uploaded FFI module handles kept alive for the current request."""
+    loaded_python_modules: list[Any] = field(default_factory=list)
+    """Imported Python module objects kept alive for the current request."""
+    loaded_python_module_names: list[str] = field(default_factory=list)
+    """Temporary module names inserted into `sys.modules` for uploaded Python modules."""
+    blobs: Dict[str, SharedMemoryBlob] = field(default_factory=dict)
+    """Uploaded request blobs addressable by blob hash."""
+    attached_shared_memories: Dict[str, shared_memory.SharedMemory] = field(default_factory=dict)
+    """Worker-local shared-memory attachments opened for uploaded blobs."""
+
+    def get_register(self, register_index: int) -> Any:
+        """Read a value from the request register file.
+
+        Parameters
+        ----------
+        register_index
+            Register index to read.
+
+        Returns
+        -------
+        Any
+            Value currently stored in the register.
+        """
+        if register_index not in self.register_file:
+            raise InvalidProgramError(f"Register r{register_index} is not defined")
+        return self.register_file[register_index]
+
+    def set_register(self, register_index: int, value: Any) -> None:
+        """Store a value in the request register file.
+
+        Parameters
+        ----------
+        register_index
+            Register index to write.
+        value
+            Value to store in the register.
+
+        Returns
+        -------
+        None
+            This method updates the request context in place.
+        """
+        self.register_file[register_index] = value
+
+    def is_loaded_shared_module(self, value: Any) -> bool:
+        """Check whether a value is a request-local uploaded FFI module handle.
+
+        Parameters
+        ----------
+        value
+            Candidate value to test.
+
+        Returns
+        -------
+        bool
+            Whether the value matches one uploaded FFI module handle by identity.
+        """
+        return any(value is shared_module for shared_module in self.loaded_shared_modules)
+
+    def get_blob_buffer(self, blob_hash: str) -> memoryview:
+        """Return a memoryview over one uploaded blob.
+
+        Parameters
+        ----------
+        blob_hash
+            Blob hash referenced by the program instruction.
+
+        Returns
+        -------
+        memoryview
+            Shared-memory view spanning the logical blob bytes.
+        """
+        if blob_hash not in self.blobs:
+            raise InvalidProgramError(f"Missing blob: {blob_hash}")
+        blob = self.blobs[blob_hash]
+        if blob_hash not in self.attached_shared_memories:
+            try:
+                self.attached_shared_memories[blob_hash] = shared_memory.SharedMemory(
+                    name=blob.name
+                )
+            except FileNotFoundError as error:
+                raise InvalidProgramError(f"Missing shared-memory blob: {blob_hash}") from error
+        return self.attached_shared_memories[blob_hash].buf[: blob.size]
+
+    def read_blob_bytes(self, blob_hash: str) -> bytes:
+        """Copy one uploaded blob into an immutable bytes object.
+
+        Parameters
+        ----------
+        blob_hash
+            Blob hash referenced by the program instruction.
+
+        Returns
+        -------
+        bytes
+            Immutable copy of the requested blob payload.
+        """
+        blob_buffer = self.get_blob_buffer(blob_hash)
+        try:
+            return bytes(blob_buffer)
+        finally:
+            blob_buffer.release()
+
+    def cleanup(self) -> None:
+        """Release request-local state after execution finishes.
+
+        Returns
+        -------
+        None
+            This method releases request-owned resources in place.
+        """
+        self.register_file.clear()
+        for function_name in sorted(self.registered_function_names):
+            try:
+                tvm_ffi.remove_global_func(function_name)
+            except Exception:
+                pass
+        self.loaded_shared_modules.clear()
+        for module_name in self.loaded_python_module_names:
+            sys.modules.pop(module_name, None)
+        self.loaded_python_modules.clear()
+        self.loaded_python_module_names.clear()
+        for attached_shared_memory in self.attached_shared_memories.values():
+            attached_shared_memory.close()
+        self.attached_shared_memories.clear()
+        self.blobs.clear()
+        self.registered_function_names.clear()
+
+
+# ---------------------------------------------------------------------------
+# Program execution
+# ---------------------------------------------------------------------------
+
+
+def execute_program(
+    program: Program, blobs: Dict[str, SharedMemoryBlob]
+) -> Tuple[ExecuteResult, Dict[str, bytes]]:
+    """Execute a validated program against request blobs.
+
+    Parameters
+    ----------
+    program
+        Validated low-level program to execute.
+    blobs
+        Uploaded request blobs stored in shared memory and keyed by blob hash.
+
+    Returns
+    -------
+    tuple[ExecuteResult, dict[str, bytes]]
+        Structured result payload plus binary multipart parts.
+    """
+    context = RequestContext(blobs=blobs)
+    returned_values: Dict[str, Any] = {}
+    execute_program_start_time = perf_counter()
+    instruction_loop_ms: float | None = None
+    serialize_returns_ms: float | None = None
+    elapsed_ms: float | None = None
+    cleanup_ms: float | None = None
+    try:
+        with tempfile.TemporaryDirectory(prefix="fib_low_level_worker_") as temporary_directory:
+            tmp_dir = Path(temporary_directory)
+            start_time = perf_counter()
+            instruction_loop_start_time = perf_counter()
+            for instruction_index, instruction in enumerate(program.instructions):
+                _execute_instruction(
+                    context, tmp_dir, instruction, instruction_index, returned_values
+                )
+            instruction_loop_ms = (perf_counter() - instruction_loop_start_time) * 1000.0
+            serialize_returns_start_time = perf_counter()
+            returns, binary_parts = _serialize_returns(returned_values)
+            serialize_returns_ms = (perf_counter() - serialize_returns_start_time) * 1000.0
+            elapsed_ms = (perf_counter() - start_time) * 1000.0
+            result = ExecuteResult(returns=returns, elapsed_ms=elapsed_ms)
+            return result, binary_parts
+    finally:
+        cleanup_start_time = perf_counter()
+        context.cleanup()
+        cleanup_ms = (perf_counter() - cleanup_start_time) * 1000.0
+        print(
+            "EXECUTOR_TIMING "
+            f"total_execute_program_ms={(perf_counter() - execute_program_start_time) * 1000.0:.3f} "
+            f"elapsed_ms={elapsed_ms} "
+            f"instruction_loop_ms={instruction_loop_ms} "
+            f"serialize_returns_ms={serialize_returns_ms} "
+            f"cleanup_ms={cleanup_ms}",
+            flush=True,
+        )
+
+
+def _execute_instruction(
+    context: RequestContext,
+    tmp_dir: Path,
+    instruction: Instruction,
+    instruction_index: int,
+    returned_values: Dict[str, Any],
+) -> None:
+    """Dispatch one typed instruction to the matching execution helper.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    tmp_dir
+        Temporary directory used for request-local module files.
+    instruction
+        Typed instruction to execute.
+    instruction_index
+        Zero-based instruction index in the program.
+    returned_values
+        Mutable map populated by `return` instructions.
+
+    Returns
+    -------
+    None
+        This function mutates the request context and return map in place.
+    """
+    if isinstance(instruction, UploadPythonModuleInstruction):
+        _execute_upload_python_module(context, tmp_dir, instruction, instruction_index)
+    elif isinstance(instruction, UploadFfiModuleInstruction):
+        _execute_upload_ffi_module(context, tmp_dir, instruction, instruction_index)
+    elif isinstance(instruction, UploadTensorInstruction):
+        _execute_upload_tensor(context, instruction)
+    elif isinstance(instruction, CallInstruction):
+        _execute_call(context, instruction, instruction_index)
+    elif isinstance(instruction, ReturnInstruction):
+        _execute_return(context, instruction, returned_values)
+
+
+def _execute_upload_python_module(
+    context: RequestContext,
+    tmp_dir: Path,
+    instruction: UploadPythonModuleInstruction,
+    instruction_index: int,
+) -> None:
+    """Import a Python module blob and track its registered global functions.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    tmp_dir
+        Temporary directory used for request-local module files.
+    instruction
+        Python module upload instruction to execute.
+    instruction_index
+        Zero-based instruction index in the program.
+
+    Returns
+    -------
+    None
+        This function mutates the request context in place.
+    """
+    try:
+        blob_bytes = context.read_blob_bytes(instruction.blob)
+        _load_python_module_blob(context, tmp_dir, instruction.blob, blob_bytes)
+    except (InvalidProgramError, ExecutionFailedError):
+        raise
+    except Exception as error:
+        raise ExecutionFailedError(
+            message=str(error), instruction_index=instruction_index
+        ) from error
+
+
+def _execute_upload_ffi_module(
+    context: RequestContext,
+    tmp_dir: Path,
+    instruction: UploadFfiModuleInstruction,
+    instruction_index: int,
+) -> None:
+    """Load a shared library blob and store the resulting module handle.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    tmp_dir
+        Temporary directory used for request-local module files.
+    instruction
+        FFI module upload instruction to execute.
+    instruction_index
+        Zero-based instruction index in the program.
+
+    Returns
+    -------
+    None
+        This function mutates the request context in place.
+    """
+    try:
+        blob_bytes = context.read_blob_bytes(instruction.blob)
+        loaded_module = _load_shared_library_blob(context, tmp_dir, instruction.blob, blob_bytes)
+        context.set_register(instruction.dst, loaded_module)
+    except (InvalidProgramError, ExecutionFailedError):
+        raise
+    except Exception as error:
+        raise ExecutionFailedError(
+            message=str(error), instruction_index=instruction_index
+        ) from error
+
+
+def _load_python_module_blob(
+    context: RequestContext, tmp_dir: Path, blob_hash: str, blob_bytes: bytes
+) -> None:
+    """Import a Python module blob and record newly registered global functions.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    tmp_dir
+        Temporary directory used for request-local module files.
+    blob_hash
+        Blob hash used to derive the temporary file name.
+    blob_bytes
+        Python module source bytes.
+
+    Returns
+    -------
+    None
+        This function mutates the request context in place.
+    """
+    before_function_names = set(list_global_func_names())
+    module_name = f"flashinfer_bench_uploaded_{uuid.uuid4().hex}"
+    source_path = tmp_dir / f"{blob_hash}.py"
+    source_path.write_bytes(blob_bytes)
+    spec = importlib.util.spec_from_file_location(module_name, str(source_path))
+    if spec is None or spec.loader is None:
+        raise InvalidProgramError(f"Failed to build import spec for blob: {blob_hash}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        after_function_names = set(list_global_func_names())
+        context.registered_function_names.update(after_function_names - before_function_names)
+        sys.modules.pop(module_name, None)
+        raise
+
+    after_function_names = set(list_global_func_names())
+    context.registered_function_names.update(after_function_names - before_function_names)
+    context.loaded_python_modules.append(module)
+    context.loaded_python_module_names.append(module_name)
+
+
+def _load_shared_library_blob(
+    context: RequestContext, tmp_dir: Path, blob_hash: str, blob_bytes: bytes
+):
+    """Load a shared library blob and record newly registered global functions.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    tmp_dir
+        Temporary directory used for request-local module files.
+    blob_hash
+        Blob hash used to derive the temporary file name.
+    blob_bytes
+        Shared-library bytes.
+
+    Returns
+    -------
+    Any
+        Loaded FFI module handle returned by `tvm_ffi.load_module`.
+    """
+    if not blob_bytes.startswith(b"\x7fELF"):
+        raise InvalidProgramError(
+            f"upload_ffi_module expects an ELF shared library blob: {blob_hash}"
+        )
+
+    before_function_names = set(list_global_func_names())
+    shared_library_path = tmp_dir / f"{blob_hash}.so"
+    shared_library_path.write_bytes(blob_bytes)
+    try:
+        loaded_module = tvm_ffi.load_module(str(shared_library_path), keep_module_alive=False)
+    except Exception:
+        after_function_names = set(list_global_func_names())
+        context.registered_function_names.update(after_function_names - before_function_names)
+        raise
+
+    after_function_names = set(list_global_func_names())
+    context.registered_function_names.update(after_function_names - before_function_names)
+    context.loaded_shared_modules.append(loaded_module)
+    return loaded_module
+
+
+def _execute_upload_tensor(context: RequestContext, instruction: UploadTensorInstruction) -> None:
+    """Materialize a tensor blob on the worker GPU and store it in a register.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    instruction
+        Tensor upload instruction to execute.
+
+    Returns
+    -------
+    None
+        This function mutates the request context in place.
+    """
+    blob_buffer = context.get_blob_buffer(instruction.blob)
+    numpy_dtype = _DTYPE_TO_NUMPY[instruction.dtype]
+    expected_nbytes = int(np.prod(instruction.shape, dtype=np.int64)) * numpy_dtype.itemsize
+    try:
+        if len(blob_buffer) != expected_nbytes:
+            raise InvalidProgramError(
+                f"upload_tensor blob size mismatch: expected {expected_nbytes} bytes, got {len(blob_buffer)}"
+            )
+
+        numpy_array = (
+            np.frombuffer(blob_buffer, dtype=numpy_dtype).copy().reshape(instruction.shape)
+        )
+        torch_dtype = dtype_str_to_torch_dtype(instruction.dtype)
+        if instruction.dtype == "bfloat16":
+            tensor = torch.from_numpy(numpy_array.view(np.int16)).view(torch.bfloat16)
+        else:
+            tensor = torch.from_numpy(numpy_array).to(dtype=torch_dtype)
+        tensor = tensor.to("cuda:0")
+        context.set_register(instruction.dst, tensor)
+    finally:
+        blob_buffer.release()
+
+
+def _execute_call(
+    context: RequestContext, instruction: CallInstruction, instruction_index: int
+) -> None:
+    """Invoke a function and optionally write the return value to a register.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    instruction
+        Function call instruction to execute.
+    instruction_index
+        Zero-based instruction index in the program.
+
+    Returns
+    -------
+    None
+        This function mutates the request context in place when `dst` is provided.
+    """
+    try:
+        resolved_args = [_resolve_operand(context, item) for item in instruction.args]
+        function = _resolve_function(context, instruction.func, instruction.module)
+        if function is None:
+            raise ExecutionFailedError(
+                message=f"Unknown function: {instruction.func}", instruction_index=instruction_index
+            )
+        result = function(*resolved_args)
+        if instruction.dst is not None:
+            context.set_register(instruction.dst, result)
+    except (InvalidProgramError, ExecutionFailedError):
+        raise
+    except Exception as error:
+        raise ExecutionFailedError(
+            message=str(error), instruction_index=instruction_index
+        ) from error
+
+
+def _resolve_function(context: RequestContext, function_name: str, module_ref: RegisterRef | None):
+    """Resolve a callable either from global scope or from a module register.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    function_name
+        Function name to resolve.
+    module_ref
+        Optional register reference pointing to an uploaded FFI module handle.
+
+    Returns
+    -------
+    Any
+        Resolved callable object, or `None` when the global function is missing.
+    """
+    if module_ref is None:
+        return tvm_ffi.get_global_func(function_name, allow_missing=True)
+
+    module_value = context.get_register(module_ref.r)
+    if context.is_loaded_shared_module(module_value):
+        return module_value.get_function(function_name)
+    raise InvalidProgramError("call.module must resolve to an uploaded FFI module handle")
+
+
+def _execute_return(
+    context: RequestContext, instruction: ReturnInstruction, returned_values: Dict[str, Any]
+) -> None:
+    """Expose a register value in the final named return map.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    instruction
+        Return instruction to execute.
+    returned_values
+        Mutable map populated with named return values.
+
+    Returns
+    -------
+    None
+        This function mutates the return map in place.
+    """
+    returned_values[instruction.key] = context.get_register(instruction.reg)
+
+
+def _resolve_operand(context: RequestContext, operand: Any) -> Any:
+    """Resolve a literal operand or a register reference.
+
+    Parameters
+    ----------
+    context
+        Request-local execution state.
+    operand
+        Literal value or register reference appearing in the instruction.
+
+    Returns
+    -------
+    Any
+        Resolved Python value ready to pass into the target function.
+    """
+    if isinstance(operand, RegisterRef):
+        return context.get_register(operand.r)
+    return operand
+
+
+def _serialize_returns(
+    returned_values: Dict[str, Any],
+) -> Tuple[Dict[str, ReturnValue], Dict[str, bytes]]:
+    """Convert returned register values into the HTTP result payload.
+
+    Parameters
+    ----------
+    returned_values
+        Named values exported by `return` instructions.
+
+    Returns
+    -------
+    tuple[dict[str, ReturnValue], dict[str, bytes]]
+        Serialized return metadata plus binary multipart parts.
+    """
+    returns: Dict[str, ReturnValue] = {}
+    binary_parts: Dict[str, bytes] = {}
+
+    for key, value in returned_values.items():
+        if isinstance(value, torch.Tensor):
+            tensor = value.detach().contiguous().cpu()
+            part_name = f"return:{key}"
+            binary_parts[part_name] = tensor.numpy().tobytes()
+            returns[key] = TensorReturnValue(
+                dtype=_TORCH_DTYPE_TO_NAME[tensor.dtype], shape=list(tensor.shape), blob=part_name
+            )
+        elif isinstance(value, (bytes, bytearray)):
+            part_name = f"return:{key}"
+            binary_parts[part_name] = bytes(value)
+            returns[key] = BytesReturnValue(blob=part_name)
+        else:
+            returns[key] = JsonReturnValue(value=value)
+
+    return returns, binary_parts

--- a/flashinfer_bench/serve/low_level/multipart.py
+++ b/flashinfer_bench/serve/low_level/multipart.py
@@ -1,31 +1,50 @@
-"""Helpers for building and parsing multipart responses."""
+"""Helpers for request and response multipart payloads."""
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
+import tempfile
 import uuid
+from enum import Enum, auto
+from pathlib import Path
 from typing import Dict, Tuple
+
+from fastapi import Request
+from pydantic import ValidationError
+
+from flashinfer_bench.serve.low_level.cache import CacheEntry, CacheManager
+from flashinfer_bench.serve.low_level.errors import InvalidProgramError
+from flashinfer_bench.serve.low_level.schema import (
+    ExecuteRequest,
+    ExecuteResult,
+    ServerExecuteRequest,
+)
+
+_BOUNDARY_RE = re.compile(r'boundary="?([^";]+)"?')
+_NAME_RE = re.compile(r'name="([^"]+)"')
 
 
 def _encode_part(boundary_bytes: bytes, name: str, content_type: str, payload: bytes) -> bytes:
-    """Encode a single multipart part.
+    """Encode one multipart/form-data part into raw bytes.
 
     Parameters
     ----------
     boundary_bytes
-        Multipart boundary encoded as ASCII bytes.
+        Multipart boundary token without the leading ``--`` marker.
     name
-        Multipart part name.
+        Form-data part name written into ``Content-Disposition``.
     content_type
-        MIME type for the part payload.
+        MIME type written into the part headers.
     payload
         Raw part payload bytes.
 
     Returns
     -------
     bytes
-        Encoded multipart fragment including headers and trailing CRLF.
+        Fully encoded multipart segment including leading boundary, headers,
+        payload, and trailing CRLF.
     """
     return (
         b"--"
@@ -38,29 +57,33 @@ def _encode_part(boundary_bytes: bytes, name: str, content_type: str, payload: b
     )
 
 
-def build_success_response(
-    result_payload: dict, binary_parts: Dict[str, bytes]
+def build_multipart_response(
+    result: ExecuteResult, binary_parts: Dict[str, bytes]
 ) -> Tuple[bytes, str]:
-    """Build a multipart response body and content type.
+    """Build the low-level server success response multipart payload.
 
     Parameters
     ----------
-    result_payload
-        JSON-serializable payload stored in the `result` multipart part.
+    result
+        Structured JSON result written into the ``result`` part.
     binary_parts
-        Named binary multipart parts keyed by part name.
+        Additional binary parts keyed by multipart part name, usually
+        ``return:<key>`` payloads produced by execution.
 
     Returns
     -------
     tuple[bytes, str]
-        Encoded multipart body and corresponding HTTP `Content-Type` header value.
+        Encoded multipart response body plus the matching ``Content-Type`` value.
     """
     boundary = f"flashinfer-bench-{uuid.uuid4().hex}"
     boundary_bytes = boundary.encode("ascii")
     chunks: list[bytes] = []
     chunks.append(
         _encode_part(
-            boundary_bytes, "result", "application/json", json.dumps(result_payload).encode("utf-8")
+            boundary_bytes,
+            "result",
+            "application/json",
+            json.dumps(result.model_dump()).encode("utf-8"),
         )
     )
     for part_name, payload in binary_parts.items():
@@ -71,54 +94,425 @@ def build_success_response(
     return body, content_type
 
 
-_BOUNDARY_RE = re.compile(r"boundary=([^\s;]+)")
-_NAME_RE = re.compile(r'name="([^"]+)"')
-
-
-def parse_multipart_response(content_type: str, body: bytes) -> Tuple[dict, Dict[str, bytes]]:
-    """Parse a multipart response produced by `build_success_response`.
+def _get_boundary(content_type: str | None) -> bytes:
+    """Extract the multipart boundary token from one Content-Type header.
 
     Parameters
     ----------
     content_type
-        HTTP Content-Type header value containing the boundary.
-    body
-        Raw multipart response body bytes.
+        Raw ``Content-Type`` header value from the HTTP request or response.
 
     Returns
     -------
-    tuple[dict, dict[str, bytes]]
-        Parsed JSON result payload and named binary parts.
+    bytes
+        Boundary token encoded as ASCII bytes, without the leading ``--``.
+
+    Raises
+    ------
+    InvalidProgramError
+        Raised when the header is missing or does not describe a multipart body.
     """
+    if content_type is None:
+        raise InvalidProgramError("Missing Content-Type header")
     boundary_match = _BOUNDARY_RE.search(content_type)
     if boundary_match is None:
-        raise ValueError(f"No boundary in Content-Type: {content_type}")
-    delimiter = b"--" + boundary_match.group(1).encode("ascii")
+        raise InvalidProgramError("Expected multipart/form-data body")
+    return boundary_match.group(1).encode("ascii")
 
-    result: dict | None = None
-    binary_parts: Dict[str, bytes] = {}
 
-    for segment in body.split(delimiter):
-        if not segment or segment in (b"\r\n", b"--\r\n", b"--"):
+class _MultipartState(Enum):
+    EXPECT_FIRST_BOUNDARY = auto()
+    READ_HEADERS = auto()
+    READ_PART_BODY = auto()
+    DONE = auto()
+
+
+class _SyncMultipartParser:
+    """Stateful synchronous parser core for low-level execute requests."""
+
+    def __init__(self, boundary: bytes, cache_manager: CacheManager) -> None:
+        self.cache_manager = cache_manager
+        self.first_boundary = b"--" + boundary + b"\r\n"
+        self.next_boundary = b"\r\n--" + boundary
+        self.boundary_overlap = len(self.next_boundary) + 4
+        self.state = _MultipartState.EXPECT_FIRST_BOUNDARY
+        self.buffer = bytearray()
+        self.execute_request: ExecuteRequest | None = None
+        self.blob_entries: Dict[str, CacheEntry] = {}
+        self.current_part_name: str | None = None
+        self.current_program = bytearray()
+        self.current_blob_hash: str | None = None
+        self.current_blob_hasher = None
+        self.current_blob_entry: CacheEntry | None = None
+        self.current_blob_file = None
+        self.current_blob_staged_path: Path | None = None
+        self.current_blob_size = 0
+
+    def feed(self, chunk: bytes) -> None:
+        """Feed one raw body chunk into the parser state machine."""
+        if chunk:
+            self.buffer.extend(chunk)
+        while True:
+            if self.state is _MultipartState.EXPECT_FIRST_BOUNDARY:
+                if len(self.buffer) < len(self.first_boundary):
+                    return
+                if not self.buffer.startswith(self.first_boundary):
+                    raise InvalidProgramError("Invalid multipart opening boundary")
+                del self.buffer[: len(self.first_boundary)]
+                self.state = _MultipartState.READ_HEADERS
+                continue
+
+            if self.state is _MultipartState.READ_HEADERS:
+                header_end = self.buffer.find(b"\r\n\r\n")
+                if header_end < 0:
+                    return
+                headers = _parse_headers(bytes(self.buffer[:header_end]))
+                del self.buffer[: header_end + 4]
+                self._start_part(_get_part_name(headers))
+                self.state = _MultipartState.READ_PART_BODY
+                continue
+
+            if self.state is _MultipartState.READ_PART_BODY:
+                boundary_index = self.buffer.find(self.next_boundary)
+                if boundary_index < 0:
+                    if len(self.buffer) <= self.boundary_overlap:
+                        return
+                    self._feed_current_part(bytes(self.buffer[: -self.boundary_overlap]))
+                    del self.buffer[: -self.boundary_overlap]
+                    return
+
+                self._feed_current_part(bytes(self.buffer[:boundary_index]))
+                del self.buffer[:boundary_index]
+                if len(self.buffer) < len(self.next_boundary) + 2:
+                    return
+
+                boundary_suffix = bytes(
+                    self.buffer[len(self.next_boundary) : len(self.next_boundary) + 2]
+                )
+                if boundary_suffix == b"\r\n":
+                    self._finish_current_part()
+                    del self.buffer[: len(self.next_boundary) + 2]
+                    self.state = _MultipartState.READ_HEADERS
+                    continue
+                if boundary_suffix == b"--":
+                    if len(self.buffer) < len(self.next_boundary) + 4:
+                        return
+                    if (
+                        bytes(
+                            self.buffer[len(self.next_boundary) + 2 : len(self.next_boundary) + 4]
+                        )
+                        != b"\r\n"
+                    ):
+                        raise InvalidProgramError("Invalid multipart closing boundary")
+                    self._finish_current_part()
+                    del self.buffer[: len(self.next_boundary) + 4]
+                    self.state = _MultipartState.DONE
+                    continue
+                raise InvalidProgramError("Invalid multipart boundary suffix")
+
+            if self.state is _MultipartState.DONE:
+                if self.buffer:
+                    raise InvalidProgramError("Unexpected trailing multipart data")
+                return
+
+    def finish(self) -> ServerExecuteRequest:
+        """Finalize parsing after all request chunks have been consumed."""
+        if self.state is not _MultipartState.DONE:
+            raise InvalidProgramError("Incomplete multipart body")
+        if self.execute_request is None:
+            raise InvalidProgramError("Missing program part")
+        return ServerExecuteRequest(
+            execute_request=self.execute_request, blob_entries=self.blob_entries
+        )
+
+    def abort(self) -> None:
+        """Release all request-local parser resources after a failure."""
+        self._cleanup_current_part()
+        for acquired_entry in self.blob_entries.values():
+            try:
+                self.cache_manager.release(acquired_entry)
+            except Exception:
+                pass
+
+    def _start_part(self, part_name: str) -> None:
+        self.current_part_name = part_name
+        if part_name == "program":
+            if self.execute_request is not None:
+                raise InvalidProgramError("Duplicate program part")
+            self.current_program = bytearray()
+            return
+
+        if not part_name.startswith("blob:"):
+            raise InvalidProgramError(f"Unsupported multipart part: {part_name}")
+        self.current_blob_hash = part_name.split(":", 1)[1]
+        if self.current_blob_hash in self.blob_entries:
+            raise InvalidProgramError(f"Duplicate blob: {self.current_blob_hash}")
+        self.current_blob_hasher = hashlib.sha256()
+        self.current_blob_size = 0
+        self.current_blob_entry = self.cache_manager.get(self.current_blob_hash)
+        if self.current_blob_entry is None:
+            staged_file = tempfile.NamedTemporaryFile(
+                mode="w+b", dir=self.cache_manager.cache_root, prefix=".upload-", delete=False
+            )
+            self.current_blob_file = staged_file
+            self.current_blob_staged_path = Path(staged_file.name)
+
+    def _reset_current_part(self) -> None:
+        self.current_part_name = None
+        self.current_program = bytearray()
+        self.current_blob_hash = None
+        self.current_blob_hasher = None
+        self.current_blob_entry = None
+        self.current_blob_file = None
+        self.current_blob_staged_path = None
+        self.current_blob_size = 0
+
+    def _cleanup_current_part(self) -> None:
+        if self.current_blob_file is not None:
+            self.current_blob_file.close()
+            self.current_blob_file = None
+        if self.current_blob_staged_path is not None:
+            self.current_blob_staged_path.unlink(missing_ok=True)
+            self.current_blob_staged_path = None
+        if self.current_blob_entry is not None:
+            self.cache_manager.release(self.current_blob_entry)
+            self.current_blob_entry = None
+        self._reset_current_part()
+
+    def _feed_current_part(self, data: bytes) -> None:
+        if not data:
+            return
+        if self.current_part_name == "program":
+            self.current_program.extend(data)
+            return
+        if self.current_blob_hasher is None or self.current_blob_hash is None:
+            raise InvalidProgramError("Multipart parser lost blob state")
+        self.current_blob_hasher.update(data)
+        self.current_blob_size += len(data)
+        if self.current_blob_file is not None:
+            self.current_blob_file.write(data)
+
+    def _finish_current_part(self) -> None:
+        if self.current_part_name == "program":
+            try:
+                raw_program = json.loads(self.current_program.decode("utf-8"))
+                self.execute_request = ExecuteRequest.model_validate(raw_program)
+            except ValidationError as error:
+                raise InvalidProgramError(str(error)) from error
+            except Exception as error:
+                raise InvalidProgramError(f"Invalid program JSON: {error}") from error
+            self._reset_current_part()
+            return
+
+        if self.current_blob_hash is None or self.current_blob_hasher is None:
+            raise InvalidProgramError("Multipart parser lost blob state")
+        if self.current_blob_hasher.hexdigest() != self.current_blob_hash:
+            raise InvalidProgramError(f"Blob hash mismatch: {self.current_blob_hash}")
+
+        if self.current_blob_file is not None:
+            self.current_blob_file.close()
+            self.current_blob_file = None
+            if self.current_blob_staged_path is None:
+                raise InvalidProgramError("Multipart parser lost staged blob path")
+            cache_entry = self.cache_manager.set_staged(
+                self.current_blob_hash, self.current_blob_staged_path, self.current_blob_size
+            )
+            self.current_blob_staged_path = None
+        else:
+            if self.current_blob_entry is None:
+                raise InvalidProgramError("Multipart parser lost cached blob entry")
+            cache_entry = self.current_blob_entry
+            self.current_blob_entry = None
+        self.blob_entries[self.current_blob_hash] = cache_entry
+        self._reset_current_part()
+
+
+async def parse_multipart_request(
+    request: Request, cache_manager: CacheManager
+) -> ServerExecuteRequest:
+    """Stream one execute request into a validated program plus cached blobs.
+
+    This parser is intentionally narrow and only supports the request protocol
+    used by the low-level server:
+
+    - one ``program`` JSON part
+    - zero or more ``blob:<sha256>`` binary parts
+
+    The async wrapper owns HTTP request streaming, while the actual multipart
+    state machine lives in a private synchronous parser core.
+
+    Parameters
+    ----------
+    request
+        Incoming FastAPI request carrying one multipart execute payload.
+    cache_manager
+        Server-owned blob cache used to resolve or commit uploaded blob parts.
+
+    Returns
+    -------
+    ServerExecuteRequest
+        Validated execute request plus already-acquired cache entries for every
+        uploaded blob referenced by the request.
+
+    Raises
+    ------
+    InvalidProgramError
+        Raised when the multipart envelope, program JSON, blob naming, or blob
+        hash validation fails.
+    """
+    parser = _SyncMultipartParser(
+        boundary=_get_boundary(request.headers.get("content-type")), cache_manager=cache_manager
+    )
+    try:
+        async for chunk in request.stream():
+            parser.feed(chunk)
+        return parser.finish()
+    except BaseException:
+        parser.abort()
+        raise
+
+
+def _parse_headers(header_block: bytes) -> dict[str, str]:
+    """Parse one multipart header block into a lower-case mapping.
+
+    Parameters
+    ----------
+    header_block
+        Raw bytes between one part boundary and the blank line that terminates
+        the part headers.
+
+    Returns
+    -------
+    dict[str, str]
+        Lower-case header name to header value mapping.
+
+    Raises
+    ------
+    InvalidProgramError
+        Raised when one header line is malformed.
+    """
+    headers: dict[str, str] = {}
+    for header_line in header_block.decode("utf-8", errors="replace").split("\r\n"):
+        if not header_line:
             continue
+        if ":" not in header_line:
+            raise InvalidProgramError(f"Invalid multipart header line: {header_line!r}")
+        header_name, header_value = header_line.split(":", 1)
+        headers[header_name.strip().lower()] = header_value.strip()
+    return headers
+
+
+def _get_part_name(headers: dict[str, str]) -> str:
+    """Return the form-data part name from parsed multipart headers.
+
+    Parameters
+    ----------
+    headers
+        Parsed lower-case header mapping for one multipart part.
+
+    Returns
+    -------
+    str
+        Part name extracted from ``Content-Disposition``.
+
+    Raises
+    ------
+    InvalidProgramError
+        Raised when the part does not provide a valid form-data name.
+    """
+    disposition = headers.get("content-disposition")
+    if disposition is None:
+        raise InvalidProgramError("Missing Content-Disposition header")
+    name_match = _NAME_RE.search(disposition)
+    name = name_match.group(1) if name_match is not None else None
+    if name is None:
+        raise InvalidProgramError("Missing multipart part name")
+    return name
+
+
+def _parse_multipart_parts(content_type: str | None, body: bytes) -> list[tuple[str, bytes]]:
+    """Parse one complete multipart body into named payload parts.
+
+    This helper is intentionally non-streaming and is only used on the response
+    side, where the body is already fully materialized in memory.
+
+    Parameters
+    ----------
+    content_type
+        Raw ``Content-Type`` header containing the multipart boundary.
+    body
+        Full multipart payload bytes.
+
+    Returns
+    -------
+    list[tuple[str, bytes]]
+        Ordered ``(part_name, payload_bytes)`` pairs.
+
+    Raises
+    ------
+    InvalidProgramError
+        Raised when the body is not a valid multipart payload for this narrow
+        parser.
+    """
+    boundary = _get_boundary(content_type)
+    delimiter = b"--" + boundary
+    if not body.startswith(delimiter):
+        raise InvalidProgramError("Invalid multipart opening boundary")
+
+    parsed_parts: list[tuple[str, bytes]] = []
+    for segment in body.split(delimiter):
+        if not segment or segment in (b"--", b"--\r\n", b"\r\n"):
+            continue
+        if segment.startswith(b"--"):
+            break
+        if segment.startswith(b"\r\n"):
+            segment = segment[2:]
+        if segment.endswith(b"\r\n"):
+            segment = segment[:-2]
+
         header_end = segment.find(b"\r\n\r\n")
         if header_end < 0:
-            continue
-        header_block = segment[:header_end].decode("utf-8", errors="replace")
+            raise InvalidProgramError("Invalid multipart part: missing header separator")
+        headers = _parse_headers(segment[:header_end])
         payload = segment[header_end + 4 :]
-        if payload.endswith(b"\r\n"):
-            payload = payload[:-2]
+        parsed_parts.append((_get_part_name(headers), payload))
+    return parsed_parts
 
-        name_match = _NAME_RE.search(header_block)
-        if name_match is None:
-            continue
-        name = name_match.group(1)
 
-        if name == "result":
-            result = json.loads(payload)
+def parse_multipart_response(
+    content_type: str, body: bytes
+) -> Tuple[ExecuteResult, Dict[str, bytes]]:
+    """Parse one multipart response produced by ``build_multipart_response``.
+
+    Parameters
+    ----------
+    content_type
+        Raw response ``Content-Type`` header containing the multipart boundary.
+    body
+        Full multipart response body bytes.
+
+    Returns
+    -------
+    tuple[ExecuteResult, dict[str, bytes]]
+        Parsed JSON result object plus a mapping of binary part name to payload.
+
+    Raises
+    ------
+    ValueError
+        Raised when the response does not include the required ``result`` part.
+    """
+    result: ExecuteResult | None = None
+    binary_parts: Dict[str, bytes] = {}
+
+    for part_name, payload in _parse_multipart_parts(content_type, body):
+        if part_name == "result":
+            result = ExecuteResult.model_validate(json.loads(payload.decode("utf-8")))
         else:
-            binary_parts[name] = payload
+            binary_parts[part_name] = payload
 
     if result is None:
         raise ValueError("Missing 'result' part in multipart response")
     return result, binary_parts
+
+
+__all__ = ["build_multipart_response", "parse_multipart_request", "parse_multipart_response"]

--- a/flashinfer_bench/serve/low_level/multipart.py
+++ b/flashinfer_bench/serve/low_level/multipart.py
@@ -1,0 +1,124 @@
+"""Helpers for building and parsing multipart responses."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Dict, Tuple
+
+
+def _encode_part(boundary_bytes: bytes, name: str, content_type: str, payload: bytes) -> bytes:
+    """Encode a single multipart part.
+
+    Parameters
+    ----------
+    boundary_bytes
+        Multipart boundary encoded as ASCII bytes.
+    name
+        Multipart part name.
+    content_type
+        MIME type for the part payload.
+    payload
+        Raw part payload bytes.
+
+    Returns
+    -------
+    bytes
+        Encoded multipart fragment including headers and trailing CRLF.
+    """
+    return (
+        b"--"
+        + boundary_bytes
+        + b"\r\n"
+        + f'Content-Disposition: form-data; name="{name}"\r\n'.encode("utf-8")
+        + f"Content-Type: {content_type}\r\n\r\n".encode("ascii")
+        + payload
+        + b"\r\n"
+    )
+
+
+def build_success_response(
+    result_payload: dict, binary_parts: Dict[str, bytes]
+) -> Tuple[bytes, str]:
+    """Build a multipart response body and content type.
+
+    Parameters
+    ----------
+    result_payload
+        JSON-serializable payload stored in the `result` multipart part.
+    binary_parts
+        Named binary multipart parts keyed by part name.
+
+    Returns
+    -------
+    tuple[bytes, str]
+        Encoded multipart body and corresponding HTTP `Content-Type` header value.
+    """
+    boundary = f"flashinfer-bench-{uuid.uuid4().hex}"
+    boundary_bytes = boundary.encode("ascii")
+    chunks: list[bytes] = []
+    chunks.append(
+        _encode_part(
+            boundary_bytes, "result", "application/json", json.dumps(result_payload).encode("utf-8")
+        )
+    )
+    for part_name, payload in binary_parts.items():
+        chunks.append(_encode_part(boundary_bytes, part_name, "application/octet-stream", payload))
+    chunks.append(b"--" + boundary_bytes + b"--\r\n")
+    body = b"".join(chunks)
+    content_type = f"multipart/form-data; boundary={boundary}"
+    return body, content_type
+
+
+_BOUNDARY_RE = re.compile(r"boundary=([^\s;]+)")
+_NAME_RE = re.compile(r'name="([^"]+)"')
+
+
+def parse_multipart_response(content_type: str, body: bytes) -> Tuple[dict, Dict[str, bytes]]:
+    """Parse a multipart response produced by `build_success_response`.
+
+    Parameters
+    ----------
+    content_type
+        HTTP Content-Type header value containing the boundary.
+    body
+        Raw multipart response body bytes.
+
+    Returns
+    -------
+    tuple[dict, dict[str, bytes]]
+        Parsed JSON result payload and named binary parts.
+    """
+    boundary_match = _BOUNDARY_RE.search(content_type)
+    if boundary_match is None:
+        raise ValueError(f"No boundary in Content-Type: {content_type}")
+    delimiter = b"--" + boundary_match.group(1).encode("ascii")
+
+    result: dict | None = None
+    binary_parts: Dict[str, bytes] = {}
+
+    for segment in body.split(delimiter):
+        if not segment or segment in (b"\r\n", b"--\r\n", b"--"):
+            continue
+        header_end = segment.find(b"\r\n\r\n")
+        if header_end < 0:
+            continue
+        header_block = segment[:header_end].decode("utf-8", errors="replace")
+        payload = segment[header_end + 4 :]
+        if payload.endswith(b"\r\n"):
+            payload = payload[:-2]
+
+        name_match = _NAME_RE.search(header_block)
+        if name_match is None:
+            continue
+        name = name_match.group(1)
+
+        if name == "result":
+            result = json.loads(payload)
+        else:
+            binary_parts[name] = payload
+
+    if result is None:
+        raise ValueError("Missing 'result' part in multipart response")
+    return result, binary_parts

--- a/flashinfer_bench/serve/low_level/schema.py
+++ b/flashinfer_bench/serve/low_level/schema.py
@@ -1,0 +1,302 @@
+"""Schemas for the low-level GPU server."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Literal, Union
+
+from pydantic import BaseModel, Field
+
+from flashinfer_bench.serve.low_level.cache import CacheEntry
+
+# ---------------------------------------------------------------------------
+# Program Schema
+# ---------------------------------------------------------------------------
+
+SUPPORTED_DTYPES = Literal[
+    "float16",
+    "bfloat16",
+    "float32",
+    "float64",
+    "float8_e4m3fn",
+    "float8_e5m2",
+    "float4_e2m1",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "bool",
+]
+
+
+class RegisterRef(BaseModel):
+    """Reference a value previously stored in the register file."""
+
+    r: int
+    """Register index to read from."""
+
+
+Operand = Union[RegisterRef, int, float, str, bool, list, None]
+
+
+class UploadPythonModuleInstruction(BaseModel):
+    """Import a Python module blob into the worker process."""
+
+    op: Literal["upload_python_module"]
+    """Instruction opcode."""
+    blob: str
+    """Blob key referencing the uploaded Python module source."""
+
+
+class UploadFfiModuleInstruction(BaseModel):
+    """Load a TVM FFI shared library blob and store its module handle."""
+
+    op: Literal["upload_ffi_module"]
+    """Instruction opcode."""
+    blob: str
+    """Blob key referencing the uploaded shared library bytes."""
+    dst: int
+    """Destination register for the loaded FFI module handle."""
+
+
+class UploadTensorInstruction(BaseModel):
+    """Load a tensor blob onto the worker GPU and store it in a register."""
+
+    op: Literal["upload_tensor"]
+    """Instruction opcode."""
+    dst: int
+    """Destination register for the uploaded tensor."""
+    blob: str
+    """Blob key referencing the raw tensor bytes."""
+    shape: list[int]
+    """Tensor shape in row-major order."""
+    dtype: SUPPORTED_DTYPES
+    """Tensor dtype name."""
+
+
+class CallInstruction(BaseModel):
+    """Call a function with literal operands or register references."""
+
+    op: Literal["call"]
+    """Instruction opcode."""
+    func: str
+    """Function name to invoke."""
+    args: list[Operand]
+    """Function arguments in call order."""
+    dst: int | None = None
+    """Destination register for the return value."""
+    module: RegisterRef | None = None
+    """Optional register reference to a module handle used for function lookup."""
+
+
+class ReturnInstruction(BaseModel):
+    """Expose a register value in the final response payload."""
+
+    op: Literal["return"]
+    """Instruction opcode."""
+    reg: int
+    """Register index to export."""
+    key: str
+    """Response key used in the returns map."""
+
+
+Instruction = Union[
+    UploadPythonModuleInstruction,
+    UploadFfiModuleInstruction,
+    UploadTensorInstruction,
+    CallInstruction,
+    ReturnInstruction,
+]
+
+
+class Program(BaseModel):
+    """Executable low-level program independent of HTTP request metadata."""
+
+    instructions: list[Instruction]
+    """Ordered instruction sequence to execute."""
+
+
+# ---------------------------------------------------------------------------
+# HTTP Request Schema
+# ---------------------------------------------------------------------------
+
+
+class ExecuteRequest(BaseModel):
+    """JSON payload stored in the ``program`` multipart field for ``/execute``."""
+
+    instructions: list[Instruction]
+    """Ordered instruction sequence to execute."""
+    timeout_seconds: float | None = None
+    """Optional per-request timeout override in seconds."""
+
+    @property
+    def program(self) -> Program:
+        """Return the execution program without HTTP-only request metadata."""
+        return Program(instructions=self.instructions)
+
+
+class TensorReturnValue(BaseModel):
+    """Tensor return value described by metadata plus a binary blob part."""
+
+    type: Literal["tensor"] = "tensor"
+    """Return value kind."""
+    dtype: SUPPORTED_DTYPES
+    """Tensor dtype name."""
+    shape: list[int]
+    """Tensor shape in row-major order."""
+    blob: str
+    """Multipart part name containing the raw tensor bytes."""
+
+
+class BytesReturnValue(BaseModel):
+    """Opaque bytes return value stored in a multipart blob part."""
+
+    type: Literal["bytes"] = "bytes"
+    """Return value kind."""
+    blob: str
+    """Multipart part name containing the raw bytes."""
+
+
+class JsonReturnValue(BaseModel):
+    """JSON-serializable return value embedded directly in the result payload."""
+
+    type: Literal["json"] = "json"
+    """Return value kind."""
+    value: Any
+    """JSON-serializable return value."""
+
+
+ReturnValue = Union[TensorReturnValue, BytesReturnValue, JsonReturnValue]
+
+
+class ExecuteResult(BaseModel):
+    """Successful execution result returned in the ``result`` multipart field."""
+
+    status: Literal["ok"] = "ok"
+    """Execution status."""
+    returns: dict[str, ReturnValue]
+    """Named return values exported by ``return`` instructions."""
+    elapsed_ms: float
+    """Wall-clock execution time in milliseconds."""
+    stdout: str | None = None
+    """Captured standard output from the worker process."""
+    stderr: str | None = None
+    """Captured standard error from the worker process."""
+
+
+class ErrorResult(BaseModel):
+    """Structured execution error returned as JSON when the request fails."""
+
+    status: Literal["error"] = "error"
+    """Execution status."""
+    error: str
+    """Stable machine-readable error code."""
+    message: str | None = None
+    """Human-readable error summary."""
+    instruction_index: int | None = None
+    """Zero-based instruction index associated with the failure, when available."""
+    timeout_seconds: float | None = None
+    """Effective timeout that was exceeded, when the error is a timeout."""
+    stdout: str | None = None
+    """Captured standard output before the failure."""
+    stderr: str | None = None
+    """Captured standard error before the failure."""
+
+
+class ServerExecuteRequest(BaseModel):
+    """Decoded server-side execute request independent of HTTP transport."""
+
+    execute_request: ExecuteRequest
+    """Validated execute request payload."""
+    blob_entries: dict[str, CacheEntry]
+    """Cached blob entries referenced by the request."""
+
+
+class ServerExecuteResponseKind(str, Enum):
+    """Semantic result kind returned by the server runtime."""
+
+    OK = "ok"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+
+
+class ServerExecuteResponse(BaseModel):
+    """Server runtime result independent of HTTP response formatting."""
+
+    kind: ServerExecuteResponseKind
+    """Semantic result kind returned by the server runtime."""
+    payload: ExecuteResult | ErrorResult
+    """Structured JSON payload returned to the HTTP layer."""
+    binary_parts: dict[str, bytes] = Field(default_factory=dict)
+    """Binary multipart payloads returned on successful execution."""
+
+
+class WorkerStatus(BaseModel):
+    """Health summary for a single GPU worker."""
+
+    gpu_id: int
+    """Physical GPU index assigned to the worker."""
+    status: Literal["idle", "busy", "restarting"]
+    """Current worker runtime status."""
+    uptime_seconds: int
+    """Worker uptime since the last process start."""
+
+
+class HealthResponse(BaseModel):
+    """Response payload for the ``/health`` endpoint."""
+
+    status: Literal["ok"] = "ok"
+    """Health check status."""
+    gpu_count: int
+    """Number of configured GPU workers."""
+    pending_tasks: int
+    """Number of queued requests waiting for a worker."""
+    workers: list[WorkerStatus]
+    """Per-worker runtime status entries."""
+
+
+# ---------------------------------------------------------------------------
+# Server-Worker IPC Schema
+# ---------------------------------------------------------------------------
+
+
+class WorkerExecuteRequest(BaseModel):
+    """IPC request sent from the scheduler process to a worker process."""
+
+    request_id: str
+    """Unique request identifier used to match the worker response."""
+    request_transport_started_at: float | None = None
+    """Monotonic timestamp recorded before the parent enqueues the request."""
+    program: Program
+    """Typed execution program."""
+    blobs: dict[str, CacheEntry]
+    """Uploaded request blobs stored in the server cache."""
+
+
+class WorkerExecuteSuccessResponse(BaseModel):
+    """IPC response emitted by a worker after successful execution."""
+
+    request_id: str
+    """Unique request identifier used to match the original request."""
+    response_transport_started_at: float | None = None
+    """Monotonic timestamp recorded before the child enqueues the response."""
+    ok: Literal[True] = True
+    """Success discriminator for the worker response."""
+    result: ExecuteResult
+    """Structured execution result."""
+    binary_parts: dict[str, bytes]
+    """Named binary multipart payloads returned by execution."""
+
+
+class WorkerExecuteErrorResponse(BaseModel):
+    """IPC response emitted by a worker after execution failure."""
+
+    request_id: str
+    """Unique request identifier used to match the original request."""
+    response_transport_started_at: float | None = None
+    """Monotonic timestamp recorded before the child enqueues the response."""
+    ok: Literal[False] = False
+    """Failure discriminator for the worker response."""
+    error: ErrorResult
+    """Structured execution error."""

--- a/flashinfer_bench/serve/low_level/server.py
+++ b/flashinfer_bench/serve/low_level/server.py
@@ -1,0 +1,285 @@
+"""Server runtime and scheduling for the low-level GPU server."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+from flashinfer_bench.serve.low_level.cache import CacheEntry, CacheManager
+from flashinfer_bench.serve.low_level.errors import TimeoutError
+from flashinfer_bench.serve.low_level.schema import (
+    ErrorResult,
+    HealthResponse,
+    Program,
+    ServerExecuteRequest,
+    ServerExecuteResponse,
+    ServerExecuteResponseKind,
+    WorkerExecuteErrorResponse,
+    WorkerExecuteSuccessResponse,
+    WorkerStatus,
+)
+from flashinfer_bench.serve.low_level.worker import LowLevelWorkerProcess
+
+
+@dataclass
+class _PendingTask:
+    """One server-side queued request waiting to run on a worker."""
+
+    request_id: str
+    program: Program
+    timeout_seconds: float
+    blob_entries: dict[str, CacheEntry]
+    future: asyncio.Future[ServerExecuteResponse]
+    enqueued_at: float
+    started_at: float | None = None
+
+
+class LowLevelServer:
+    """Own the low-level server runtime, scheduling, and decoded request execution."""
+
+    def __init__(self, devices: list[str], default_timeout_seconds: int = 30) -> None:
+        """Initialize one low-level server instance.
+
+        Parameters
+        ----------
+        devices
+            CUDA device strings assigned to worker processes.
+        default_timeout_seconds
+            Default request timeout in seconds.
+
+        Returns
+        -------
+        None
+            This constructor initializes the cache manager and worker scheduling state.
+        """
+        self.cache_manager = CacheManager()
+        self._default_timeout_seconds = default_timeout_seconds
+        self._workers = [LowLevelWorkerProcess(device=device) for device in devices]
+        self._pending_queue: asyncio.Queue[_PendingTask] = asyncio.Queue()
+        self._worker_tasks: list[asyncio.Task[None]] = []
+
+    async def start(self) -> None:
+        """Start one queue consumer coroutine per worker."""
+        if self._worker_tasks:
+            return
+        self._worker_tasks = [
+            asyncio.create_task(
+                self._worker_loop(worker), name=f"low-level-worker-loop-{worker.gpu_id}"
+            )
+            for worker in self._workers
+        ]
+
+    async def shutdown(self) -> None:
+        """Cancel queue consumers, drain pending tasks, and close worker processes."""
+        if self._worker_tasks:
+            for worker_task in self._worker_tasks:
+                worker_task.cancel()
+            await asyncio.gather(*self._worker_tasks, return_exceptions=True)
+            self._worker_tasks.clear()
+        self._drain_pending_queue()
+        for worker in self._workers:
+            worker.close()
+
+    async def execute_request(
+        self, server_execute_request: ServerExecuteRequest, trace_id: str
+    ) -> ServerExecuteResponse:
+        """Execute one decoded low-level program request.
+
+        Parameters
+        ----------
+        server_execute_request
+            Decoded execute request plus cached blob entries referenced by it.
+
+        Returns
+        -------
+        ServerExecuteResponse
+            Semantic execution result independent of HTTP response formatting.
+        """
+        request_start_time = time.perf_counter()
+        print(f"TRACE request_id={trace_id} span=server.execute_request phase=begin", flush=True)
+        execute_request = server_execute_request.execute_request
+        blob_entries = server_execute_request.blob_entries
+        effective_timeout = float(execute_request.timeout_seconds or self._default_timeout_seconds)
+        loop = asyncio.get_running_loop()
+        pending_task = _PendingTask(
+            request_id=trace_id,
+            program=execute_request.program,
+            timeout_seconds=effective_timeout,
+            blob_entries=blob_entries,
+            future=loop.create_future(),
+            enqueued_at=time.monotonic(),
+        )
+        queued = False
+        try:
+            queue_put_start_time = time.perf_counter()
+            print(f"TRACE request_id={trace_id} span=server.queue_put phase=begin", flush=True)
+            await self._pending_queue.put(pending_task)
+            queued = True
+            print(
+                f"TRACE request_id={trace_id} span=server.queue_put phase=end "
+                f"duration_ms={(time.perf_counter() - queue_put_start_time) * 1000.0:.3f}",
+                flush=True,
+            )
+            print(f"TRACE request_id={trace_id} span=server.queue_wait phase=begin", flush=True)
+            future_wait_start_time = time.perf_counter()
+            print(f"TRACE request_id={trace_id} span=server.future_wait phase=begin", flush=True)
+            response = await asyncio.shield(pending_task.future)
+            print(
+                f"TRACE request_id={trace_id} span=server.future_wait phase=end "
+                f"duration_ms={(time.perf_counter() - future_wait_start_time) * 1000.0:.3f}",
+                flush=True,
+            )
+            return response
+        finally:
+            if not queued:
+                release_start_time = time.perf_counter()
+                print(
+                    f"TRACE request_id={trace_id} span=server.release_blobs phase=begin", flush=True
+                )
+                self._release_blob_entries(blob_entries)
+                print(
+                    f"TRACE request_id={trace_id} span=server.release_blobs phase=end "
+                    f"duration_ms={(time.perf_counter() - release_start_time) * 1000.0:.3f}",
+                    flush=True,
+                )
+            print(
+                f"TRACE request_id={trace_id} span=server.execute_request phase=end "
+                f"duration_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f}",
+                flush=True,
+            )
+
+    async def _worker_loop(self, worker: LowLevelWorkerProcess) -> None:
+        """Continuously pull queued tasks and execute them on one worker."""
+        while True:
+            pending_task = await self._pending_queue.get()
+            pending_task.started_at = time.monotonic()
+            queue_wait_seconds = pending_task.started_at - pending_task.enqueued_at
+            print(
+                f"TRACE request_id={pending_task.request_id} span=server.queue_wait phase=end "
+                f"duration_ms={queue_wait_seconds * 1000.0:.3f}",
+                flush=True,
+            )
+            remaining_timeout = pending_task.timeout_seconds - queue_wait_seconds
+            worker_loop_start_time = time.perf_counter()
+            print(
+                f"TRACE request_id={pending_task.request_id} span=server.worker_loop phase=begin",
+                flush=True,
+            )
+            worker_execute_start_time = time.perf_counter()
+            try:
+                if remaining_timeout <= 0:
+                    server_response = ServerExecuteResponse(
+                        kind=ServerExecuteResponseKind.TIMEOUT,
+                        payload=ErrorResult(
+                            error="timeout", timeout_seconds=pending_task.timeout_seconds
+                        ),
+                    )
+                else:
+                    print(
+                        f"TRACE request_id={pending_task.request_id} span=server.worker_execute phase=begin",
+                        flush=True,
+                    )
+                    response = await asyncio.to_thread(
+                        worker.execute,
+                        request_id=pending_task.request_id,
+                        program=pending_task.program,
+                        blobs=pending_task.blob_entries,
+                        timeout_seconds=float(remaining_timeout),
+                    )
+                    print(
+                        f"TRACE request_id={pending_task.request_id} span=server.worker_execute phase=end "
+                        f"duration_ms={(time.perf_counter() - worker_execute_start_time) * 1000.0:.3f}",
+                        flush=True,
+                    )
+                    if isinstance(response, WorkerExecuteErrorResponse):
+                        server_response = ServerExecuteResponse(
+                            kind=ServerExecuteResponseKind.ERROR, payload=response.error
+                        )
+                    else:
+                        success_response: WorkerExecuteSuccessResponse = response
+                        server_response = ServerExecuteResponse(
+                            kind=ServerExecuteResponseKind.OK,
+                            payload=success_response.result,
+                            binary_parts=success_response.binary_parts,
+                        )
+            except TimeoutError as error:
+                server_response = ServerExecuteResponse(
+                    kind=ServerExecuteResponseKind.TIMEOUT,
+                    payload=ErrorResult(error="timeout", timeout_seconds=error.timeout_seconds),
+                )
+            except asyncio.CancelledError:
+                if not pending_task.future.done():
+                    pending_task.future.cancel()
+                raise
+            except Exception as error:
+                server_response = ServerExecuteResponse(
+                    kind=ServerExecuteResponseKind.ERROR,
+                    payload=ErrorResult(error="execution_failed", message=str(error)),
+                )
+            finally:
+                print(
+                    "SCHEDULER_TIMING "
+                    f"request_id={pending_task.request_id} "
+                    f"selected_gpu_id={worker.gpu_id} "
+                    f"queue_wait_ms={queue_wait_seconds * 1000.0:.3f} "
+                    f"worker_execute_ms={(time.perf_counter() - worker_execute_start_time) * 1000.0:.3f}",
+                    flush=True,
+                )
+                if not pending_task.future.done():
+                    pending_task.future.set_result(server_response)
+                release_start_time = time.perf_counter()
+                print(
+                    f"TRACE request_id={pending_task.request_id} span=server.release_blobs phase=begin",
+                    flush=True,
+                )
+                self._release_blob_entries(pending_task.blob_entries)
+                print(
+                    f"TRACE request_id={pending_task.request_id} span=server.release_blobs phase=end "
+                    f"duration_ms={(time.perf_counter() - release_start_time) * 1000.0:.3f}",
+                    flush=True,
+                )
+                print(
+                    f"TRACE request_id={pending_task.request_id} span=server.worker_loop phase=end "
+                    f"duration_ms={(time.perf_counter() - worker_loop_start_time) * 1000.0:.3f}",
+                    flush=True,
+                )
+                self._pending_queue.task_done()
+
+    def _drain_pending_queue(self) -> None:
+        """Cancel and release every task still waiting in the global queue."""
+        while True:
+            try:
+                pending_task = self._pending_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if not pending_task.future.done():
+                pending_task.future.cancel()
+            self._release_blob_entries(pending_task.blob_entries)
+            self._pending_queue.task_done()
+
+    def _release_blob_entries(self, blob_entries: dict[str, CacheEntry]) -> None:
+        """Release acquired cache entries after the queued task fully finishes."""
+        for acquired_entry in blob_entries.values():
+            self.cache_manager.release(acquired_entry)
+
+    def health_response(self) -> HealthResponse:
+        """Return the current server health response payload.
+
+        Returns
+        -------
+        HealthResponse
+            Structured health summary for all managed workers.
+        """
+        workers = [
+            WorkerStatus(
+                gpu_id=worker.gpu_id, status=worker.status, uptime_seconds=worker.uptime_seconds
+            )
+            for worker in self._workers
+        ]
+        return HealthResponse(
+            gpu_count=len(workers), pending_tasks=self._pending_queue.qsize(), workers=workers
+        )
+
+
+__all__ = ["LowLevelServer"]

--- a/flashinfer_bench/serve/low_level/worker.py
+++ b/flashinfer_bench/serve/low_level/worker.py
@@ -1,0 +1,566 @@
+"""Worker process management for the low-level GPU server."""
+
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import multiprocessing as mp
+import os
+import queue
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from typing import Literal
+
+from pydantic import BaseModel
+
+from flashinfer_bench.serve.low_level.errors import (
+    ExecutionFailedError,
+    InvalidProgramError,
+    TimeoutError,
+)
+from flashinfer_bench.serve.low_level.executor import (
+    ErrorResult,
+    ExecuteResult,
+    Program,
+    SharedMemoryBlob,
+)
+
+WorkerRuntimeStatus = Literal["idle", "busy", "restarting"]
+
+
+class WorkerExecuteRequest(BaseModel):
+    """IPC request sent from the scheduler process to a worker process."""
+
+    request_id: str
+    """Unique request identifier used to match the worker response."""
+    program: Program
+    """Typed execution program."""
+    blobs: dict[str, SharedMemoryBlob]
+    """Uploaded request blobs stored in shared memory."""
+
+
+class WorkerExecuteSuccessResponse(BaseModel):
+    """IPC response emitted by a worker after successful execution."""
+
+    request_id: str
+    """Unique request identifier used to match the original request."""
+    ok: Literal[True] = True
+    """Success discriminator for the worker response."""
+    result: ExecuteResult
+    """Structured execution result."""
+    binary_parts: dict[str, bytes]
+    """Named binary multipart payloads returned by execution."""
+
+
+class WorkerExecuteErrorResponse(BaseModel):
+    """IPC response emitted by a worker after execution failure."""
+
+    request_id: str
+    """Unique request identifier used to match the original request."""
+    ok: Literal[False] = False
+    """Failure discriminator for the worker response."""
+    error: ErrorResult
+    """Structured execution error."""
+
+
+def _flush_process_output() -> None:
+    """Flush Python and libc buffered output before swapping file descriptors.
+
+    Returns
+    -------
+    None
+        This function flushes process output streams in place.
+    """
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:
+        pass
+    try:
+        libc = ctypes.CDLL(None)
+        libc.fflush(None)
+    except Exception:
+        pass
+
+
+@contextlib.contextmanager
+def _capture_process_output():
+    """Capture process-level stdout and stderr into temporary files.
+
+    Yields
+    ------
+    tuple
+        Temporary files capturing stdout and stderr for the current request.
+    """
+    stdout_file = tempfile.TemporaryFile(mode="w+b")
+    stderr_file = tempfile.TemporaryFile(mode="w+b")
+    saved_stdout_fd = os.dup(1)
+    saved_stderr_fd = os.dup(2)
+    try:
+        _flush_process_output()
+        os.dup2(stdout_file.fileno(), 1)
+        os.dup2(stderr_file.fileno(), 2)
+        yield stdout_file, stderr_file
+    finally:
+        _flush_process_output()
+        os.dup2(saved_stdout_fd, 1)
+        os.dup2(saved_stderr_fd, 2)
+        os.close(saved_stdout_fd)
+        os.close(saved_stderr_fd)
+
+
+def _read_captured_output(captured_file) -> str | None:
+    """Decode one captured output file into UTF-8 text.
+
+    Parameters
+    ----------
+    captured_file
+        Temporary file object holding captured process output.
+
+    Returns
+    -------
+    str | None
+        Decoded UTF-8 text, or `None` when the file is empty.
+    """
+    if captured_file is None:
+        return None
+    captured_file.seek(0)
+    output = captured_file.read()
+    if not output:
+        return None
+    return output.decode("utf-8", errors="replace")
+
+
+def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue) -> None:
+    """Run the worker loop bound to a single visible CUDA device.
+
+    Parameters
+    ----------
+    device
+        CUDA device string assigned to this worker.
+    request_queue
+        Queue used to receive execution requests from the scheduler.
+    response_queue
+        Queue used to send typed execution responses back to the scheduler.
+
+    Returns
+    -------
+    None
+        This function runs the worker loop until shutdown.
+    """
+    visible_device = device.split(":", 1)[1]
+    os.environ["CUDA_VISIBLE_DEVICES"] = visible_device
+
+    from flashinfer_bench.serve.low_level.executor import execute_program
+
+    while True:
+        message = request_queue.get()
+        if message is None:
+            return
+
+        if not isinstance(message, WorkerExecuteRequest):
+            message = WorkerExecuteRequest.model_validate(message)
+
+        request_id = message.request_id
+        program = message.program
+        blobs = message.blobs
+        stdout_file = None
+        stderr_file = None
+        execute_program_ms: float | None = None
+        read_captured_output_ms: float | None = None
+        response_queue_put_ms: float | None = None
+        worker_status = "ok"
+        request_start_time = time.perf_counter()
+
+        try:
+            with _capture_process_output() as (stdout_file, stderr_file):
+                execute_program_start_time = time.perf_counter()
+                result, binary_parts = execute_program(program, blobs)
+                execute_program_ms = (time.perf_counter() - execute_program_start_time) * 1000.0
+            read_captured_output_start_time = time.perf_counter()
+            stdout = _read_captured_output(stdout_file)
+            stderr = _read_captured_output(stderr_file)
+            read_captured_output_ms = (
+                time.perf_counter() - read_captured_output_start_time
+            ) * 1000.0
+            result = result.model_copy(update={"stdout": stdout, "stderr": stderr})
+            response_queue_put_start_time = time.perf_counter()
+            response_queue.put(
+                WorkerExecuteSuccessResponse(
+                    request_id=request_id, result=result, binary_parts=binary_parts
+                )
+            )
+            response_queue_put_ms = (time.perf_counter() - response_queue_put_start_time) * 1000.0
+        except InvalidProgramError as error:
+            worker_status = "invalid_program"
+            read_captured_output_start_time = time.perf_counter()
+            stdout = _read_captured_output(stdout_file)
+            stderr = _read_captured_output(stderr_file)
+            read_captured_output_ms = (
+                time.perf_counter() - read_captured_output_start_time
+            ) * 1000.0
+            response_queue_put_start_time = time.perf_counter()
+            response_queue.put(
+                WorkerExecuteErrorResponse(
+                    request_id=request_id,
+                    error=ErrorResult(
+                        error="invalid_program", message=error.message, stdout=stdout, stderr=stderr
+                    ),
+                )
+            )
+            response_queue_put_ms = (time.perf_counter() - response_queue_put_start_time) * 1000.0
+        except ExecutionFailedError as error:
+            worker_status = "execution_failed"
+            read_captured_output_start_time = time.perf_counter()
+            stdout = _read_captured_output(stdout_file)
+            stderr = _read_captured_output(stderr_file)
+            read_captured_output_ms = (
+                time.perf_counter() - read_captured_output_start_time
+            ) * 1000.0
+            response_queue_put_start_time = time.perf_counter()
+            response_queue.put(
+                WorkerExecuteErrorResponse(
+                    request_id=request_id,
+                    error=ErrorResult(
+                        error="execution_failed",
+                        message=error.message,
+                        instruction_index=error.instruction_index,
+                        stdout=stdout,
+                        stderr=stderr,
+                    ),
+                )
+            )
+            response_queue_put_ms = (time.perf_counter() - response_queue_put_start_time) * 1000.0
+        except Exception as error:
+            worker_status = "unexpected_error"
+            read_captured_output_start_time = time.perf_counter()
+            stdout = _read_captured_output(stdout_file)
+            stderr = _read_captured_output(stderr_file)
+            read_captured_output_ms = (
+                time.perf_counter() - read_captured_output_start_time
+            ) * 1000.0
+            response_queue_put_start_time = time.perf_counter()
+            response_queue.put(
+                WorkerExecuteErrorResponse(
+                    request_id=request_id,
+                    error=ErrorResult(
+                        error="execution_failed", message=str(error), stdout=stdout, stderr=stderr
+                    ),
+                )
+            )
+            response_queue_put_ms = (time.perf_counter() - response_queue_put_start_time) * 1000.0
+        finally:
+            print(
+                "WORKER_MAIN_TIMING "
+                f"request_id={request_id} "
+                f"status={worker_status} "
+                f"total_request_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f} "
+                f"execute_program_ms={execute_program_ms} "
+                f"read_captured_output_ms={read_captured_output_ms} "
+                f"response_queue_put_ms={response_queue_put_ms}",
+                flush=True,
+            )
+            if stdout_file is not None:
+                stdout_file.close()
+            if stderr_file is not None:
+                stderr_file.close()
+
+
+class LowLevelWorkerProcess:
+    """One dedicated worker process bound to one GPU."""
+
+    def __init__(self, device: str):
+        """Initialize one worker process controller.
+
+        Parameters
+        ----------
+        device
+            CUDA device string assigned to this worker.
+
+        Returns
+        -------
+        None
+            This constructor initializes internal state and starts the worker.
+        """
+        self.device = device
+        self.gpu_id = int(device.split(":", 1)[1])
+        self._context = mp.get_context("spawn")
+        self._request_queue: mp.Queue = self._context.Queue()
+        self._response_queue: mp.Queue = self._context.Queue()
+        self._process: mp.Process | None = None
+        self._status: WorkerRuntimeStatus = "idle"
+        self._busy = False
+        self._started_at = 0.0
+        self._lock = threading.Lock()
+        self.start()
+
+    @property
+    def status(self) -> WorkerRuntimeStatus:
+        """Return the public runtime status for this worker.
+
+        Returns
+        -------
+        WorkerRuntimeStatus
+            Public worker status exposed through the health endpoint.
+        """
+        if self._status == "restarting":
+            return "restarting"
+        return "busy" if self._busy else "idle"
+
+    @property
+    def queue_length(self) -> int:
+        """Return the number of active requests tracked by this worker.
+
+        Returns
+        -------
+        int
+            Number of currently active requests tracked by this worker.
+        """
+        return 1 if self._busy else 0
+
+    @property
+    def uptime_seconds(self) -> int:
+        """Return the worker uptime in seconds since the last process start.
+
+        Returns
+        -------
+        int
+            Worker uptime in whole seconds.
+        """
+        if self._started_at == 0:
+            return 0
+        return max(0, int(time.time() - self._started_at))
+
+    def is_alive(self) -> bool:
+        """Check whether the underlying worker process is still alive.
+
+        Returns
+        -------
+        bool
+            Whether the worker process is currently alive.
+        """
+        return self._process is not None and self._process.is_alive()
+
+    def start(self) -> None:
+        """Spawn the worker process and reset runtime state.
+
+        Returns
+        -------
+        None
+            This method starts the worker process in place.
+        """
+        self._process = self._context.Process(
+            target=_worker_main,
+            args=(self.device, self._request_queue, self._response_queue),
+            daemon=True,
+        )
+        self._process.start()
+        self._started_at = time.time()
+        self._status = "idle"
+        self._busy = False
+
+    def close(self) -> None:
+        """Shut down the worker process and release queue resources.
+
+        Returns
+        -------
+        None
+            This method releases worker-owned process and queue resources in place.
+        """
+        if self._process is None:
+            return
+        try:
+            self._request_queue.put(None)
+        except Exception:
+            pass
+        self._process.join(timeout=2.0)
+        if self._process.is_alive():
+            self._process.kill()
+            self._process.join(timeout=2.0)
+        self._process = None
+        for queue_object in (self._request_queue, self._response_queue):
+            try:
+                queue_object.cancel_join_thread()
+            except Exception:
+                pass
+            try:
+                queue_object.close()
+            except Exception:
+                pass
+
+    def restart(self) -> None:
+        """Restart the worker process after a fatal error or timeout.
+
+        Returns
+        -------
+        None
+            This method replaces the underlying worker process in place.
+        """
+        self._status = "restarting"
+        self.close()
+        self._request_queue = self._context.Queue()
+        self._response_queue = self._context.Queue()
+        self.start()
+
+    def execute(
+        self, program: Program, blobs: dict[str, SharedMemoryBlob], timeout_seconds: float
+    ) -> WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse:
+        """Execute one request on this worker and wait for the typed IPC response.
+
+        Parameters
+        ----------
+        program
+            Validated low-level program to execute.
+        blobs
+            Uploaded request blobs stored in shared memory and keyed by blob hash.
+        timeout_seconds
+            Effective timeout in seconds for the request.
+
+        Returns
+        -------
+        WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse
+            Typed IPC response returned by the worker process.
+        """
+        request_id = uuid.uuid4().hex
+        request_message = WorkerExecuteRequest(request_id=request_id, program=program, blobs=blobs)
+        request_start_time = time.perf_counter()
+        request_queue_put_ms: float | None = None
+        response_wait_ms: float | None = None
+        response_validate_ms: float | None = None
+        status = "ok"
+        with self._lock:
+            self._busy = True
+            try:
+                request_queue_put_start_time = time.perf_counter()
+                self._request_queue.put(request_message)
+                request_queue_put_ms = (time.perf_counter() - request_queue_put_start_time) * 1000.0
+                response_wait_start_time = time.perf_counter()
+                response = self._response_queue.get(timeout=timeout_seconds)
+                response_wait_ms = (time.perf_counter() - response_wait_start_time) * 1000.0
+                if not isinstance(
+                    response, (WorkerExecuteSuccessResponse, WorkerExecuteErrorResponse)
+                ):
+                    response_validate_start_time = time.perf_counter()
+                    if response.get("ok"):
+                        response = WorkerExecuteSuccessResponse.model_validate(response)
+                    else:
+                        response = WorkerExecuteErrorResponse.model_validate(response)
+                    response_validate_ms = (
+                        time.perf_counter() - response_validate_start_time
+                    ) * 1000.0
+                if response.request_id != request_id:
+                    raise RuntimeError("Mismatched worker response")
+                return response
+            except queue.Empty:
+                status = "timeout"
+                self.restart()
+                raise TimeoutError(timeout_seconds)
+            finally:
+                print(
+                    "WORKER_IPC_TIMING "
+                    f"request_id={request_id} "
+                    f"status={status} "
+                    f"total_execute_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f} "
+                    f"request_queue_put_ms={request_queue_put_ms} "
+                    f"response_wait_ms={response_wait_ms} "
+                    f"response_validate_ms={response_validate_ms}",
+                    flush=True,
+                )
+                self._busy = False
+
+
+class LowLevelScheduler:
+    """Pick an idle worker and execute requests synchronously."""
+
+    def __init__(self, devices: list[str], default_timeout_seconds: int):
+        """Initialize the scheduler and spawn one worker per device.
+
+        Parameters
+        ----------
+        devices
+            CUDA device strings assigned to worker processes.
+        default_timeout_seconds
+            Default request timeout in seconds.
+
+        Returns
+        -------
+        None
+            This constructor initializes internal scheduler state in place.
+        """
+        self.default_timeout_seconds = default_timeout_seconds
+        self._workers = [LowLevelWorkerProcess(device=device) for device in devices]
+        self._condition = threading.Condition()
+        self._next_worker_index = 0
+
+    def close(self) -> None:
+        """Stop all managed workers.
+
+        Returns
+        -------
+        None
+            This method releases all managed worker processes in place.
+        """
+        for worker in self._workers:
+            worker.close()
+
+    def execute(
+        self, program: Program, timeout_seconds: float | None, blobs: dict[str, SharedMemoryBlob]
+    ) -> WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse:
+        """Dispatch one request to an idle worker with the effective timeout.
+
+        Parameters
+        ----------
+        program
+            Validated low-level program to execute.
+        timeout_seconds
+            Optional per-request timeout override in seconds.
+        blobs
+            Uploaded request blobs stored in shared memory and keyed by blob hash.
+
+        Returns
+        -------
+        WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse
+            Typed IPC response returned by the selected worker.
+        """
+        effective_timeout = timeout_seconds or self.default_timeout_seconds
+
+        wait_worker_start_time = time.perf_counter()
+        worker = self._acquire_worker()
+        wait_worker_ms = (time.perf_counter() - wait_worker_start_time) * 1000.0
+        try:
+            worker_execute_start_time = time.perf_counter()
+            return worker.execute(
+                program=program, blobs=blobs, timeout_seconds=float(effective_timeout)
+            )
+        finally:
+            print(
+                "SCHEDULER_TIMING "
+                f"selected_gpu_id={worker.gpu_id} "
+                f"effective_timeout_seconds={float(effective_timeout)} "
+                f"wait_worker_ms={wait_worker_ms:.3f} "
+                f"worker_execute_ms={(time.perf_counter() - worker_execute_start_time) * 1000.0:.3f}",
+                flush=True,
+            )
+            with self._condition:
+                self._condition.notify_all()
+
+    def _acquire_worker(self) -> LowLevelWorkerProcess:
+        """Block until one worker becomes idle and return it.
+
+        Returns
+        -------
+        LowLevelWorkerProcess
+            Idle worker selected for the next request.
+        """
+        with self._condition:
+            while True:
+                for offset in range(len(self._workers)):
+                    worker_index = (self._next_worker_index + offset) % len(self._workers)
+                    worker = self._workers[worker_index]
+                    if worker.status == "idle":
+                        self._next_worker_index = (worker_index + 1) % len(self._workers)
+                        return worker
+                self._condition.wait(timeout=0.1)

--- a/flashinfer_bench/serve/low_level/worker.py
+++ b/flashinfer_bench/serve/low_level/worker.py
@@ -11,59 +11,24 @@ import sys
 import tempfile
 import threading
 import time
-import uuid
 from typing import Literal
 
-from pydantic import BaseModel
-
+from flashinfer_bench.serve.low_level.cache import CacheEntry
 from flashinfer_bench.serve.low_level.errors import (
     ExecutionFailedError,
     InvalidProgramError,
     TimeoutError,
 )
-from flashinfer_bench.serve.low_level.executor import (
+from flashinfer_bench.serve.low_level.executor import execute_program
+from flashinfer_bench.serve.low_level.schema import (
     ErrorResult,
-    ExecuteResult,
     Program,
-    SharedMemoryBlob,
+    WorkerExecuteErrorResponse,
+    WorkerExecuteRequest,
+    WorkerExecuteSuccessResponse,
 )
 
 WorkerRuntimeStatus = Literal["idle", "busy", "restarting"]
-
-
-class WorkerExecuteRequest(BaseModel):
-    """IPC request sent from the scheduler process to a worker process."""
-
-    request_id: str
-    """Unique request identifier used to match the worker response."""
-    program: Program
-    """Typed execution program."""
-    blobs: dict[str, SharedMemoryBlob]
-    """Uploaded request blobs stored in shared memory."""
-
-
-class WorkerExecuteSuccessResponse(BaseModel):
-    """IPC response emitted by a worker after successful execution."""
-
-    request_id: str
-    """Unique request identifier used to match the original request."""
-    ok: Literal[True] = True
-    """Success discriminator for the worker response."""
-    result: ExecuteResult
-    """Structured execution result."""
-    binary_parts: dict[str, bytes]
-    """Named binary multipart payloads returned by execution."""
-
-
-class WorkerExecuteErrorResponse(BaseModel):
-    """IPC response emitted by a worker after execution failure."""
-
-    request_id: str
-    """Unique request identifier used to match the original request."""
-    ok: Literal[False] = False
-    """Failure discriminator for the worker response."""
-    error: ErrorResult
-    """Structured execution error."""
 
 
 def _flush_process_output() -> None:
@@ -154,8 +119,6 @@ def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue)
     visible_device = device.split(":", 1)[1]
     os.environ["CUDA_VISIBLE_DEVICES"] = visible_device
 
-    from flashinfer_bench.serve.low_level.executor import execute_program
-
     while True:
         message = request_queue.get()
         if message is None:
@@ -167,6 +130,12 @@ def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue)
         request_id = message.request_id
         program = message.program
         blobs = message.blobs
+        if message.request_transport_started_at is not None:
+            print(
+                f"TRACE request_id={request_id} span=worker_ipc.request_transport phase=end "
+                f"duration_ms={(time.perf_counter() - message.request_transport_started_at) * 1000.0:.3f}",
+                flush=True,
+            )
         stdout_file = None
         stderr_file = None
         execute_program_ms: float | None = None
@@ -176,24 +145,60 @@ def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue)
         request_start_time = time.perf_counter()
 
         try:
+            print(f"TRACE request_id={request_id} span=worker_main.total phase=begin", flush=True)
             with _capture_process_output() as (stdout_file, stderr_file):
                 execute_program_start_time = time.perf_counter()
-                result, binary_parts = execute_program(program, blobs)
+                print(
+                    f"TRACE request_id={request_id} span=worker_main.execute_program phase=begin",
+                    flush=True,
+                )
+                result, binary_parts = execute_program(program, blobs, request_id=request_id)
                 execute_program_ms = (time.perf_counter() - execute_program_start_time) * 1000.0
+                print(
+                    f"TRACE request_id={request_id} span=worker_main.execute_program phase=end "
+                    f"duration_ms={execute_program_ms:.3f}",
+                    flush=True,
+                )
             read_captured_output_start_time = time.perf_counter()
+            print(
+                f"TRACE request_id={request_id} span=worker_main.read_captured_output phase=begin",
+                flush=True,
+            )
             stdout = _read_captured_output(stdout_file)
             stderr = _read_captured_output(stderr_file)
             read_captured_output_ms = (
                 time.perf_counter() - read_captured_output_start_time
             ) * 1000.0
+            print(
+                f"TRACE request_id={request_id} span=worker_main.read_captured_output phase=end "
+                f"duration_ms={read_captured_output_ms:.3f}",
+                flush=True,
+            )
             result = result.model_copy(update={"stdout": stdout, "stderr": stderr})
             response_queue_put_start_time = time.perf_counter()
+            response_transport_started_at = time.perf_counter()
+            print(
+                f"TRACE request_id={request_id} span=worker_ipc.response_transport phase=begin",
+                flush=True,
+            )
+            print(
+                f"TRACE request_id={request_id} span=worker_main.response_queue_put phase=begin",
+                flush=True,
+            )
             response_queue.put(
                 WorkerExecuteSuccessResponse(
-                    request_id=request_id, result=result, binary_parts=binary_parts
+                    request_id=request_id,
+                    response_transport_started_at=response_transport_started_at,
+                    result=result,
+                    binary_parts=binary_parts,
                 )
             )
             response_queue_put_ms = (time.perf_counter() - response_queue_put_start_time) * 1000.0
+            print(
+                f"TRACE request_id={request_id} span=worker_main.response_queue_put phase=end "
+                f"duration_ms={response_queue_put_ms:.3f}",
+                flush=True,
+            )
         except InvalidProgramError as error:
             worker_status = "invalid_program"
             read_captured_output_start_time = time.perf_counter()
@@ -203,9 +208,15 @@ def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue)
                 time.perf_counter() - read_captured_output_start_time
             ) * 1000.0
             response_queue_put_start_time = time.perf_counter()
+            response_transport_started_at = time.perf_counter()
+            print(
+                f"TRACE request_id={request_id} span=worker_ipc.response_transport phase=begin",
+                flush=True,
+            )
             response_queue.put(
                 WorkerExecuteErrorResponse(
                     request_id=request_id,
+                    response_transport_started_at=response_transport_started_at,
                     error=ErrorResult(
                         error="invalid_program", message=error.message, stdout=stdout, stderr=stderr
                     ),
@@ -221,9 +232,15 @@ def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue)
                 time.perf_counter() - read_captured_output_start_time
             ) * 1000.0
             response_queue_put_start_time = time.perf_counter()
+            response_transport_started_at = time.perf_counter()
+            print(
+                f"TRACE request_id={request_id} span=worker_ipc.response_transport phase=begin",
+                flush=True,
+            )
             response_queue.put(
                 WorkerExecuteErrorResponse(
                     request_id=request_id,
+                    response_transport_started_at=response_transport_started_at,
                     error=ErrorResult(
                         error="execution_failed",
                         message=error.message,
@@ -243,9 +260,15 @@ def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue)
                 time.perf_counter() - read_captured_output_start_time
             ) * 1000.0
             response_queue_put_start_time = time.perf_counter()
+            response_transport_started_at = time.perf_counter()
+            print(
+                f"TRACE request_id={request_id} span=worker_ipc.response_transport phase=begin",
+                flush=True,
+            )
             response_queue.put(
                 WorkerExecuteErrorResponse(
                     request_id=request_id,
+                    response_transport_started_at=response_transport_started_at,
                     error=ErrorResult(
                         error="execution_failed", message=str(error), stdout=stdout, stderr=stderr
                     ),
@@ -261,6 +284,11 @@ def _worker_main(device: str, request_queue: mp.Queue, response_queue: mp.Queue)
                 f"execute_program_ms={execute_program_ms} "
                 f"read_captured_output_ms={read_captured_output_ms} "
                 f"response_queue_put_ms={response_queue_put_ms}",
+                flush=True,
+            )
+            print(
+                f"TRACE request_id={request_id} span=worker_main.total phase=end "
+                f"duration_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f}",
                 flush=True,
             )
             if stdout_file is not None:
@@ -406,7 +434,11 @@ class LowLevelWorkerProcess:
         self.start()
 
     def execute(
-        self, program: Program, blobs: dict[str, SharedMemoryBlob], timeout_seconds: float
+        self,
+        request_id: str,
+        program: Program,
+        blobs: dict[str, CacheEntry],
+        timeout_seconds: float,
     ) -> WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse:
         """Execute one request on this worker and wait for the typed IPC response.
 
@@ -415,7 +447,7 @@ class LowLevelWorkerProcess:
         program
             Validated low-level program to execute.
         blobs
-            Uploaded request blobs stored in shared memory and keyed by blob hash.
+            Uploaded request blobs stored in the server cache and keyed by blob hash.
         timeout_seconds
             Effective timeout in seconds for the request.
 
@@ -424,33 +456,57 @@ class LowLevelWorkerProcess:
         WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse
             Typed IPC response returned by the worker process.
         """
-        request_id = uuid.uuid4().hex
-        request_message = WorkerExecuteRequest(request_id=request_id, program=program, blobs=blobs)
+        request_transport_started_at = time.perf_counter()
+        request_message = WorkerExecuteRequest(
+            request_id=request_id,
+            request_transport_started_at=request_transport_started_at,
+            program=program,
+            blobs=blobs,
+        )
         request_start_time = time.perf_counter()
         request_queue_put_ms: float | None = None
         response_wait_ms: float | None = None
-        response_validate_ms: float | None = None
         status = "ok"
         with self._lock:
             self._busy = True
             try:
                 request_queue_put_start_time = time.perf_counter()
+                print(
+                    f"TRACE request_id={request_id} span=worker_ipc.total phase=begin", flush=True
+                )
+                print(
+                    f"TRACE request_id={request_id} span=worker_ipc.request_queue_put phase=begin",
+                    flush=True,
+                )
+                print(
+                    f"TRACE request_id={request_id} span=worker_ipc.request_transport phase=begin",
+                    flush=True,
+                )
                 self._request_queue.put(request_message)
                 request_queue_put_ms = (time.perf_counter() - request_queue_put_start_time) * 1000.0
+                print(
+                    f"TRACE request_id={request_id} span=worker_ipc.request_queue_put phase=end "
+                    f"duration_ms={request_queue_put_ms:.3f}",
+                    flush=True,
+                )
                 response_wait_start_time = time.perf_counter()
+                print(
+                    f"TRACE request_id={request_id} span=worker_ipc.response_wait phase=begin",
+                    flush=True,
+                )
                 response = self._response_queue.get(timeout=timeout_seconds)
                 response_wait_ms = (time.perf_counter() - response_wait_start_time) * 1000.0
-                if not isinstance(
-                    response, (WorkerExecuteSuccessResponse, WorkerExecuteErrorResponse)
-                ):
-                    response_validate_start_time = time.perf_counter()
-                    if response.get("ok"):
-                        response = WorkerExecuteSuccessResponse.model_validate(response)
-                    else:
-                        response = WorkerExecuteErrorResponse.model_validate(response)
-                    response_validate_ms = (
-                        time.perf_counter() - response_validate_start_time
-                    ) * 1000.0
+                print(
+                    f"TRACE request_id={request_id} span=worker_ipc.response_wait phase=end "
+                    f"duration_ms={response_wait_ms:.3f}",
+                    flush=True,
+                )
+                if response.response_transport_started_at is not None:
+                    print(
+                        f"TRACE request_id={request_id} span=worker_ipc.response_transport phase=end "
+                        f"duration_ms={(time.perf_counter() - response.response_transport_started_at) * 1000.0:.3f}",
+                        flush=True,
+                    )
                 if response.request_id != request_id:
                     raise RuntimeError("Mismatched worker response")
                 return response
@@ -465,102 +521,12 @@ class LowLevelWorkerProcess:
                     f"status={status} "
                     f"total_execute_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f} "
                     f"request_queue_put_ms={request_queue_put_ms} "
-                    f"response_wait_ms={response_wait_ms} "
-                    f"response_validate_ms={response_validate_ms}",
+                    f"response_wait_ms={response_wait_ms} ",
+                    flush=True,
+                )
+                print(
+                    f"TRACE request_id={request_id} span=worker_ipc.total phase=end "
+                    f"duration_ms={(time.perf_counter() - request_start_time) * 1000.0:.3f}",
                     flush=True,
                 )
                 self._busy = False
-
-
-class LowLevelScheduler:
-    """Pick an idle worker and execute requests synchronously."""
-
-    def __init__(self, devices: list[str], default_timeout_seconds: int):
-        """Initialize the scheduler and spawn one worker per device.
-
-        Parameters
-        ----------
-        devices
-            CUDA device strings assigned to worker processes.
-        default_timeout_seconds
-            Default request timeout in seconds.
-
-        Returns
-        -------
-        None
-            This constructor initializes internal scheduler state in place.
-        """
-        self.default_timeout_seconds = default_timeout_seconds
-        self._workers = [LowLevelWorkerProcess(device=device) for device in devices]
-        self._condition = threading.Condition()
-        self._next_worker_index = 0
-
-    def close(self) -> None:
-        """Stop all managed workers.
-
-        Returns
-        -------
-        None
-            This method releases all managed worker processes in place.
-        """
-        for worker in self._workers:
-            worker.close()
-
-    def execute(
-        self, program: Program, timeout_seconds: float | None, blobs: dict[str, SharedMemoryBlob]
-    ) -> WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse:
-        """Dispatch one request to an idle worker with the effective timeout.
-
-        Parameters
-        ----------
-        program
-            Validated low-level program to execute.
-        timeout_seconds
-            Optional per-request timeout override in seconds.
-        blobs
-            Uploaded request blobs stored in shared memory and keyed by blob hash.
-
-        Returns
-        -------
-        WorkerExecuteSuccessResponse | WorkerExecuteErrorResponse
-            Typed IPC response returned by the selected worker.
-        """
-        effective_timeout = timeout_seconds or self.default_timeout_seconds
-
-        wait_worker_start_time = time.perf_counter()
-        worker = self._acquire_worker()
-        wait_worker_ms = (time.perf_counter() - wait_worker_start_time) * 1000.0
-        try:
-            worker_execute_start_time = time.perf_counter()
-            return worker.execute(
-                program=program, blobs=blobs, timeout_seconds=float(effective_timeout)
-            )
-        finally:
-            print(
-                "SCHEDULER_TIMING "
-                f"selected_gpu_id={worker.gpu_id} "
-                f"effective_timeout_seconds={float(effective_timeout)} "
-                f"wait_worker_ms={wait_worker_ms:.3f} "
-                f"worker_execute_ms={(time.perf_counter() - worker_execute_start_time) * 1000.0:.3f}",
-                flush=True,
-            )
-            with self._condition:
-                self._condition.notify_all()
-
-    def _acquire_worker(self) -> LowLevelWorkerProcess:
-        """Block until one worker becomes idle and return it.
-
-        Returns
-        -------
-        LowLevelWorkerProcess
-            Idle worker selected for the next request.
-        """
-        with self._condition:
-            while True:
-                for offset in range(len(self._workers)):
-                    worker_index = (self._next_worker_index + offset) % len(self._workers)
-                    worker = self._workers[worker_index]
-                    if worker.status == "idle":
-                        self._next_worker_index = (worker_index + 1) % len(self._workers)
-                        return worker
-                self._condition.wait(timeout=0.1)

--- a/flashinfer_bench/version.py
+++ b/flashinfer_bench/version.py
@@ -1,0 +1,5 @@
+try:
+    from flashinfer_bench._version import __version__, __version_tuple__
+except Exception:
+    __version__ = "0.0.0.dev0"
+    __version_tuple__ = (0, 0, 0, "dev0")

--- a/tests/serve/test_low_level_server_e2e.py
+++ b/tests/serve/test_low_level_server_e2e.py
@@ -1,0 +1,262 @@
+"""End-to-end tests for the low-level GPU server.
+
+These tests require a real GPU and start a real low-level server process.
+"""
+
+import hashlib
+import json
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from email.parser import BytesParser
+from email.policy import default
+from pathlib import Path
+
+import numpy as np
+import pytest
+import requests
+import tvm_ffi
+
+pytestmark = pytest.mark.requires_torch_cuda
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_server(port: int, timeout_seconds: float) -> None:
+    deadline = time.time() + timeout_seconds
+    last_error = None
+    while time.time() < deadline:
+        try:
+            response = requests.get(f"http://127.0.0.1:{port}/health", timeout=1.0)
+            if response.status_code == 200:
+                return
+        except Exception as error:  # pragma: no cover - polling helper
+            last_error = error
+        time.sleep(0.2)
+    raise RuntimeError(f"Server did not start in time: {last_error}")
+
+
+def _parse_multipart_response(response: requests.Response) -> tuple[dict, dict[str, bytes]]:
+    content_type = response.headers["content-type"]
+    mime_message = (
+        f"Content-Type: {content_type}\r\nMIME-Version: 1.0\r\n\r\n".encode("utf-8")
+        + response.content
+    )
+    message = BytesParser(policy=default).parsebytes(mime_message)
+    parts: dict[str, bytes] = {}
+    result = None
+    for part in message.iter_parts():
+        name = part.get_param("name", header="content-disposition")
+        payload = part.get_payload(decode=True)
+        if name == "result":
+            result = json.loads(payload.decode("utf-8"))
+        else:
+            parts[name] = payload
+    assert result is not None
+    return result, parts
+
+
+def test_low_level_gpu_server_e2e():
+    port = _find_free_port()
+    command = [
+        sys.executable,
+        "-m",
+        "flashinfer_bench.serve.low_level.app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--devices",
+        "cuda:0",
+        "--timeout",
+        "30",
+        "--log-level",
+        "INFO",
+    ]
+    server_process = subprocess.Popen(command)
+    try:
+        _wait_for_server(port, timeout_seconds=60.0)
+
+        module_source = b"""
+import torch
+import tvm_ffi
+
+def _to_torch(tensor):
+    return torch.utils.dlpack.from_dlpack(tensor)
+
+@tvm_ffi.register_global_func("e2e_scale")
+def e2e_scale(tensor):
+    torch_tensor = _to_torch(tensor)
+    return torch_tensor + torch_tensor
+
+@tvm_ffi.register_global_func("e2e_sum")
+def e2e_sum(tensor):
+    torch_tensor = _to_torch(tensor)
+    return float(torch_tensor.sum().item())
+
+@tvm_ffi.register_global_func("e2e_fail")
+def e2e_fail():
+    raise RuntimeError("expected e2e failure")
+"""
+        input_array = np.arange(8, dtype=np.float16)
+        tensor_bytes = input_array.tobytes()
+
+        module_hash = hashlib.sha256(module_source).hexdigest()
+        tensor_hash = hashlib.sha256(tensor_bytes).hexdigest()
+
+        success_program = {
+            "instructions": [
+                {"op": "upload_python_module", "blob": module_hash},
+                {
+                    "op": "upload_tensor",
+                    "dst": 1,
+                    "blob": tensor_hash,
+                    "shape": [8],
+                    "dtype": "float16",
+                },
+                {"op": "call", "dst": 2, "func": "e2e_scale", "args": [{"r": 1}]},
+                {"op": "call", "dst": 3, "func": "e2e_sum", "args": [{"r": 2}]},
+                {"op": "return", "reg": 2, "key": "output"},
+                {"op": "return", "reg": 3, "key": "total"},
+            ],
+            "timeout_seconds": 30,
+        }
+
+        for _ in range(2):
+            response = requests.post(
+                f"http://127.0.0.1:{port}/execute",
+                files={
+                    "program": (
+                        "program.json",
+                        json.dumps(success_program).encode("utf-8"),
+                        "application/json",
+                    ),
+                    f"blob:{module_hash}": ("module.py", module_source, "application/octet-stream"),
+                    f"blob:{tensor_hash}": ("tensor.bin", tensor_bytes, "application/octet-stream"),
+                },
+                timeout=120.0,
+            )
+            assert response.status_code == 200, response.text
+            result, binary_parts = _parse_multipart_response(response)
+            assert result["status"] == "ok"
+            assert result["returns"]["total"]["type"] == "json"
+            assert result["returns"]["total"]["value"] == pytest.approx(56.0)
+            output_part = result["returns"]["output"]["blob"]
+            output_array = np.frombuffer(binary_parts[output_part], dtype=np.float16)
+            np.testing.assert_allclose(output_array, input_array * 2)
+
+        failure_program = {
+            "instructions": [
+                {
+                    "op": "upload_tensor",
+                    "dst": 0,
+                    "blob": "missing_blob",
+                    "shape": [8],
+                    "dtype": "float16",
+                }
+            ],
+            "timeout_seconds": 30,
+        }
+        failure_response = requests.post(
+            f"http://127.0.0.1:{port}/execute",
+            files={
+                "program": (
+                    "program.json",
+                    json.dumps(failure_program).encode("utf-8"),
+                    "application/json",
+                )
+            },
+            timeout=30.0,
+        )
+        assert failure_response.status_code == 400
+        failure_payload = failure_response.json()
+        assert failure_payload["error"] == "invalid_program"
+        assert "Missing blob" in failure_payload["message"]
+    finally:
+        server_process.terminate()
+        server_process.wait(timeout=30.0)
+
+
+def test_low_level_gpu_server_module_handle_e2e():
+    port = _find_free_port()
+    command = [
+        sys.executable,
+        "-m",
+        "flashinfer_bench.serve.low_level.app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--devices",
+        "cuda:0",
+        "--timeout",
+        "30",
+        "--log-level",
+        "INFO",
+    ]
+    server_process = subprocess.Popen(command)
+    try:
+        _wait_for_server(port, timeout_seconds=60.0)
+
+        with tempfile.TemporaryDirectory(prefix="fib_low_level_cpp_") as temp_dir:
+            source_path = Path(temp_dir) / "module.cc"
+            source_path.write_text(
+                """
+#include <tvm/ffi/function.h>
+
+int64_t ReturnSeven() {
+  return 7;
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(return_seven, ReturnSeven);
+""",
+                encoding="utf-8",
+            )
+            so_path = tvm_ffi.cpp.build(
+                name="low_level_module_handle_e2e",
+                cpp_files=[str(source_path)],
+                build_directory=temp_dir,
+            )
+            so_bytes = Path(so_path).read_bytes()
+
+        module_hash = hashlib.sha256(so_bytes).hexdigest()
+        program = {
+            "instructions": [
+                {"op": "upload_ffi_module", "dst": 0, "blob": module_hash},
+                {"op": "call", "dst": 1, "func": "return_seven", "module": {"r": 0}, "args": []},
+                {"op": "return", "reg": 1, "key": "value"},
+            ],
+            "timeout_seconds": 30,
+        }
+
+        response = requests.post(
+            f"http://127.0.0.1:{port}/execute",
+            files={
+                "program": (
+                    "program.json",
+                    json.dumps(program).encode("utf-8"),
+                    "application/json",
+                ),
+                f"blob:{module_hash}": ("module.so", so_bytes, "application/octet-stream"),
+            },
+            timeout=120.0,
+        )
+        assert response.status_code == 200, response.text
+        result, binary_parts = _parse_multipart_response(response)
+        assert binary_parts == {}
+        assert result["status"] == "ok"
+        assert result["returns"]["value"]["type"] == "json"
+        assert result["returns"]["value"]["value"] == 7
+    finally:
+        server_process.terminate()
+        server_process.wait(timeout=30.0)
+
+
+if __name__ == "__main__":
+    pytest.main(sys.argv)


### PR DESCRIPTION
## Summary

- Add an experimental low-level GPU judge server under `flashinfer_bench.serve.low_level`.
- Support multipart `/execute` requests with JSON programs plus `blob:<sha256>` binary payloads.
- Add request-scoped execution, blob caching, worker scheduling, structured error responses, and e2e coverage.

Related design: https://gist.github.com/Ubospica/1260ee76a42758a716f380b0b305569a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a low-level GPU server with HTTP endpoints for request execution, supporting module uploads and tensor operations
  * Added health monitoring endpoint with worker status and queue tracking
  * Implemented persistent shared-memory blob caching with configurable capacity limits
  * Enabled multi-GPU worker process scheduling with automatic timeout handling

* **Tests**
  * Added end-to-end integration tests for server functionality and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->